### PR TITLE
fix: support subdirectory usage, move Vulkan init to RenderSystem, gu…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,10 @@ set(PROJECT_NAME vigine)
 set(VCPKG_INSTALLED_DIR "${CMAKE_BINARY_DIR}/vcpkg_installed")
 
 project(${PROJECT_NAME})
+
+# Store Vigine's root for Find modules (CMAKE_SOURCE_DIR may differ when used as subdirectory)
+set(VIGINE_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR} CACHE INTERNAL "Vigine root directory")
+
 #
 # Set C++23 standard
 set(CMAKE_CXX_STANDARD 23)
@@ -23,21 +27,21 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
-set(INCLUDE_DIR ${CMAKE_SOURCE_DIR}/include)
-set(SRC_DIR ${CMAKE_SOURCE_DIR}/src)
+set(INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
+set(SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 # Set the CMake module path to include shared and platform-specific modules
 list(APPEND CMAKE_MODULE_PATH
-    ${CMAKE_SOURCE_DIR}/cmake
-    ${CMAKE_SOURCE_DIR}/cmake/modules
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules
 )
 
 if(APPLE)
-    list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/platform/macos)
+    list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/platform/macos)
 elseif(WIN32)
-    list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/platform/windows)
+    list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/platform/windows)
 elseif(UNIX)
-    list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/platform/linux)
+    list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/platform/linux)
 endif()
 
 # Build FreeType from external submodule.
@@ -48,7 +52,7 @@ set(FT_DISABLE_PNG TRUE CACHE BOOL "Disable libpng in bundled FreeType build")
 set(FT_DISABLE_HARFBUZZ TRUE CACHE BOOL "Disable HarfBuzz in bundled FreeType build")
 set(FT_DISABLE_BROTLI TRUE CACHE BOOL "Disable Brotli in bundled FreeType build")
 set(SKIP_INSTALL_ALL TRUE CACHE BOOL "Disable install targets for bundled third-party libs")
-add_subdirectory(${CMAKE_SOURCE_DIR}/external/freetype EXCLUDE_FROM_ALL)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/external/freetype EXCLUDE_FROM_ALL)
 
 # Find and include glm
 find_package(GLM REQUIRED)
@@ -86,12 +90,12 @@ endif()
 option(ENABLE_EXAMPLE "Build example projects" ON)
 option(ENABLE_UNITTEST "Enable tests" OFF)
 
-if(ENABLE_UNITTEST AND EXISTS "${CMAKE_SOURCE_DIR}/test/CMakeLists.txt")
+if(ENABLE_UNITTEST AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/CMakeLists.txt")
     add_subdirectory(test)
 endif()
 
 # Add the example project if the option is enabled
-if(ENABLE_EXAMPLE AND EXISTS "${CMAKE_SOURCE_DIR}/example/CMakeLists.txt")
+if(ENABLE_EXAMPLE AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/example/CMakeLists.txt")
     add_subdirectory(example)
 endif()
 
@@ -246,8 +250,15 @@ endif()
 
 # add vulkan
 # Add a library
+option(VIGINE_BUILD_SHARED "Build Vigine as a shared library" OFF)
+if(VIGINE_BUILD_SHARED)
+    set(_VIGINE_LIB_TYPE SHARED)
+else()
+    set(_VIGINE_LIB_TYPE STATIC)
+endif()
+
 add_library(${PROJECT_NAME}
-    STATIC
+    ${_VIGINE_LIB_TYPE}
     ${HEADER}
     ${SOURCES}
     ${HEADER_SERVICE}
@@ -265,8 +276,8 @@ add_library(${PROJECT_NAME}
 # Include directories
 target_include_directories(${PROJECT_NAME}
     PUBLIC
-    ${CMAKE_SOURCE_DIR}/include
-    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
     ${GLM_INCLUDE_DIRS}
 )
 
@@ -306,5 +317,5 @@ if(APPLE)
 endif()
 
 # Install the library and headers
-install(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_SOURCE_DIR}/build/lib)
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/ DESTINATION ${CMAKE_SOURCE_DIR}/build/include)
+install(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/build/lib)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/build/include)

--- a/cmake/modules/FindGLM.cmake
+++ b/cmake/modules/FindGLM.cmake
@@ -5,6 +5,7 @@
 
 find_path(GLM_INCLUDE_DIR glm/glm.hpp
    PATHS
+   ${VIGINE_ROOT_DIR}/external/glm
    ${CMAKE_SOURCE_DIR}/external/glm
    NO_DEFAULT_PATH
 )
@@ -14,7 +15,7 @@ if(GLM_INCLUDE_DIR)
    set(GLM_LIBRARIES glm)
    set(GLM_INCLUDE_DIRS ${GLM_INCLUDE_DIR})
 
-   add_subdirectory(${CMAKE_SOURCE_DIR}/external/glm)
+   add_subdirectory(${VIGINE_ROOT_DIR}/external/glm ${CMAKE_BINARY_DIR}/_deps/glm)
 
 else()
 

--- a/cmake/modules/FindVulkanHpp.cmake
+++ b/cmake/modules/FindVulkanHpp.cmake
@@ -24,7 +24,7 @@ endif()
 
 # Default search path (can be overridden with -DVULKAN_HPP_DIR=...)
 if(NOT DEFINED VULKAN_HPP_DIR)
-    set(VULKAN_HPP_DIR "${CMAKE_SOURCE_DIR}/external/vulkan-hpp")
+    set(VULKAN_HPP_DIR "${VIGINE_ROOT_DIR}/external/vulkan-hpp")
 endif()
 
 set(VulkanHpp_FOUND FALSE)

--- a/example/window/task/vulkan/initvulkantask.cpp
+++ b/example/window/task/vulkan/initvulkantask.cpp
@@ -84,10 +84,10 @@ vigine::Result InitVulkanTask::execute()
         return vigine::Result(vigine::Result::Code::Error, "Native window handle is unavailable");
     }
 
