### PR TITLE
feat(graph): declare IGraph family public headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,18 @@ set(HEADER
     ${INCLUDE_DIR}/vigine/entitybindinghost.h
     ${INCLUDE_DIR}/vigine/base/constant.h
     ${INCLUDE_DIR}/vigine/base/function.h
+    ${INCLUDE_DIR}/vigine/graph/nodeid.h
+    ${INCLUDE_DIR}/vigine/graph/edgeid.h
+    ${INCLUDE_DIR}/vigine/graph/traverse_mode.h
+    ${INCLUDE_DIR}/vigine/graph/visit_result.h
+    ${INCLUDE_DIR}/vigine/graph/kind.h
+    ${INCLUDE_DIR}/vigine/graph/iedgedata.h
+    ${INCLUDE_DIR}/vigine/graph/inode.h
+    ${INCLUDE_DIR}/vigine/graph/iedge.h
+    ${INCLUDE_DIR}/vigine/graph/igraphvisitor.h
+    ${INCLUDE_DIR}/vigine/graph/igraphquery.h
+    ${INCLUDE_DIR}/vigine/graph/igraph.h
+    ${INCLUDE_DIR}/vigine/graph/factory.h
 )
 
 set(SOURCES

--- a/include/vigine/graph/edgeid.h
+++ b/include/vigine/graph/edgeid.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <compare>
+#include <cstdint>
+
+namespace vigine::graph
+{
+/**
+ * @brief Generational identifier of a graph edge.
+ *
+ * POD value type with the same layout contract as @ref NodeId. Generation
+ * `0` is the invalid sentinel; lookups with a stale identifier fail safely.
+ */
+struct EdgeId
+{
+    std::uint32_t index{0};
+    std::uint32_t generation{0};
+
+    /**
+     * @brief Reports whether the identifier refers to a live slot at
+     *        construction time.
+     */
+    [[nodiscard]] constexpr bool valid() const noexcept { return generation != 0; }
+
+    friend constexpr auto operator<=>(const EdgeId &, const EdgeId &) = default;
+    friend constexpr bool operator==(const EdgeId &, const EdgeId &)  = default;
+};
+
+} // namespace vigine::graph

--- a/include/vigine/graph/factory.h
+++ b/include/vigine/graph/factory.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <memory>
+
+#include "vigine/graph/igraph.h"
+
+namespace vigine::graph
+{
+/**
+ * @brief Constructs the default in-memory @ref IGraph implementation.
+ *
+ * Returns a new graph instance wrapped in a `std::shared_ptr` so that
+ * multiple wrappers can share the same substrate when required. The
+ * factory is deliberately non-templated: every implementation is
+ * selected at build time by the engine library.
+ */
+[[nodiscard]] std::shared_ptr<IGraph> createGraph();
+
+} // namespace vigine::graph

--- a/include/vigine/graph/iedge.h
+++ b/include/vigine/graph/iedge.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "vigine/graph/edgeid.h"
+#include "vigine/graph/iedgedata.h"
+#include "vigine/graph/kind.h"
+#include "vigine/graph/nodeid.h"
+
+namespace vigine::graph
+{
+/**
+ * @brief Pure-virtual directed edge of an @ref IGraph.
+ *
+ * Each edge knows its own identifier, its endpoints, its kind tag, and
+ * carries an optional polymorphic @ref IEdgeData payload. The graph owns
+ * the edge after @ref IGraph::addEdge succeeds; ownership is transferred
+ * via `std::unique_ptr`.
+ *
+ * Copy and move operations are deleted for the same pinning reason as
+ * @ref INode.
+ */
+class IEdge
+{
+  public:
+    virtual ~IEdge() = default;
+
+    /**
+     * @brief Returns the identifier assigned by the owning graph.
+     */
+    [[nodiscard]] virtual EdgeId id() const noexcept = 0;
+
+    /**
+     * @brief Returns the kind tag selected by the concrete edge.
+     */
+    [[nodiscard]] virtual EdgeKind kind() const noexcept = 0;
+
+    /**
+     * @brief Returns the source vertex of the directed edge.
+     */
+    [[nodiscard]] virtual NodeId from() const noexcept = 0;
+
+    /**
+     * @brief Returns the target vertex of the directed edge.
+     */
+    [[nodiscard]] virtual NodeId to() const noexcept = 0;
+
+    /**
+     * @brief Returns the optional polymorphic payload.
+     *
+     * Returns `nullptr` when the edge carries no payload. Callers branch on
+     * @ref IEdgeData::dataTypeId to decide how to downcast.
+     */
+    [[nodiscard]] virtual const IEdgeData *data() const noexcept = 0;
+
+  protected:
+    IEdge() = default;
+
+  public:
+    IEdge(const IEdge &)            = delete;
+    IEdge &operator=(const IEdge &) = delete;
+    IEdge(IEdge &&)                 = delete;
+    IEdge &operator=(IEdge &&)      = delete;
+};
+
+} // namespace vigine::graph

--- a/include/vigine/graph/iedgedata.h
+++ b/include/vigine/graph/iedgedata.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <cstdint>
+
+namespace vigine::graph
+{
+/**
+ * @brief Optional polymorphic payload carried by an edge.
+ *
+ * Pure-virtual interface. Concrete data types subclass @ref IEdgeData and
+ * expose their own accessors; callers branch on @ref dataTypeId to select
+ * the correct static downcast. The interface is intentionally minimal so
+ * that edges without payload can pass `nullptr` through
+ * @ref IEdge::data without penalty.
+ *
+ * @note `dataTypeId` is a runtime tag, not an RTTI hook; implementations
+ *       MUST return a stable value across program runs so that downstream
+ *       wrappers can match payloads by identifier alone and avoid
+ *       `dynamic_cast` in hot paths.
+ */
+class IEdgeData
+{
+  public:
+    virtual ~IEdgeData() = default;
+
+    /**
+     * @brief Returns the stable identifier of the concrete payload type.
+     *
+     * Each concrete payload class returns its own unique value. Consumers
+     * branch on this value to perform a safe `static_cast` to the expected
+     * concrete type.
+     */
+    [[nodiscard]] virtual std::uint32_t dataTypeId() const noexcept = 0;
+
+  protected:
+    IEdgeData() = default;
+
+  public:
+    IEdgeData(const IEdgeData &)            = delete;
+    IEdgeData &operator=(const IEdgeData &) = delete;
+    IEdgeData(IEdgeData &&)                 = delete;
+    IEdgeData &operator=(IEdgeData &&)      = delete;
+};
+
+} // namespace vigine::graph

--- a/include/vigine/graph/igraph.h
+++ b/include/vigine/graph/igraph.h
@@ -1,0 +1,143 @@
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <string>
+
+#include "vigine/graph/edgeid.h"
+#include "vigine/graph/iedge.h"
+#include "vigine/graph/igraphquery.h"
+#include "vigine/graph/igraphvisitor.h"
+#include "vigine/graph/inode.h"
+#include "vigine/graph/nodeid.h"
+#include "vigine/graph/traverse_mode.h"
+#include "vigine/result.h"
+
+namespace vigine::graph
+{
+/**
+ * @brief Pure-virtual core of the graph substrate.
+ *
+ * @ref IGraph is the level-0 primitive underneath every wrapper in the
+ * engine (messaging, ECS, state machine, task flow). It owns nodes and
+ * edges, exposes traversal and query surfaces, and offers a tooling hook
+ * for GraphViz export. It knows nothing about higher-level concepts such
+ * as entities, components, or messages; those live in wrapper headers.
+ *
+ * Ownership semantics:
+ *   - @ref addNode and @ref addEdge take unique ownership of the
+ *     implementation objects.
+ *   - @ref node and @ref edge return non-owning raw pointers. Returned
+ *     pointers are valid until the next mutation of the graph from any
+ *     thread; callers that need longer-lived references should copy the
+ *     identifier and re-resolve.
+ *   - Identifiers are generational (@ref NodeId, @ref EdgeId). Stale
+ *     identifiers never alias live slots after removal.
+ */
+class IGraph
+{
+  public:
+    virtual ~IGraph() = default;
+
+    // ------ Node lifecycle ------
+
+    /**
+     * @brief Takes ownership of @p node and returns the generational id.
+     *
+     * The returned identifier is always valid; implementations never
+     * return a generation of zero from @ref addNode. Passing a null
+     * pointer is a programming error and is undefined.
+     */
+    [[nodiscard]] virtual NodeId addNode(std::unique_ptr<INode> node) = 0;
+
+    /**
+     * @brief Removes the node addressed by @p id and every attached edge.
+     *
+     * Idempotent: removing a stale identifier reports a
+     * @ref Result::Code::Error status without side effects. On success
+     * returns a default-constructed (Success) @ref Result.
+     */
+    virtual Result removeNode(NodeId id) = 0;
+
+    /**
+     * @brief Returns a non-owning view of the node, or `nullptr` when the
+     *        identifier is stale.
+     */
+    [[nodiscard]] virtual const INode *node(NodeId id) const noexcept = 0;
+
+    // ------ Edge lifecycle ------
+
+    /**
+     * @brief Takes ownership of @p edge and returns the generational id.
+     *
+     * Implementations validate that the endpoints addressed by @p edge
+     * exist; when they do not, the returned identifier is invalid.
+     */
+    [[nodiscard]] virtual EdgeId addEdge(std::unique_ptr<IEdge> edge) = 0;
+
+    /**
+     * @brief Removes the edge addressed by @p id. Idempotent.
+     */
+    virtual Result removeEdge(EdgeId id) = 0;
+
+    /**
+     * @brief Returns a non-owning view of the edge, or `nullptr` when the
+     *        identifier is stale.
+     */
+    [[nodiscard]] virtual const IEdge *edge(EdgeId id) const noexcept = 0;
+
+    // ------ Traversal ------
+
+    /**
+     * @brief Walks the graph starting at @p startNode under @p mode and
+     *        reports each visited vertex and edge to @p visitor.
+     *
+     * Returns a successful @ref Result on normal completion, an error
+     * @ref Result when the visitor requested a stop or when
+     * @ref TraverseMode::Topological encounters a cycle.
+     */
+    virtual Result traverse(NodeId startNode, TraverseMode mode, IGraphVisitor &visitor) = 0;
+
+    // ------ Query ------
+
+    /**
+     * @brief Returns the read-only query surface.
+     *
+     * The returned reference is valid for the lifetime of the graph.
+     */
+    [[nodiscard]] virtual const IGraphQuery &query() const noexcept = 0;
+
+    // ------ Observability ------
+
+    /**
+     * @brief Returns the number of live nodes.
+     */
+    [[nodiscard]] virtual std::size_t nodeCount() const noexcept = 0;
+
+    /**
+     * @brief Returns the number of live edges.
+     */
+    [[nodiscard]] virtual std::size_t edgeCount() const noexcept = 0;
+
+    // ------ Tooling ------
+
+    /**
+     * @brief Serialises the current graph to GraphViz DOT into @p out.
+     *
+     * The implementation writes to the caller-supplied buffer only; it
+     * never touches the file system. Existing contents of @p out are
+     * overwritten.
+     */
+    virtual Result exportGraphViz(std::string &out) const = 0;
+
+  protected:
+    IGraph() = default;
+
+  public:
+    IGraph(const IGraph &)            = delete;
+    IGraph &operator=(const IGraph &) = delete;
+    IGraph(IGraph &&)                 = delete;
+    IGraph &operator=(IGraph &&)      = delete;
+};
+
+} // namespace vigine::graph

--- a/include/vigine/graph/igraphquery.h
+++ b/include/vigine/graph/igraphquery.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include <optional>
+#include <vector>
+
+#include "vigine/graph/edgeid.h"
+#include "vigine/graph/kind.h"
+#include "vigine/graph/nodeid.h"
+
+namespace vigine::graph
+{
+/**
+ * @brief Pure-virtual read-only query surface of an @ref IGraph.
+ *
+ * Every method is `const`. Implementations are free to cache indices and
+ * materialise results lazily; callers treat the returned vectors as
+ * snapshots valid at call time.
+ *
+ * Neighbourhood queries return edge identifiers rather than node
+ * identifiers because a single neighbour can be connected by several
+ * edges of different kinds; the edge view is therefore the canonical
+ * primitive, and consumers navigate to the other endpoint through
+ * @ref IGraph::edge.
+ */
+class IGraphQuery
+{
+  public:
+    virtual ~IGraphQuery() = default;
+
+    // ------ Node / edge existence ------
+
+    /**
+     * @brief Returns `true` when the identifier refers to a live node.
+     */
+    [[nodiscard]] virtual bool hasNode(NodeId id) const noexcept = 0;
+
+    /**
+     * @brief Returns `true` when the identifier refers to a live edge.
+     */
+    [[nodiscard]] virtual bool hasEdge(EdgeId id) const noexcept = 0;
+
+    // ------ Directed neighbourhood ------
+
+    /**
+     * @brief Returns identifiers of edges leaving @p id.
+     */
+    [[nodiscard]] virtual std::vector<EdgeId> outEdges(NodeId id) const = 0;
+
+    /**
+     * @brief Returns identifiers of edges arriving at @p id.
+     */
+    [[nodiscard]] virtual std::vector<EdgeId> inEdges(NodeId id) const = 0;
+
+    /**
+     * @brief Returns edges leaving @p id whose kind equals @p kind.
+     */
+    [[nodiscard]] virtual std::vector<EdgeId> outEdgesOfKind(NodeId id, EdgeKind kind) const = 0;
+
+    /**
+     * @brief Returns edges arriving at @p id whose kind equals @p kind.
+     */
+    [[nodiscard]] virtual std::vector<EdgeId> inEdgesOfKind(NodeId id, EdgeKind kind) const = 0;
+
+    // ------ Structural queries ------
+
+    /**
+     * @brief Returns the shortest unweighted path from @p from to @p to.
+     *
+     * Returns an empty optional when no path exists or when either
+     * identifier is stale.
+     */
+    [[nodiscard]] virtual std::optional<std::vector<NodeId>>
+        shortestPath(NodeId from, NodeId to) const = 0;
+
+    /**
+     * @brief Returns the list of connected components (treated as
+     *        undirected).
+     */
+    [[nodiscard]] virtual std::vector<std::vector<NodeId>>
+        connectedComponents() const = 0;
+
+    /**
+     * @brief Returns `true` when the graph contains at least one directed
+     *        cycle.
+     */
+    [[nodiscard]] virtual bool hasCycle() const = 0;
+
+    /**
+     * @brief Returns a topological ordering when the graph is acyclic.
+     *
+     * Returns an empty optional when the graph has a cycle.
+     */
+    [[nodiscard]] virtual std::optional<std::vector<NodeId>>
+        topologicalOrder() const = 0;
+
+  protected:
+    IGraphQuery() = default;
+
+  public:
+    IGraphQuery(const IGraphQuery &)            = delete;
+    IGraphQuery &operator=(const IGraphQuery &) = delete;
+    IGraphQuery(IGraphQuery &&)                 = delete;
+    IGraphQuery &operator=(IGraphQuery &&)      = delete;
+};
+
+} // namespace vigine::graph

--- a/include/vigine/graph/igraphvisitor.h
+++ b/include/vigine/graph/igraphvisitor.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "vigine/graph/iedge.h"
+#include "vigine/graph/inode.h"
+#include "vigine/graph/nodeid.h"
+#include "vigine/graph/visit_result.h"
+
+namespace vigine::graph
+{
+/**
+ * @brief Pure-virtual callback consumed by @ref IGraph::traverse.
+ *
+ * The traversal driver calls @ref onNode as it enters a vertex and
+ * @ref onEdge as it crosses an outbound edge. The driver honours the
+ * returned @ref VisitResult: `Continue` keeps walking, `Skip` prunes the
+ * current subtree, `Stop` terminates the whole traversal.
+ *
+ * For @ref TraverseMode::Custom the driver additionally calls
+ * @ref nextForCustom to let the visitor choose the next target vertex
+ * manually; returning an invalid @ref NodeId ends the walk.
+ */
+class IGraphVisitor
+{
+  public:
+    virtual ~IGraphVisitor() = default;
+
+    /**
+     * @brief Invoked as traversal enters a vertex (pre-order for DFS).
+     */
+    virtual VisitResult onNode(const INode &node) = 0;
+
+    /**
+     * @brief Invoked before traversal descends along an outbound edge.
+     */
+    virtual VisitResult onEdge(const IEdge &edge) = 0;
+
+    /**
+     * @brief Supplies the next vertex for @ref TraverseMode::Custom.
+     *
+     * Default returns an invalid @ref NodeId, which ends traversal. Visitors
+     * that do not use custom mode simply inherit the default.
+     */
+    [[nodiscard]] virtual NodeId nextForCustom(const INode &current) { (void)current; return NodeId{}; }
+
+  protected:
+    IGraphVisitor() = default;
+
+  public:
+    IGraphVisitor(const IGraphVisitor &)            = delete;
+    IGraphVisitor &operator=(const IGraphVisitor &) = delete;
+    IGraphVisitor(IGraphVisitor &&)                 = delete;
+    IGraphVisitor &operator=(IGraphVisitor &&)      = delete;
+};
+
+} // namespace vigine::graph

--- a/include/vigine/graph/inode.h
+++ b/include/vigine/graph/inode.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "vigine/graph/kind.h"
+#include "vigine/graph/nodeid.h"
+
+namespace vigine::graph
+{
+/**
+ * @brief Pure-virtual vertex of an @ref IGraph.
+ *
+ * An @ref INode is the polymorphic hook every client plugs custom data
+ * into. The graph owns the node after @ref IGraph::addNode succeeds and
+ * never moves it thereafter, so implementations are pinned in memory for
+ * the lifetime of their slot.
+ *
+ * Copy and move operations are deleted to keep the pinning invariant
+ * explicit at the type level. Construct a concrete node on the heap and
+ * transfer ownership to @ref IGraph::addNode via `std::unique_ptr`.
+ *
+ * Adjacency queries live on @ref IGraphQuery rather than on the node
+ * itself so that the substrate stays minimal and implementations are free
+ * to store topology in whichever layout they prefer.
+ */
+class INode
+{
+  public:
+    virtual ~INode() = default;
+
+    /**
+     * @brief Returns the identifier assigned by the owning graph.
+     *
+     * Before @ref IGraph::addNode returns, the identifier is a
+     * default-constructed (invalid) @ref NodeId. After, it reports the
+     * generational slot assigned by the graph.
+     */
+    [[nodiscard]] virtual NodeId id() const noexcept = 0;
+
+    /**
+     * @brief Returns the kind tag selected by the concrete node.
+     *
+     * @see NodeKind
+     */
+    [[nodiscard]] virtual NodeKind kind() const noexcept = 0;
+
+  protected:
+    INode() = default;
+
+  public:
+    INode(const INode &)            = delete;
+    INode &operator=(const INode &) = delete;
+    INode(INode &&)                 = delete;
+    INode &operator=(INode &&)      = delete;
+};
+
+} // namespace vigine::graph

--- a/include/vigine/graph/kind.h
+++ b/include/vigine/graph/kind.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <cstdint>
+
+namespace vigine::graph
+{
+/**
+ * @brief Byte-wide tag classifying a node.
+ *
+ * Open-ended alias rather than a closed enum so downstream wrappers can
+ * register their own values without forcing a breaking change to the core
+ * graph. Reserved value ranges are documented per wrapper; the core itself
+ * only defines @ref kind::Generic.
+ */
+using NodeKind = std::uint8_t;
+
+/**
+ * @brief Byte-wide tag classifying an edge.
+ *
+ * Mirrors @ref NodeKind. Wrappers (messaging, ECS, state machine, task
+ * flow) supply their own named constants in their public headers; the core
+ * only defines @ref edge_kind::Generic.
+ */
+using EdgeKind = std::uint8_t;
+
+/**
+ * @brief Node kind constants owned by the graph core.
+ *
+ * Wrappers MUST NOT put their own constants in this namespace; they supply
+ * their own (for example `vigine::messaging::kind`). Keeping the core
+ * namespace free of engine-specific concepts is a structural invariant of
+ * the graph substrate.
+ */
+namespace kind
+{
+inline constexpr NodeKind Generic = 1;
+} // namespace kind
+
+/**
+ * @brief Edge kind constants owned by the graph core.
+ */
+namespace edge_kind
+{
+inline constexpr EdgeKind Generic = 1;
+} // namespace edge_kind
+
+} // namespace vigine::graph

--- a/include/vigine/graph/nodeid.h
+++ b/include/vigine/graph/nodeid.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <compare>
+#include <cstdint>
+
+namespace vigine::graph
+{
+/**
+ * @brief Generational identifier of a graph node.
+ *
+ * POD value type carried by every client that refers to a node owned by an
+ * @ref IGraph. Identifiers are composed of a slot index and a generation
+ * counter. The counter bumps each time a slot is reused, so a lookup with a
+ * stale identifier fails safely rather than returning a different node.
+ *
+ * @note Generation `0` is reserved as the invalid sentinel. A default
+ *       constructed @ref NodeId is therefore always invalid and never
+ *       returned by @ref IGraph::addNode.
+ */
+struct NodeId
+{
+    std::uint32_t index{0};
+    std::uint32_t generation{0};
+
+    /**
+     * @brief Reports whether the identifier refers to a live slot at
+     *        construction time.
+     *
+     * A `true` return only means the generation is non-zero. The graph may
+     * still have invalidated the slot since; use @ref IGraph::node or
+     * @ref IGraphQuery::hasNode for the authoritative check.
+     */
+    [[nodiscard]] constexpr bool valid() const noexcept { return generation != 0; }
+
+    friend constexpr auto operator<=>(const NodeId &, const NodeId &) = default;
+    friend constexpr bool operator==(const NodeId &, const NodeId &)  = default;
+};
+
+} // namespace vigine::graph

--- a/include/vigine/graph/traverse_mode.h
+++ b/include/vigine/graph/traverse_mode.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <cstdint>
+
+namespace vigine::graph
+{
+/**
+ * @brief Strategy passed to @ref IGraph::traverse.
+ *
+ * Closed enumeration. Extending this set is a breaking API change because
+ * every @ref IGraphVisitor implementation and every downstream wrapper
+ * assumes the surface is exhaustive; adding a value requires coordinated
+ * review of the engine.
+ */
+enum class TraverseMode : std::uint8_t
+{
+    DepthFirst         = 1, ///< DFS, pre-order (enter before children).
+    BreadthFirst       = 2, ///< BFS, level by level.
+    Topological        = 3, ///< DAG only; traversal reports an error on cycle.
+    ReverseTopological = 4, ///< DAG only; reverse of Topological.
+    Custom             = 5, ///< Visitor supplies the next node via
+                            ///< @ref IGraphVisitor::nextForCustom.
+};
+
+} // namespace vigine::graph

--- a/include/vigine/graph/visit_result.h
+++ b/include/vigine/graph/visit_result.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cstdint>
+
+namespace vigine::graph
+{
+/**
+ * @brief Control flow directive returned by @ref IGraphVisitor.
+ *
+ * Closed enumeration. Returned from @ref IGraphVisitor::onNode and
+ * @ref IGraphVisitor::onEdge to steer the traversal driver inside
+ * @ref IGraph::traverse.
+ */
+enum class VisitResult : std::uint8_t
+{
+    Continue = 1, ///< Continue traversal normally.
+    Skip     = 2, ///< Do not descend into the current subtree, keep walking.
+    Stop     = 3, ///< Stop the traversal completely (early exit).
+};
+
+} // namespace vigine::graph


### PR DESCRIPTION
Adds the public header set for the new graph primitive at `include/vigine/graph/`.

## What ships

- Six pure-virtual interfaces: `IGraph`, `INode`, `IEdge`, `IEdgeData`, `IGraphVisitor`, `IGraphQuery`.
- Two POD identifier types: `NodeId`, `EdgeId` (generational `{index, generation}` pairs with a defaulted three-way comparison and a `valid()` helper).
- Two closed enums: `TraverseMode` (`DepthFirst`, `BreadthFirst`, `Topological`, `ReverseTopological`, `Custom`) and `VisitResult` (`Continue`, `Skip`, `Stop`).
- The `vigine::graph::kind` / `vigine::graph::edge_kind` namespaces, each carrying a single core-reserved constant `Generic = 1`. Wrapper-specific kinds belong to wrapper headers, not here.
- A non-templated factory `std::shared_ptr<IGraph> createGraph();`.
- `CMakeLists.txt` now lists the new headers in the `vigine` target's public header set.

## What stays the same

Header-only change. No `.cpp` files, no implementation, no runtime behaviour changes. Existing sources compile unchanged; the new headers are self-contained and include-clean.

## Acceptance

The twelve new headers compile standalone (each one as the only `#include` in a translation unit) and together, under `cl /std:c++latest /W4 /permissive-`, with zero warnings. No templates appear anywhere in `include/vigine/graph/`. No engine-specific concepts (entity, component, state, task, message, subscription, target, transition, etc.) leak into the core.

Implementation lands in a follow-up change.

Closes #85