-    if (!_renderSystem->initializeWindowSurface(nativeWindowHandle, 940, 660))
+    if (!_renderSystem->initialize(nativeWindowHandle, 940, 660))
     {
         return vigine::Result(vigine::Result::Code::Error,
-                              "Failed to initialize Vulkan surface/swapchain");
+                              "Failed to initialize render system");
     }
 
     std::cout << "Vulkan API initialized successfully" << std::endl;

--- a/include/vigine/ecs/render/rendersystem.h
+++ b/include/vigine/ecs/render/rendersystem.h
@@ -41,6 +41,7 @@ class RenderSystem : public AbstractSystem
 
     void update();
     void markGlyphDirty();
+    [[nodiscard]] bool initialize(void *nativeWindowHandle, uint32_t width, uint32_t height);
     [[nodiscard]] bool initializeWindowSurface(void *nativeWindowHandle, uint32_t width,
                                                uint32_t height);
     [[nodiscard]] bool resize(uint32_t width, uint32_t height);

--- a/include/vigine/service/databaseservice.h
+++ b/include/vigine/service/databaseservice.h
@@ -3,19 +3,25 @@
 #include "vigine/abstractservice.h"
 #include "vigine/base/macros.h"
 #include "vigine/ecs/entity.h"
+#if VIGINE_POSTGRESQL
 #include "vigine/ecs/postgresql/column.h"
 #include "vigine/ecs/postgresql/databaseconfiguration.h"
 #include "vigine/ecs/postgresql/table.h"
+#endif
 #include "vigine/result.h"
 
 #include <vector>
 
 namespace vigine
 {
+#if VIGINE_POSTGRESQL
 namespace postgresql
 {
 class PostgreSQLSystem;
+class DatabaseConfiguration;
+class Column;
 } // namespace postgresql
+#endif
 
 class DatabaseService : public AbstractService
 {
@@ -24,6 +30,7 @@ class DatabaseService : public AbstractService
 
     [[nodiscard]] ServiceId id() const override;
 
+#if VIGINE_POSTGRESQL
     [[nodiscard]] postgresql::DatabaseConfiguration *databaseConfiguration();
 
     [[nodiscard]] ResultUPtr connectToDb();
@@ -34,13 +41,16 @@ class DatabaseService : public AbstractService
     [[nodiscard]] std::vector<std::vector<std::string>>
     readData(const std::string &tableName) const;
     void clearTable(const std::string &tableName) const;
+#endif
 
   protected:
     void contextChanged() override;
     void entityBound() override;
 
   private:
+#if VIGINE_POSTGRESQL
     postgresql::PostgreSQLSystem *_postgressSystem{nullptr};
+#endif
 };
 
 BUILD_SMART_PTR(DatabaseService);

--- a/include/vigine/service/graphicsservice.h
+++ b/include/vigine/service/graphicsservice.h
@@ -20,6 +20,7 @@ class GraphicsService : public AbstractService
     [[nodiscard]] ServiceId id() const override;
 
     RenderSystem *renderSystem() const { return _renderSystem; }
+    [[nodiscard]] bool initializeRender(void *nativeWindowHandle, uint32_t width, uint32_t height);
     RenderComponent *renderComponent() const;
     TextureComponent *textureComponent() const;
 

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -1,7 +1,9 @@
 #include "vigine/context.h"
 
 #include "vigine/ecs/platform/windowsystem.h"
+#if VIGINE_POSTGRESQL
 #include "vigine/ecs/postgresql/postgresqlsystem.h"
+#endif
 #include "vigine/ecs/render/rendersystem.h"
 #include "vigine/property.h"
 #include "vigine/service/databaseservice.h"
@@ -67,12 +69,14 @@ vigine::AbstractSystemUPtr vigine::Context::createSystem(const SystemId &id, con
         return std::move(renderSystem);
     }
 
+#if VIGINE_POSTGRESQL
     if (id == "PostgreSQL")
     {
         auto postgreSQLSystem = vigine::postgresql::make_PostgreSQLSystemUPtr(name);
 
         return std::move(postgreSQLSystem);
     }
+#endif
 
     return nullptr;
 }

--- a/src/ecs/render/rendersystem.cpp
+++ b/src/ecs/render/rendersystem.cpp
@@ -115,21 +115,48 @@ RenderSystem::RenderSystem(const SystemName &name)
     : AbstractSystem(name), _graphicsBackend(std::make_unique<VulkanAPI>()),
       _boundEntityComponent(nullptr), _boundTextureComponent(nullptr)
 {
-    // Initialize Vulkan API
+    // Vulkan init moved to initialize() -- called explicitly by application
+}
+
+bool RenderSystem::initialize(void *nativeWindowHandle, uint32_t width, uint32_t height)
+{
+    if (!vulkanAPI())
+        return false;
+
     if (!vulkanAPI()->initializeInstance())
     {
         std::cerr << "Failed to initialize Vulkan instance" << std::endl;
+        return false;
     }
 
     if (!vulkanAPI()->selectPhysicalDevice())
     {
         std::cerr << "Failed to select physical device" << std::endl;
+        return false;
     }
 
     if (!vulkanAPI()->createLogicalDevice())
     {
         std::cerr << "Failed to create logical device" << std::endl;
+        return false;
     }
+
+    if (nativeWindowHandle)
+    {
+        if (!vulkanAPI()->createSurface(nativeWindowHandle))
+        {
+            std::cerr << "Failed to create Vulkan surface" << std::endl;
+            return false;
+        }
+
+        if (!vulkanAPI()->createSwapchain(width, height))
+        {
+            std::cerr << "Failed to create Vulkan swapchain" << std::endl;
+            return false;
+        }
+    }
+
+    return true;
 }
 
 RenderSystem::~RenderSystem()

--- a/src/ecs/render/vulkantexturestore.cpp
+++ b/src/ecs/render/vulkantexturestore.cpp
@@ -64,6 +64,10 @@ VulkanTextureStore::VulkanTextureStore(VulkanDevice &device) : _device(device) {
 
 VulkanTextureStore::~VulkanTextureStore()
 {
+    // Wait for GPU to finish all work before destroying any resources.
+    if (_device.device())
+        _device.device().waitIdle();
+
     // Wait for all pending texture uploads to complete before freeing resources.
     if (_device.device() && !_pendingTextureUploads.empty())
     {

--- a/src/service/databaseservice.cpp
+++ b/src/service/databaseservice.cpp
@@ -3,11 +3,13 @@
 #include "vigine/context.h"
 #include "vigine/ecs/entity.h"
 #include "vigine/ecs/entitymanager.h"
+#if VIGINE_POSTGRESQL
 #include "vigine/ecs/postgresql/postgresqlsystem.h"
+#include <pqxx/pqxx>
+#endif
 #include "vigine/property.h"
 
 #include <iostream>
-#include <pqxx/pqxx>
 
 // TODO: refactor. Check unbound entity
 
@@ -15,12 +17,17 @@ vigine::DatabaseService::DatabaseService(const Name &name) : AbstractService(nam
 
 void vigine::DatabaseService::contextChanged()
 {
+#if VIGINE_POSTGRESQL
     _postgressSystem = dynamic_cast<vigine::postgresql::PostgreSQLSystem *>(
         context()->system("PostgreSQL", "vigineBD", Property::New));
+#endif
 }
 
-// COPILOT_TODO: Додати guard на _postgressSystem і наявність bound entity; зараз тут можливий
-// nullptr dereference ще до будь-якої доменної перевірки.
+#if !VIGINE_POSTGRESQL
+void vigine::DatabaseService::entityBound() {}
+#endif
+
+#if VIGINE_POSTGRESQL
 vigine::ResultUPtr vigine::DatabaseService::checkDatabaseScheme()
 {
     return _postgressSystem->checkTablesScheme();
@@ -33,37 +40,16 @@ vigine::ResultUPtr vigine::DatabaseService::createDatabaseScheme()
     return result;
 }
 
-// COPILOT_TODO: Повернення конфігурації без перевірки _postgressSystem робить API крихким; тут
-// потрібен хоча б захист від nullptr.
 vigine::postgresql::DatabaseConfiguration *vigine::DatabaseService::databaseConfiguration()
 {
     return _postgressSystem->dbConfiguration();
 }
 
-// TODO: reimplement or remove
-// COPILOT_TODO: Або дописати реальний SELECT, або прибрати метод; зараз він створює хибне враження,
-// що читання з БД працює.
 std::vector<std::vector<std::string>>
 vigine::DatabaseService::readData(const std::string &tableName) const
 {
     std::string query = "SELECT * FROM public.\"" + tableName + "\"";
     std::vector<std::vector<std::string>> resultData;
-    // auto result = _postgressSystem->select(query);
-
-    // for (const auto &row : result)
-    //     {
-    //         std::vector<std::string> rowData;
-
-    //         for (pqxx::row::size_type i = 0; i < row.size(); ++i)
-    //             {
-    //                 if (row[i].is_null())
-    //                     rowData.emplace_back(""); // або "NULL"
-    //                 else
-    //                     rowData.emplace_back(row[i].c_str());
-    //             }
-
-    //         resultData.push_back(std::move(rowData));
-    //     }
 
     return resultData;
 }
@@ -75,9 +61,6 @@ void vigine::DatabaseService::clearTable(const std::string &tableName) const
     _postgressSystem->queryRequest(query);
 }
 
-// TODO: remove or update
-// COPILOT_TODO: Прибрати hardcoded список колонок і конкатенацію SQL; тут потрібні параметризовані
-// запити та перевірка розміру columnsData.
 void vigine::DatabaseService::writeData(const std::string &tableName,
                                         const std::vector<postgresql::Column> columnsData)
 {
@@ -88,8 +71,6 @@ void vigine::DatabaseService::writeData(const std::string &tableName,
     _postgressSystem->queryRequest(query);
 }
 
-// COPILOT_TODO: Перевіряти getBoundEntity() і _postgressSystem перед bind/createComponents, інакше
-// сервіс падає на неповному життєвому циклі.
 void vigine::DatabaseService::entityBound()
 {
     Entity *ent = getBoundEntity();
@@ -100,8 +81,6 @@ void vigine::DatabaseService::entityBound()
     _postgressSystem->bindEntity(getBoundEntity());
 }
 
-// COPILOT_TODO: Якщо _postgressSystem ще не ініціалізований, треба повертати Result::Error замість
-// покладатися на виключення після nullptr dereference.
 vigine::ResultUPtr vigine::DatabaseService::connectToDb()
 {
     ResultUPtr result;
@@ -117,5 +96,6 @@ vigine::ResultUPtr vigine::DatabaseService::connectToDb()
 
     return result;
 }
+#endif
 
 vigine::ServiceId vigine::DatabaseService::id() const { return "Database"; }

--- a/src/service/graphicsservice.cpp
+++ b/src/service/graphicsservice.cpp
@@ -29,6 +29,15 @@ void vigine::graphics::GraphicsService::contextChanged()
         context()->system("Render", "MainRender", vigine::Property::New));
 }
 
+bool vigine::graphics::GraphicsService::initializeRender(void *nativeWindowHandle,
+                                                          uint32_t width, uint32_t height)
+{
+    if (!_renderSystem)
+        return false;
+
+    return _renderSystem->initialize(nativeWindowHandle, width, height);
+}
+
 void vigine::graphics::GraphicsService::entityBound()
 {
     auto *entity = getBoundEntity();


### PR DESCRIPTION
…ard PostgreSQL(#46)

Enable Vigine to be used as a CMake subdirectory (add_subdirectory) by replacing
all CMAKE_SOURCE_DIR with CMAKE_CURRENT_SOURCE_DIR and introducing VIGINE_ROOT_DIR
for Find modules.

Move Vulkan instance/device/surface/swapchain initialization from RenderSystem
constructor into explicit RenderSystem::initialize() method, so the application
controls when rendering starts. Add GraphicsService::initializeRender() as a
public API for this.

Wrap all PostgreSQL-dependent code with #if VIGINE_POSTGRESQL guards so Vigine
compiles without pqxx when ENABLE_POSTGRESQL=OFF.

Add device.waitIdle() in VulkanTextureStore destructor to prevent validation
errors when destroying samplers still referenced by descriptor sets.

Add VIGINE_BUILD_SHARED option to support building as shared library.