### PR TITLE
feat(graph): ship AbstractGraph + DefaultGraph (adjacency-list impl)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,7 @@ set(HEADER
     ${INCLUDE_DIR}/vigine/graph/igraphquery.h
     ${INCLUDE_DIR}/vigine/graph/igraph.h
     ${INCLUDE_DIR}/vigine/graph/factory.h
+    ${INCLUDE_DIR}/vigine/graph/abstractgraph.h
 )
 
 set(SOURCES
@@ -177,6 +178,12 @@ set(SOURCES
     ${SRC_DIR}/ecs/entitymanager.cpp
     ${SRC_DIR}/ecs/abstractsystem.cpp
     ${SRC_DIR}/entitybindinghost.cpp
+    ${SRC_DIR}/graph/abstractgraph.cpp
+    ${SRC_DIR}/graph/defaultgraph.cpp
+    ${SRC_DIR}/graph/defaultgraph_traverse.cpp
+    ${SRC_DIR}/graph/defaultgraph_query.cpp
+    ${SRC_DIR}/graph/defaultgraph_export.cpp
+    ${SRC_DIR}/graph/factory.cpp
 )
 
 # Add platform-specific surface factory

--- a/include/vigine/graph/abstractgraph.h
+++ b/include/vigine/graph/abstractgraph.h
@@ -1,0 +1,199 @@
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <shared_mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "vigine/graph/edgeid.h"
+#include "vigine/graph/iedge.h"
+#include "vigine/graph/igraph.h"
+#include "vigine/graph/igraphquery.h"
+#include "vigine/graph/igraphvisitor.h"
+#include "vigine/graph/inode.h"
+#include "vigine/graph/kind.h"
+#include "vigine/graph/nodeid.h"
+#include "vigine/graph/traverse_mode.h"
+#include "vigine/result.h"
+
+namespace vigine::graph
+{
+/**
+ * @brief Concrete stateful base for every in-memory @ref IGraph.
+ *
+ * @ref AbstractGraph carries the shared storage, the generational id
+ * machinery, the reader-writer mutex, and the version counter that every
+ * concrete graph implementation and every wrapper built on the graph
+ * substrate relies on. It is the common foundation of the five-layer
+ * recipe used by the engine's Level-1 wrappers (messaging, ECS, state
+ * machine, task flow, service container), all of which inherit
+ * @ref AbstractGraph as @c protected to reuse the substrate without
+ * re-exposing it on the wrapper's public surface.
+ *
+ * The class carries state, so it follows the project's @c Abstract naming
+ * convention rather than the @c I pure-virtual prefix. It is abstract only
+ * in the logical sense — users do not instantiate it directly because the
+ * factory in @ref factory.h returns a @c final subclass (@ref DefaultGraph)
+ * that merely marks the inheritance chain closed.
+ *
+ * Thread-safety: every mutating entry point takes an exclusive lock on the
+ * internal @c std::shared_mutex; every read-only entry point takes a shared
+ * lock. Traversal snapshots the structural information it needs under a
+ * shared lock and then runs the visitor callbacks lock-free, so a visitor
+ * that re-enters the graph does not deadlock and so concurrent readers do
+ * not block each other.
+ */
+class AbstractGraph : public IGraph
+{
+  public:
+    ~AbstractGraph() override;
+
+    // ------ IGraph: node lifecycle ------
+
+    [[nodiscard]] NodeId addNode(std::unique_ptr<INode> node) override;
+    Result               removeNode(NodeId id) override;
+    [[nodiscard]] const INode *node(NodeId id) const noexcept override;
+
+    // ------ IGraph: edge lifecycle ------
+
+    [[nodiscard]] EdgeId addEdge(std::unique_ptr<IEdge> edge) override;
+    Result               removeEdge(EdgeId id) override;
+    [[nodiscard]] const IEdge *edge(EdgeId id) const noexcept override;
+
+    // ------ IGraph: traversal ------
+
+    Result traverse(NodeId startNode, TraverseMode mode, IGraphVisitor &visitor) override;
+
+    // ------ IGraph: query ------
+
+    [[nodiscard]] const IGraphQuery &query() const noexcept override;
+
+    // ------ IGraph: observability ------
+
+    [[nodiscard]] std::size_t nodeCount() const noexcept override;
+    [[nodiscard]] std::size_t edgeCount() const noexcept override;
+
+    // ------ IGraph: tooling ------
+
+    Result exportGraphViz(std::string &out) const override;
+
+    /**
+     * @brief Optional mixin nodes and edges inherit when they want their
+     *        own generational id back from the graph at insertion time.
+     *
+     * Nodes and edges that do not need to cache their own id just ignore
+     * the mixin and return @c NodeId{} / @c EdgeId{} from their
+     * @ref INode::id / @ref IEdge::id methods. The graph internally
+     * tracks the canonical mapping either way; this hook exists only so
+     * that @ref INode::id / @ref IEdge::id can report the assigned id
+     * without round-tripping through the graph.
+     */
+    class IdStamp
+    {
+      public:
+        virtual ~IdStamp() = default;
+        /**
+         * @brief Called once by the graph immediately after the node or
+         *        edge has been placed into its storage slot. Exactly one
+         *        of the two arguments carries a valid id; the other is
+         *        a default-constructed sentinel.
+         */
+        virtual void onGraphIdAssigned(NodeId nodeId, EdgeId edgeId) noexcept = 0;
+
+      protected:
+        IdStamp() = default;
+    };
+
+  protected:
+    AbstractGraph();
+
+  private:
+    struct NodeSlot
+    {
+        std::unique_ptr<INode> node;
+        std::uint32_t          generation{0};
+        std::vector<EdgeId>    outEdges;
+        std::vector<EdgeId>    inEdges;
+    };
+
+    struct EdgeSlot
+    {
+        std::unique_ptr<IEdge> edge;
+        std::uint32_t          generation{0};
+    };
+
+    class QueryImpl final : public IGraphQuery
+    {
+      public:
+        explicit QueryImpl(const AbstractGraph &graph);
+
+        [[nodiscard]] bool hasNode(NodeId id) const noexcept override;
+        [[nodiscard]] bool hasEdge(EdgeId id) const noexcept override;
+        [[nodiscard]] std::vector<EdgeId> outEdges(NodeId id) const override;
+        [[nodiscard]] std::vector<EdgeId> inEdges(NodeId id) const override;
+        [[nodiscard]] std::vector<EdgeId> outEdgesOfKind(NodeId id, EdgeKind kind) const override;
+        [[nodiscard]] std::vector<EdgeId> inEdgesOfKind(NodeId id, EdgeKind kind) const override;
+        [[nodiscard]] std::optional<std::vector<NodeId>>
+            shortestPath(NodeId from, NodeId to) const override;
+        [[nodiscard]] std::vector<std::vector<NodeId>> connectedComponents() const override;
+        [[nodiscard]] bool                             hasCycle() const override;
+        [[nodiscard]] std::optional<std::vector<NodeId>>
+            topologicalOrder() const override;
+
+      private:
+        const AbstractGraph &_graph;
+    };
+
+    // Snapshot shape used by the traversal driver and by the structural
+    // query methods. Copying the relevant adjacency into plain vectors lets
+    // the caller drive its algorithm lock-free once the snapshot is done.
+    struct Snapshot
+    {
+        struct Endpoints
+        {
+            NodeId from;
+            NodeId to;
+        };
+        std::vector<NodeId>                                   nodes;
+        std::unordered_map<std::uint64_t, std::vector<EdgeId>> outByKey;
+        std::unordered_map<std::uint64_t, std::vector<EdgeId>> inByKey;
+        std::unordered_map<std::uint64_t, Endpoints>           edgeEndpoints;
+
+        static std::uint64_t nodeKey(NodeId id) noexcept
+        {
+            return (static_cast<std::uint64_t>(id.index) << 32)
+                   | static_cast<std::uint64_t>(id.generation);
+        }
+        static std::uint64_t edgeKey(EdgeId id) noexcept
+        {
+            return (static_cast<std::uint64_t>(id.index) << 32)
+                   | static_cast<std::uint64_t>(id.generation);
+        }
+    };
+
+    Snapshot buildSnapshot() const;
+
+    // Private helpers used by traversal / queries.
+    std::vector<NodeId> snapshotLiveNodes() const;
+    std::vector<EdgeId> snapshotOutEdges(NodeId id) const;
+    bool                eraseEdgeLocked(EdgeId id);
+    static void         stampOnInsert(INode &node, NodeId id) noexcept;
+    static void         stampOnInsert(IEdge &edge, EdgeId id) noexcept;
+
+    mutable std::shared_mutex                         _mutex;
+    std::unordered_map<std::uint32_t, NodeSlot>       _nodes;
+    std::unordered_map<std::uint32_t, EdgeSlot>       _edges;
+    std::uint32_t                                     _nextNodeIndex{1};
+    std::uint32_t                                     _nextEdgeIndex{1};
+    std::atomic<std::uint64_t>                        _version{0};
+    QueryImpl                                         _query;
+
+    friend class QueryImpl;
+};
+
+} // namespace vigine::graph

--- a/src/graph/abstractgraph.cpp
+++ b/src/graph/abstractgraph.cpp
@@ -1,0 +1,397 @@
+#include "vigine/graph/abstractgraph.h"
+
+#include <algorithm>
+#include <mutex>
+#include <utility>
+
+namespace vigine::graph
+{
+// ---------------------------------------------------------------------------
+// Construction / destruction.
+// ---------------------------------------------------------------------------
+
+AbstractGraph::AbstractGraph() : _query(*this) {}
+
+AbstractGraph::~AbstractGraph() = default;
+
+// ---------------------------------------------------------------------------
+// Id stamping — concrete nodes / edges that want their own id inherit
+// IdStamp and receive a single callback from the graph when their slot is
+// ready. Callers that do not inherit IdStamp get no callback and report
+// NodeId{} / EdgeId{} from id(); the graph still tracks them internally.
+// ---------------------------------------------------------------------------
+
+void AbstractGraph::stampOnInsert(INode &node, NodeId id) noexcept
+{
+    if (auto *stamp = dynamic_cast<IdStamp *>(&node))
+    {
+        stamp->onGraphIdAssigned(id, EdgeId{});
+    }
+}
+
+void AbstractGraph::stampOnInsert(IEdge &edge, EdgeId id) noexcept
+{
+    if (auto *stamp = dynamic_cast<IdStamp *>(&edge))
+    {
+        stamp->onGraphIdAssigned(NodeId{}, id);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Node lifecycle.
+// ---------------------------------------------------------------------------
+
+NodeId AbstractGraph::addNode(std::unique_ptr<INode> node)
+{
+    if (!node)
+    {
+        return NodeId{};
+    }
+    std::unique_lock lock(_mutex);
+
+    const std::uint32_t index      = _nextNodeIndex++;
+    const std::uint32_t generation = 1;
+    NodeSlot            slot;
+    slot.node       = std::move(node);
+    slot.generation = generation;
+    const NodeId id{index, generation};
+    stampOnInsert(*slot.node, id);
+    _nodes.emplace(index, std::move(slot));
+    _version.fetch_add(1, std::memory_order_release);
+    return id;
+}
+
+Result AbstractGraph::removeNode(NodeId id)
+{
+    if (!id.valid())
+    {
+        return Result(Result::Code::Error, "invalid node id");
+    }
+    std::unique_lock lock(_mutex);
+    const auto       it = _nodes.find(id.index);
+    if (it == _nodes.end() || it->second.generation != id.generation || !it->second.node)
+    {
+        return Result(Result::Code::Error, "stale node id");
+    }
+
+    const std::vector<EdgeId> outCopy = it->second.outEdges;
+    const std::vector<EdgeId> inCopy  = it->second.inEdges;
+    for (EdgeId eid : outCopy)
+    {
+        eraseEdgeLocked(eid);
+    }
+    for (EdgeId eid : inCopy)
+    {
+        eraseEdgeLocked(eid);
+    }
+
+    auto &slot = it->second;
+    slot.node.reset();
+    slot.outEdges.clear();
+    slot.inEdges.clear();
+    ++slot.generation;
+    _version.fetch_add(1, std::memory_order_release);
+    return Result();
+}
+
+const INode *AbstractGraph::node(NodeId id) const noexcept
+{
+    if (!id.valid())
+    {
+        return nullptr;
+    }
+    std::shared_lock lock(_mutex);
+    const auto       it = _nodes.find(id.index);
+    if (it == _nodes.end() || it->second.generation != id.generation || !it->second.node)
+    {
+        return nullptr;
+    }
+    return it->second.node.get();
+}
+
+// ---------------------------------------------------------------------------
+// Edge lifecycle.
+// ---------------------------------------------------------------------------
+
+EdgeId AbstractGraph::addEdge(std::unique_ptr<IEdge> edge)
+{
+    if (!edge)
+    {
+        return EdgeId{};
+    }
+    const NodeId fromId = edge->from();
+    const NodeId toId   = edge->to();
+
+    std::unique_lock lock(_mutex);
+    const auto       fromIt = _nodes.find(fromId.index);
+    const auto       toIt   = _nodes.find(toId.index);
+    if (fromIt == _nodes.end() || fromIt->second.generation != fromId.generation || !fromIt->second.node
+        || toIt == _nodes.end() || toIt->second.generation != toId.generation || !toIt->second.node)
+    {
+        return EdgeId{};
+    }
+
+    const std::uint32_t index      = _nextEdgeIndex++;
+    const std::uint32_t generation = 1;
+    EdgeSlot            slot;
+    slot.edge       = std::move(edge);
+    slot.generation = generation;
+    const EdgeId id{index, generation};
+    stampOnInsert(*slot.edge, id);
+
+    fromIt->second.outEdges.push_back(id);
+    toIt->second.inEdges.push_back(id);
+    _edges.emplace(index, std::move(slot));
+    _version.fetch_add(1, std::memory_order_release);
+    return id;
+}
+
+Result AbstractGraph::removeEdge(EdgeId id)
+{
+    if (!id.valid())
+    {
+        return Result(Result::Code::Error, "invalid edge id");
+    }
+    std::unique_lock lock(_mutex);
+    if (!eraseEdgeLocked(id))
+    {
+        return Result(Result::Code::Error, "stale edge id");
+    }
+    _version.fetch_add(1, std::memory_order_release);
+    return Result();
+}
+
+const IEdge *AbstractGraph::edge(EdgeId id) const noexcept
+{
+    if (!id.valid())
+    {
+        return nullptr;
+    }
+    std::shared_lock lock(_mutex);
+    const auto       it = _edges.find(id.index);
+    if (it == _edges.end() || it->second.generation != id.generation || !it->second.edge)
+    {
+        return nullptr;
+    }
+    return it->second.edge.get();
+}
+
+// ---------------------------------------------------------------------------
+// Query / observability.
+// ---------------------------------------------------------------------------
+
+const IGraphQuery &AbstractGraph::query() const noexcept
+{
+    return _query;
+}
+
+std::size_t AbstractGraph::nodeCount() const noexcept
+{
+    std::shared_lock lock(_mutex);
+    std::size_t      live = 0;
+    for (const auto &[_, slot] : _nodes)
+    {
+        if (slot.node)
+        {
+            ++live;
+        }
+    }
+    return live;
+}
+
+std::size_t AbstractGraph::edgeCount() const noexcept
+{
+    std::shared_lock lock(_mutex);
+    std::size_t      live = 0;
+    for (const auto &[_, slot] : _edges)
+    {
+        if (slot.edge)
+        {
+            ++live;
+        }
+    }
+    return live;
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot helpers used by traversal / export.
+// ---------------------------------------------------------------------------
+
+std::vector<NodeId> AbstractGraph::snapshotLiveNodes() const
+{
+    std::shared_lock    lock(_mutex);
+    std::vector<NodeId> ids;
+    ids.reserve(_nodes.size());
+    for (const auto &[index, slot] : _nodes)
+    {
+        if (slot.node)
+        {
+            ids.push_back(NodeId{index, slot.generation});
+        }
+    }
+    return ids;
+}
+
+std::vector<EdgeId> AbstractGraph::snapshotOutEdges(NodeId id) const
+{
+    std::shared_lock lock(_mutex);
+    const auto       it = _nodes.find(id.index);
+    if (it == _nodes.end() || it->second.generation != id.generation)
+    {
+        return {};
+    }
+    return it->second.outEdges;
+}
+
+// ---------------------------------------------------------------------------
+// buildSnapshot — captures the full adjacency shape of the graph under a
+// single shared lock. The traversal driver and the structural query
+// methods use the returned value to run their algorithms without holding
+// the mutex during the actual work.
+// ---------------------------------------------------------------------------
+
+AbstractGraph::Snapshot AbstractGraph::buildSnapshot() const
+{
+    Snapshot         s;
+    std::shared_lock lock(_mutex);
+    s.nodes.reserve(_nodes.size());
+    for (const auto &[index, slot] : _nodes)
+    {
+        if (!slot.node)
+        {
+            continue;
+        }
+        NodeId nid{index, slot.generation};
+        s.nodes.push_back(nid);
+        s.outByKey[Snapshot::nodeKey(nid)] = slot.outEdges;
+        s.inByKey[Snapshot::nodeKey(nid)]  = slot.inEdges;
+    }
+    for (const auto &[index, slot] : _edges)
+    {
+        if (!slot.edge)
+        {
+            continue;
+        }
+        EdgeId eid{index, slot.generation};
+        s.edgeEndpoints[Snapshot::edgeKey(eid)] = {slot.edge->from(), slot.edge->to()};
+    }
+    return s;
+}
+
+// ---------------------------------------------------------------------------
+// eraseEdgeLocked — removes a single edge while the caller already holds
+// the exclusive lock. Updates both endpoints' adjacency lists so that the
+// cascade in removeNode does not leave dangling references. Reports
+// whether the edge existed.
+// ---------------------------------------------------------------------------
+
+bool AbstractGraph::eraseEdgeLocked(EdgeId id)
+{
+    const auto it = _edges.find(id.index);
+    if (it == _edges.end() || it->second.generation != id.generation || !it->second.edge)
+    {
+        return false;
+    }
+    const NodeId fromId = it->second.edge->from();
+    const NodeId toId   = it->second.edge->to();
+
+    const auto detach = [&](NodeId nid, bool outgoing)
+    {
+        const auto nit = _nodes.find(nid.index);
+        if (nit == _nodes.end() || nit->second.generation != nid.generation)
+        {
+            return;
+        }
+        auto &list = outgoing ? nit->second.outEdges : nit->second.inEdges;
+        list.erase(std::remove(list.begin(), list.end(), id), list.end());
+    };
+    detach(fromId, /*outgoing=*/true);
+    detach(toId, /*outgoing=*/false);
+
+    it->second.edge.reset();
+    ++it->second.generation;
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// QueryImpl — the read-only surface delegates back into the owning graph
+// under shared locks. Each method builds its own container.
+// ---------------------------------------------------------------------------
+
+AbstractGraph::QueryImpl::QueryImpl(const AbstractGraph &graph) : _graph(graph) {}
+
+bool AbstractGraph::QueryImpl::hasNode(NodeId id) const noexcept
+{
+    return _graph.node(id) != nullptr;
+}
+
+bool AbstractGraph::QueryImpl::hasEdge(EdgeId id) const noexcept
+{
+    return _graph.edge(id) != nullptr;
+}
+
+std::vector<EdgeId> AbstractGraph::QueryImpl::outEdges(NodeId id) const
+{
+    std::shared_lock lock(_graph._mutex);
+    const auto       it = _graph._nodes.find(id.index);
+    if (it == _graph._nodes.end() || it->second.generation != id.generation)
+    {
+        return {};
+    }
+    return it->second.outEdges;
+}
+
+std::vector<EdgeId> AbstractGraph::QueryImpl::inEdges(NodeId id) const
+{
+    std::shared_lock lock(_graph._mutex);
+    const auto       it = _graph._nodes.find(id.index);
+    if (it == _graph._nodes.end() || it->second.generation != id.generation)
+    {
+        return {};
+    }
+    return it->second.inEdges;
+}
+
+std::vector<EdgeId> AbstractGraph::QueryImpl::outEdgesOfKind(NodeId id, EdgeKind kind) const
+{
+    std::shared_lock lock(_graph._mutex);
+    const auto       it = _graph._nodes.find(id.index);
+    if (it == _graph._nodes.end() || it->second.generation != id.generation)
+    {
+        return {};
+    }
+    std::vector<EdgeId> out;
+    out.reserve(it->second.outEdges.size());
+    for (EdgeId eid : it->second.outEdges)
+    {
+        const auto eit = _graph._edges.find(eid.index);
+        if (eit != _graph._edges.end() && eit->second.generation == eid.generation && eit->second.edge && eit->second.edge->kind() == kind)
+        {
+            out.push_back(eid);
+        }
+    }
+    return out;
+}
+
+std::vector<EdgeId> AbstractGraph::QueryImpl::inEdgesOfKind(NodeId id, EdgeKind kind) const
+{
+    std::shared_lock lock(_graph._mutex);
+    const auto       it = _graph._nodes.find(id.index);
+    if (it == _graph._nodes.end() || it->second.generation != id.generation)
+    {
+        return {};
+    }
+    std::vector<EdgeId> out;
+    out.reserve(it->second.inEdges.size());
+    for (EdgeId eid : it->second.inEdges)
+    {
+        const auto eit = _graph._edges.find(eid.index);
+        if (eit != _graph._edges.end() && eit->second.generation == eid.generation && eit->second.edge && eit->second.edge->kind() == kind)
+        {
+            out.push_back(eid);
+        }
+    }
+    return out;
+}
+
+} // namespace vigine::graph

--- a/src/graph/defaultgraph.cpp
+++ b/src/graph/defaultgraph.cpp
@@ -1,0 +1,11 @@
+#include "graph/defaultgraph.h"
+
+// DefaultGraph is a thin final subclass of AbstractGraph. All storage and
+// lifecycle behaviour lives on AbstractGraph; this translation unit exists
+// only so that the build has an explicit home for the class' out-of-line
+// linkage in case the implementation needs to migrate back out of the
+// header without churning every consumer.
+
+namespace vigine::graph
+{
+} // namespace vigine::graph

--- a/src/graph/defaultgraph.h
+++ b/src/graph/defaultgraph.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+
+#include "vigine/graph/abstractgraph.h"
+#include "vigine/graph/edgeid.h"
+#include "vigine/graph/iedge.h"
+#include "vigine/graph/iedgedata.h"
+#include "vigine/graph/inode.h"
+#include "vigine/graph/kind.h"
+#include "vigine/graph/nodeid.h"
+
+namespace vigine::graph
+{
+/**
+ * @brief Default concrete implementation of @ref IGraph.
+ *
+ * Closes the inheritance chain on @ref AbstractGraph and provides no
+ * storage or behaviour of its own; all mechanics live on @ref AbstractGraph.
+ * The @c final keyword prevents further subclassing so that
+ * @ref createGraph has one well-defined concrete return type.
+ */
+class DefaultGraph final : public AbstractGraph
+{
+  public:
+    DefaultGraph()           = default;
+    ~DefaultGraph() override = default;
+};
+
+namespace internal
+{
+/**
+ * @brief Minimal concrete @ref INode used by the smoke test and by any
+ *        ad-hoc client that only cares about topology.
+ *
+ * Inherits @ref AbstractGraph::IdStamp so that the graph can feed the
+ * generational id back to the node at insertion time. Wrappers supply
+ * their own @ref INode subclasses carrying wrapper-specific state; they
+ * are not required to rely on @ref NodeImpl.
+ */
+class NodeImpl final
+    : public INode
+    , public AbstractGraph::IdStamp
+{
+  public:
+    explicit NodeImpl(NodeKind kind) noexcept : _kind{kind} {}
+
+    [[nodiscard]] NodeId   id() const noexcept override { return _id; }
+    [[nodiscard]] NodeKind kind() const noexcept override { return _kind; }
+
+    void onGraphIdAssigned(NodeId nodeId, EdgeId edgeId) noexcept override
+    {
+        _id = nodeId;
+        (void)edgeId;
+    }
+
+  private:
+    NodeId   _id{};
+    NodeKind _kind{};
+};
+
+/**
+ * @brief Minimal concrete @ref IEdge paired with @ref NodeImpl.
+ */
+class EdgeImpl final
+    : public IEdge
+    , public AbstractGraph::IdStamp
+{
+  public:
+    EdgeImpl(NodeId from, NodeId to, EdgeKind kind, std::unique_ptr<IEdgeData> data) noexcept
+        : _from{from}, _to{to}, _kind{kind}, _data{std::move(data)}
+    {
+    }
+
+    [[nodiscard]] EdgeId           id() const noexcept override { return _id; }
+    [[nodiscard]] EdgeKind         kind() const noexcept override { return _kind; }
+    [[nodiscard]] NodeId           from() const noexcept override { return _from; }
+    [[nodiscard]] NodeId           to() const noexcept override { return _to; }
+    [[nodiscard]] const IEdgeData *data() const noexcept override { return _data.get(); }
+
+    void onGraphIdAssigned(NodeId nodeId, EdgeId edgeId) noexcept override
+    {
+        _id = edgeId;
+        (void)nodeId;
+    }
+
+  private:
+    EdgeId                     _id{};
+    NodeId                     _from{};
+    NodeId                     _to{};
+    EdgeKind                   _kind{};
+    std::unique_ptr<IEdgeData> _data{};
+};
+
+[[nodiscard]] inline std::unique_ptr<INode> makeNode(NodeKind kind)
+{
+    return std::make_unique<NodeImpl>(kind);
+}
+
+[[nodiscard]] inline std::unique_ptr<IEdge>
+    makeEdge(NodeId from, NodeId to, EdgeKind kind, std::unique_ptr<IEdgeData> data = nullptr)
+{
+    return std::make_unique<EdgeImpl>(from, to, kind, std::move(data));
+}
+
+} // namespace internal
+
+} // namespace vigine::graph

--- a/src/graph/defaultgraph_export.cpp
+++ b/src/graph/defaultgraph_export.cpp
@@ -1,0 +1,77 @@
+#include "vigine/graph/abstractgraph.h"
+
+#include <shared_mutex>
+#include <string>
+
+namespace vigine::graph
+{
+namespace
+{
+// Emits a small integer into a string buffer without pulling in locale or
+// stream overhead. The exporter runs under a shared lock; keeping it
+// allocation-light matters for larger graphs.
+void appendUint(std::string &out, std::uint64_t value)
+{
+    if (value == 0)
+    {
+        out.push_back('0');
+        return;
+    }
+    char   buf[21];
+    size_t len = 0;
+    while (value > 0 && len < sizeof(buf))
+    {
+        buf[len++] = static_cast<char>('0' + (value % 10));
+        value /= 10;
+    }
+    for (size_t i = 0; i < len; ++i)
+    {
+        out.push_back(buf[len - 1 - i]);
+    }
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// exportGraphViz — writes a minimal DOT graph into the caller-supplied
+// buffer. No file-system access; the caller owns the string and is free to
+// route it anywhere. The exporter prints each live node with its kind tag
+// and every live edge as a directed arrow between the two endpoints.
+// ---------------------------------------------------------------------------
+
+Result AbstractGraph::exportGraphViz(std::string &out) const
+{
+    std::shared_lock lock(_mutex);
+    out.clear();
+    out += "digraph G {\n";
+    for (const auto &[index, slot] : _nodes)
+    {
+        if (!slot.node)
+        {
+            continue;
+        }
+        out += "  n";
+        appendUint(out, index);
+        out += " [label=\"n";
+        appendUint(out, index);
+        out += " kind=";
+        appendUint(out, static_cast<std::uint64_t>(slot.node->kind()));
+        out += "\"];\n";
+    }
+    for (const auto &[index, slot] : _edges)
+    {
+        if (!slot.edge)
+        {
+            continue;
+        }
+        out += "  n";
+        appendUint(out, slot.edge->from().index);
+        out += " -> n";
+        appendUint(out, slot.edge->to().index);
+        out += ";\n";
+    }
+    out += "}\n";
+    return Result();
+}
+
+} // namespace vigine::graph

--- a/src/graph/defaultgraph_query.cpp
+++ b/src/graph/defaultgraph_query.cpp
@@ -1,0 +1,307 @@
+#include "vigine/graph/abstractgraph.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <deque>
+#include <optional>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace vigine::graph
+{
+namespace
+{
+// Hash adapter so NodeId can be an unordered-container key.
+struct NodeIdHasher
+{
+    std::size_t operator()(NodeId id) const noexcept
+    {
+        return (static_cast<std::size_t>(id.index) << 32) ^ static_cast<std::size_t>(id.generation);
+    }
+};
+
+using NodeIdSet = std::unordered_set<NodeId, NodeIdHasher>;
+
+template <class Value>
+using NodeIdMap = std::unordered_map<NodeId, Value, NodeIdHasher>;
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// shortestPath — unweighted BFS on the snapshot. Returns nullopt when
+// either endpoint is absent or when no path exists.
+// ---------------------------------------------------------------------------
+
+std::optional<std::vector<NodeId>>
+AbstractGraph::QueryImpl::shortestPath(NodeId from, NodeId to) const
+{
+    if (!hasNode(from) || !hasNode(to))
+    {
+        return std::nullopt;
+    }
+    if (from == to)
+    {
+        return std::vector<NodeId>{from};
+    }
+
+    const Snapshot snap = _graph.buildSnapshot();
+
+    NodeIdMap<NodeId> parent;
+    parent[from] = NodeId{};
+    std::deque<NodeId> queue;
+    queue.push_back(from);
+    bool found = false;
+    while (!queue.empty())
+    {
+        const NodeId current = queue.front();
+        queue.pop_front();
+        if (current == to)
+        {
+            found = true;
+            break;
+        }
+        const auto outIt = snap.outByKey.find(Snapshot::nodeKey(current));
+        if (outIt == snap.outByKey.end())
+        {
+            continue;
+        }
+        for (EdgeId eid : outIt->second)
+        {
+            const auto endpointsIt = snap.edgeEndpoints.find(Snapshot::edgeKey(eid));
+            if (endpointsIt == snap.edgeEndpoints.end())
+            {
+                continue;
+            }
+            const NodeId neighbour = endpointsIt->second.to;
+            if (parent.emplace(neighbour, current).second)
+            {
+                queue.push_back(neighbour);
+            }
+        }
+    }
+
+    if (!found)
+    {
+        return std::nullopt;
+    }
+
+    std::vector<NodeId> path;
+    NodeId              cursor = to;
+    while (cursor.valid())
+    {
+        path.push_back(cursor);
+        if (cursor == from)
+        {
+            break;
+        }
+        const auto it = parent.find(cursor);
+        if (it == parent.end())
+        {
+            break;
+        }
+        cursor = it->second;
+    }
+    std::reverse(path.begin(), path.end());
+    return path;
+}
+
+// ---------------------------------------------------------------------------
+// connectedComponents — treats the graph as undirected. Walks in and out
+// edges indiscriminately so that a purely incoming neighbourhood is still
+// linked to its reachable component.
+// ---------------------------------------------------------------------------
+
+std::vector<std::vector<NodeId>>
+AbstractGraph::QueryImpl::connectedComponents() const
+{
+    const Snapshot snap = _graph.buildSnapshot();
+
+    NodeIdSet                        seen;
+    std::vector<std::vector<NodeId>> components;
+    for (const NodeId &seed : snap.nodes)
+    {
+        if (seen.count(seed))
+        {
+            continue;
+        }
+        std::vector<NodeId> component;
+        std::deque<NodeId>  frontier;
+        frontier.push_back(seed);
+        seen.insert(seed);
+        while (!frontier.empty())
+        {
+            const NodeId current = frontier.front();
+            frontier.pop_front();
+            component.push_back(current);
+
+            const auto walk = [&](const std::vector<EdgeId> &edgesForNode, bool outgoing)
+            {
+                for (EdgeId eid : edgesForNode)
+                {
+                    const auto endpointsIt = snap.edgeEndpoints.find(Snapshot::edgeKey(eid));
+                    if (endpointsIt == snap.edgeEndpoints.end())
+                    {
+                        continue;
+                    }
+                    const NodeId other =
+                        outgoing ? endpointsIt->second.to : endpointsIt->second.from;
+                    if (seen.insert(other).second)
+                    {
+                        frontier.push_back(other);
+                    }
+                }
+            };
+            const auto outIt = snap.outByKey.find(Snapshot::nodeKey(current));
+            if (outIt != snap.outByKey.end())
+            {
+                walk(outIt->second, /*outgoing=*/true);
+            }
+            const auto inIt = snap.inByKey.find(Snapshot::nodeKey(current));
+            if (inIt != snap.inByKey.end())
+            {
+                walk(inIt->second, /*outgoing=*/false);
+            }
+        }
+        components.push_back(std::move(component));
+    }
+    return components;
+}
+
+// ---------------------------------------------------------------------------
+// hasCycle — iterative DFS with white/gray/black colouring.
+// ---------------------------------------------------------------------------
+
+bool AbstractGraph::QueryImpl::hasCycle() const
+{
+    const Snapshot snap = _graph.buildSnapshot();
+    enum class Colour
+    {
+        White,
+        Gray,
+        Black
+    };
+    NodeIdMap<Colour> colour;
+    for (const NodeId &nid : snap.nodes)
+    {
+        colour[nid] = Colour::White;
+    }
+    for (const NodeId &seed : snap.nodes)
+    {
+        if (colour[seed] != Colour::White)
+        {
+            continue;
+        }
+        struct Frame
+        {
+            NodeId      node;
+            std::size_t next{0};
+        };
+        std::vector<Frame> stack;
+        stack.push_back({seed, 0});
+        colour[seed] = Colour::Gray;
+        while (!stack.empty())
+        {
+            Frame     &top   = stack.back();
+            const auto outIt = snap.outByKey.find(Snapshot::nodeKey(top.node));
+            if (outIt == snap.outByKey.end() || top.next >= outIt->second.size())
+            {
+                colour[top.node] = Colour::Black;
+                stack.pop_back();
+                continue;
+            }
+            const EdgeId eid = outIt->second[top.next++];
+            const auto   endpointsIt = snap.edgeEndpoints.find(Snapshot::edgeKey(eid));
+            if (endpointsIt == snap.edgeEndpoints.end())
+            {
+                continue;
+            }
+            const NodeId target = endpointsIt->second.to;
+            const auto   cit    = colour.find(target);
+            if (cit == colour.end())
+            {
+                continue;
+            }
+            if (cit->second == Colour::Gray)
+            {
+                return true;
+            }
+            if (cit->second == Colour::White)
+            {
+                cit->second = Colour::Gray;
+                stack.push_back({target, 0});
+            }
+        }
+    }
+    return false;
+}
+
+// ---------------------------------------------------------------------------
+// topologicalOrder — Kahn's algorithm. Returns nullopt on cycle.
+// ---------------------------------------------------------------------------
+
+std::optional<std::vector<NodeId>>
+AbstractGraph::QueryImpl::topologicalOrder() const
+{
+    const Snapshot         snap = _graph.buildSnapshot();
+    NodeIdMap<std::size_t> indegree;
+    for (const NodeId &nid : snap.nodes)
+    {
+        const auto it = snap.inByKey.find(Snapshot::nodeKey(nid));
+        indegree[nid] = it == snap.inByKey.end() ? 0 : it->second.size();
+    }
+
+    std::deque<NodeId> ready;
+    for (const NodeId &nid : snap.nodes)
+    {
+        if (indegree[nid] == 0)
+        {
+            ready.push_back(nid);
+        }
+    }
+
+    std::vector<NodeId> order;
+    order.reserve(snap.nodes.size());
+    while (!ready.empty())
+    {
+        const NodeId current = ready.front();
+        ready.pop_front();
+        order.push_back(current);
+        const auto outIt = snap.outByKey.find(Snapshot::nodeKey(current));
+        if (outIt == snap.outByKey.end())
+        {
+            continue;
+        }
+        for (EdgeId eid : outIt->second)
+        {
+            const auto endpointsIt = snap.edgeEndpoints.find(Snapshot::edgeKey(eid));
+            if (endpointsIt == snap.edgeEndpoints.end())
+            {
+                continue;
+            }
+            const NodeId target = endpointsIt->second.to;
+            const auto   it     = indegree.find(target);
+            if (it == indegree.end())
+            {
+                continue;
+            }
+            if (it->second > 0)
+            {
+                --it->second;
+            }
+            if (it->second == 0)
+            {
+                ready.push_back(target);
+            }
+        }
+    }
+
+    if (order.size() < snap.nodes.size())
+    {
+        return std::nullopt;
+    }
+    return order;
+}
+
+} // namespace vigine::graph

--- a/src/graph/defaultgraph_traverse.cpp
+++ b/src/graph/defaultgraph_traverse.cpp
@@ -1,0 +1,335 @@
+#include "vigine/graph/abstractgraph.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <deque>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace vigine::graph
+{
+namespace
+{
+// Hash adapter so NodeId can be stored in unordered containers.
+struct NodeIdHasher
+{
+    std::size_t operator()(NodeId id) const noexcept
+    {
+        return (static_cast<std::size_t>(id.index) << 32) ^ static_cast<std::size_t>(id.generation);
+    }
+};
+
+using NodeIdSet = std::unordered_set<NodeId, NodeIdHasher>;
+
+// Re-looks-up a node / edge through the public read path, which handles
+// its own locking and generational check.
+const INode *resolve(const AbstractGraph &graph, NodeId id)
+{
+    return graph.node(id);
+}
+
+const IEdge *resolve(const AbstractGraph &graph, EdgeId id)
+{
+    return graph.edge(id);
+}
+
+// Drives the onNode callback and translates the visitor's return into the
+// next driver step.
+enum class NodeStep
+{
+    Descend,
+    Prune,
+    Stop
+};
+
+NodeStep visitNode(const AbstractGraph &graph, NodeId id, IGraphVisitor &visitor)
+{
+    const INode *ptr = resolve(graph, id);
+    if (!ptr)
+    {
+        // Node removed between snapshot and visit — safe to skip.
+        return NodeStep::Prune;
+    }
+    const VisitResult result = visitor.onNode(*ptr);
+    switch (result)
+    {
+        case VisitResult::Continue: return NodeStep::Descend;
+        case VisitResult::Skip:     return NodeStep::Prune;
+        case VisitResult::Stop:     return NodeStep::Stop;
+    }
+    return NodeStep::Descend;
+}
+
+// Drives the onEdge callback. Returns true to keep walking, false to stop;
+// *prune is set to true if the edge should be ignored but walking should
+// continue on sibling edges.
+bool visitEdge(const AbstractGraph &graph, EdgeId id, IGraphVisitor &visitor, bool *prune)
+{
+    *prune = false;
+    const IEdge *ptr = resolve(graph, id);
+    if (!ptr)
+    {
+        *prune = true;
+        return true;
+    }
+    const VisitResult result = visitor.onEdge(*ptr);
+    switch (result)
+    {
+        case VisitResult::Continue: return true;
+        case VisitResult::Skip:     *prune = true; return true;
+        case VisitResult::Stop:     return false;
+    }
+    return true;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// traverse — dispatches on the requested mode. The driver for each mode
+// runs against a snapshot of the relevant structural data so that the
+// visitor callbacks run lock-free.
+// ---------------------------------------------------------------------------
+
+Result AbstractGraph::traverse(NodeId startNode, TraverseMode mode, IGraphVisitor &visitor)
+{
+    switch (mode)
+    {
+        case TraverseMode::DepthFirst:
+        {
+            if (!startNode.valid() || !node(startNode))
+            {
+                return Result(Result::Code::Error, "invalid start node");
+            }
+            NodeIdSet           visited;
+            std::vector<NodeId> stack;
+            stack.push_back(startNode);
+            while (!stack.empty())
+            {
+                const NodeId current = stack.back();
+                stack.pop_back();
+                if (!visited.insert(current).second)
+                {
+                    continue;
+                }
+                const NodeStep step = visitNode(*this, current, visitor);
+                if (step == NodeStep::Stop)
+                {
+                    return Result(Result::Code::Error, "traversal stopped");
+                }
+                if (step == NodeStep::Prune)
+                {
+                    continue;
+                }
+                const std::vector<EdgeId> outs = snapshotOutEdges(current);
+                // Reverse-push so that the first outgoing edge is processed
+                // first by the LIFO stack.
+                for (auto it = outs.rbegin(); it != outs.rend(); ++it)
+                {
+                    bool       prune = false;
+                    const bool cont  = visitEdge(*this, *it, visitor, &prune);
+                    if (!cont)
+                    {
+                        return Result(Result::Code::Error, "traversal stopped");
+                    }
+                    if (prune)
+                    {
+                        continue;
+                    }
+                    const IEdge *e = resolve(*this, *it);
+                    if (!e)
+                    {
+                        continue;
+                    }
+                    if (!visited.count(e->to()))
+                    {
+                        stack.push_back(e->to());
+                    }
+                }
+            }
+            return Result();
+        }
+        case TraverseMode::BreadthFirst:
+        {
+            if (!startNode.valid() || !node(startNode))
+            {
+                return Result(Result::Code::Error, "invalid start node");
+            }
+            NodeIdSet          visited;
+            std::deque<NodeId> queue;
+            queue.push_back(startNode);
+            visited.insert(startNode);
+            while (!queue.empty())
+            {
+                const NodeId current = queue.front();
+                queue.pop_front();
+                const NodeStep step = visitNode(*this, current, visitor);
+                if (step == NodeStep::Stop)
+                {
+                    return Result(Result::Code::Error, "traversal stopped");
+                }
+                if (step == NodeStep::Prune)
+                {
+                    continue;
+                }
+                const std::vector<EdgeId> outs = snapshotOutEdges(current);
+                for (EdgeId eid : outs)
+                {
+                    bool       prune = false;
+                    const bool cont  = visitEdge(*this, eid, visitor, &prune);
+                    if (!cont)
+                    {
+                        return Result(Result::Code::Error, "traversal stopped");
+                    }
+                    if (prune)
+                    {
+                        continue;
+                    }
+                    const IEdge *e = resolve(*this, eid);
+                    if (!e)
+                    {
+                        continue;
+                    }
+                    if (visited.insert(e->to()).second)
+                    {
+                        queue.push_back(e->to());
+                    }
+                }
+            }
+            return Result();
+        }
+        case TraverseMode::Topological:
+        case TraverseMode::ReverseTopological:
+        {
+            // Kahn's algorithm. startNode is advisory only — topological
+            // traversal walks every reachable component.
+            (void)startNode;
+
+            const Snapshot snap = buildSnapshot();
+            std::unordered_map<NodeId, std::size_t, NodeIdHasher> indegree;
+            for (const NodeId &nid : snap.nodes)
+            {
+                const auto it = snap.inByKey.find(Snapshot::nodeKey(nid));
+                indegree[nid] = it == snap.inByKey.end() ? 0 : it->second.size();
+            }
+
+            std::deque<NodeId> ready;
+            for (const NodeId &nid : snap.nodes)
+            {
+                if (indegree[nid] == 0)
+                {
+                    ready.push_back(nid);
+                }
+            }
+
+            std::vector<NodeId> order;
+            order.reserve(snap.nodes.size());
+            while (!ready.empty())
+            {
+                const NodeId current = ready.front();
+                ready.pop_front();
+                order.push_back(current);
+                const auto outIt = snap.outByKey.find(Snapshot::nodeKey(current));
+                if (outIt == snap.outByKey.end())
+                {
+                    continue;
+                }
+                for (EdgeId eid : outIt->second)
+                {
+                    const auto endpointsIt = snap.edgeEndpoints.find(Snapshot::edgeKey(eid));
+                    if (endpointsIt == snap.edgeEndpoints.end())
+                    {
+                        continue;
+                    }
+                    const NodeId target = endpointsIt->second.to;
+                    const auto   it     = indegree.find(target);
+                    if (it == indegree.end())
+                    {
+                        continue;
+                    }
+                    if (it->second > 0)
+                    {
+                        --it->second;
+                    }
+                    if (it->second == 0)
+                    {
+                        ready.push_back(target);
+                    }
+                }
+            }
+
+            if (order.size() < snap.nodes.size())
+            {
+                return Result(Result::Code::Error, "cycle detected during topological traversal");
+            }
+
+            if (mode == TraverseMode::ReverseTopological)
+            {
+                std::reverse(order.begin(), order.end());
+            }
+
+            for (const NodeId &nid : order)
+            {
+                const NodeStep step = visitNode(*this, nid, visitor);
+                if (step == NodeStep::Stop)
+                {
+                    return Result(Result::Code::Error, "traversal stopped");
+                }
+                if (step == NodeStep::Prune)
+                {
+                    continue;
+                }
+                const std::vector<EdgeId> outs = snapshotOutEdges(nid);
+                for (EdgeId eid : outs)
+                {
+                    bool       prune = false;
+                    const bool cont  = visitEdge(*this, eid, visitor, &prune);
+                    if (!cont)
+                    {
+                        return Result(Result::Code::Error, "traversal stopped");
+                    }
+                    if (prune)
+                    {
+                        continue;
+                    }
+                }
+            }
+            return Result();
+        }
+        case TraverseMode::Custom:
+        {
+            if (!startNode.valid() || !node(startNode))
+            {
+                return Result(Result::Code::Error, "invalid start node");
+            }
+            NodeIdSet visited;
+            NodeId    current = startNode;
+            while (current.valid())
+            {
+                if (!visited.insert(current).second)
+                {
+                    break;
+                }
+                const NodeStep step = visitNode(*this, current, visitor);
+                if (step == NodeStep::Stop)
+                {
+                    return Result(Result::Code::Error, "traversal stopped");
+                }
+                if (step == NodeStep::Prune)
+                {
+                    break;
+                }
+                const INode *still = resolve(*this, current);
+                if (!still)
+                {
+                    break;
+                }
+                current = visitor.nextForCustom(*still);
+            }
+            return Result();
+        }
+    }
+    return Result(Result::Code::Error, "unknown traverse mode");
+}
+
+} // namespace vigine::graph

--- a/src/graph/factory.cpp
+++ b/src/graph/factory.cpp
@@ -1,0 +1,18 @@
+#include "vigine/graph/factory.h"
+
+#include <memory>
+
+#include "graph/defaultgraph.h"
+
+namespace vigine::graph
+{
+// Factory returns the default adjacency-list implementation behind the
+// pure-virtual IGraph interface. shared_ptr so that several wrappers can
+// share the same substrate when that is the right architectural choice.
+
+std::shared_ptr<IGraph> createGraph()
+{
+    return std::make_shared<DefaultGraph>();
+}
+
+} // namespace vigine::graph

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(${PROJECT_TEST_NAME}
     architecture/ecs/AbstractSystemTest.cpp
     architecture/ecs/AbstractComponentTest.cpp
     architecture/ecs/AbstractEntityTest.cpp
+    graph/smoke_test.cpp
 )
 
 # ====================== Add Include Directories =======================

--- a/test/graph/smoke_test.cpp
+++ b/test/graph/smoke_test.cpp
@@ -1,0 +1,120 @@
+#include "graph/defaultgraph.h"
+#include "vigine/graph/abstractgraph.h"
+#include "vigine/graph/factory.h"
+#include "vigine/graph/igraph.h"
+#include "vigine/graph/igraphvisitor.h"
+#include "vigine/graph/kind.h"
+#include "vigine/graph/traverse_mode.h"
+#include "vigine/graph/visit_result.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace vigine;
+using namespace vigine::graph;
+
+namespace
+{
+class RecordingVisitor final : public IGraphVisitor
+{
+  public:
+    VisitResult onNode(const INode &node) override
+    {
+        visitedNodes.push_back(node.id());
+        return VisitResult::Continue;
+    }
+    VisitResult onEdge(const IEdge &edge) override
+    {
+        visitedEdges.push_back(edge.id());
+        return VisitResult::Continue;
+    }
+
+    std::vector<NodeId> visitedNodes;
+    std::vector<EdgeId> visitedEdges;
+};
+} // namespace
+
+TEST(DefaultGraphSmoke, CreateAndAddNodes)
+{
+    std::shared_ptr<IGraph> graph = createGraph();
+    ASSERT_NE(graph, nullptr);
+
+    const NodeId n1 = graph->addNode(internal::makeNode(kind::Generic));
+    const NodeId n2 = graph->addNode(internal::makeNode(kind::Generic));
+    EXPECT_TRUE(n1.valid());
+    EXPECT_TRUE(n2.valid());
+    EXPECT_EQ(graph->nodeCount(), 2u);
+
+    EXPECT_NE(graph->node(n1), nullptr);
+    EXPECT_EQ(graph->node(n1)->kind(), kind::Generic);
+    EXPECT_EQ(graph->node(n1)->id(), n1);
+}
+
+TEST(DefaultGraphSmoke, AddEdgeAndTraverseDfs)
+{
+    std::shared_ptr<IGraph> graph = createGraph();
+    const NodeId            a     = graph->addNode(internal::makeNode(kind::Generic));
+    const NodeId            b     = graph->addNode(internal::makeNode(kind::Generic));
+    const EdgeId            e     = graph->addEdge(internal::makeEdge(a, b, edge_kind::Generic));
+    EXPECT_TRUE(e.valid());
+    EXPECT_EQ(graph->edgeCount(), 1u);
+
+    RecordingVisitor visitor;
+    const Result     r = graph->traverse(a, TraverseMode::DepthFirst, visitor);
+    EXPECT_TRUE(r.isSuccess());
+    ASSERT_EQ(visitor.visitedNodes.size(), 2u);
+    EXPECT_EQ(visitor.visitedNodes[0], a);
+    EXPECT_EQ(visitor.visitedNodes[1], b);
+}
+
+TEST(DefaultGraphSmoke, RemoveNodeCascadesEdges)
+{
+    std::shared_ptr<IGraph> graph = createGraph();
+    const NodeId            a     = graph->addNode(internal::makeNode(kind::Generic));
+    const NodeId            b     = graph->addNode(internal::makeNode(kind::Generic));
+    const EdgeId            e     = graph->addEdge(internal::makeEdge(a, b, edge_kind::Generic));
+    ASSERT_EQ(graph->edgeCount(), 1u);
+
+    const Result removed = graph->removeNode(a);
+    EXPECT_TRUE(removed.isSuccess());
+    EXPECT_EQ(graph->nodeCount(), 1u);
+    EXPECT_EQ(graph->edgeCount(), 0u);
+    EXPECT_EQ(graph->edge(e), nullptr);
+}
+
+TEST(DefaultGraphSmoke, ExportGraphVizRoundTrip)
+{
+    std::shared_ptr<IGraph> graph = createGraph();
+    const NodeId            a     = graph->addNode(internal::makeNode(kind::Generic));
+    const NodeId            b     = graph->addNode(internal::makeNode(kind::Generic));
+    static_cast<void>(graph->addEdge(internal::makeEdge(a, b, edge_kind::Generic)));
+
+    std::string  dot;
+    const Result r = graph->exportGraphViz(dot);
+    EXPECT_TRUE(r.isSuccess());
+    EXPECT_NE(dot.find("digraph G {"), std::string::npos);
+    EXPECT_NE(dot.find("->"), std::string::npos);
+}
+
+TEST(DefaultGraphSmoke, TopologicalOrderAndCycleDetection)
+{
+    std::shared_ptr<IGraph> graph = createGraph();
+    const NodeId            a     = graph->addNode(internal::makeNode(kind::Generic));
+    const NodeId            b     = graph->addNode(internal::makeNode(kind::Generic));
+    const NodeId            c     = graph->addNode(internal::makeNode(kind::Generic));
+    static_cast<void>(graph->addEdge(internal::makeEdge(a, b, edge_kind::Generic)));
+    static_cast<void>(graph->addEdge(internal::makeEdge(b, c, edge_kind::Generic)));
+
+    const auto order = graph->query().topologicalOrder();
+    ASSERT_TRUE(order.has_value());
+    ASSERT_EQ(order->size(), 3u);
+
+    EXPECT_FALSE(graph->query().hasCycle());
+
+    static_cast<void>(graph->addEdge(internal::makeEdge(c, a, edge_kind::Generic)));
+    EXPECT_TRUE(graph->query().hasCycle());
+    EXPECT_FALSE(graph->query().topologicalOrder().has_value());
+}


### PR DESCRIPTION
## Summary

Implements the concrete graph storage engine behind the pure-virtual `IGraph` family declared in the previous change.

`AbstractGraph` carries the shared state — the generational id machinery, the reader-writer mutex, a monotonic version counter, and the adjacency-list storage keyed by `NodeId` / `EdgeId` slots. `DefaultGraph` is a `final` subclass that closes the inheritance chain; the factory returns a `std::shared_ptr<IGraph>` pointing at a `DefaultGraph`.

Traversal is snapshot-based: the driver captures whichever structural slice it needs under a short shared lock, releases the lock, and then invokes the visitor callbacks lock-free. A re-entrant visitor that calls back into the graph (for example, a bus subscriber that adds a new subscription) cannot deadlock. The five traversal modes ship — depth-first, breadth-first, topological (Kahn), reverse-topological, and custom — alongside the structural queries (`shortestPath`, `connectedComponents`, `hasCycle`, `topologicalOrder`) and a GraphViz DOT export that writes into a caller-supplied string buffer.

Node removal cascades: every incident edge is detached before the node slot is vacated and its generation bumped, so stale `NodeId` values fail safely on lookup instead of aliasing a reused slot. The implementation uses only `std::unique_ptr` for owned resources; there is no raw `new` / `delete` anywhere.

A small smoke suite (`test/graph/smoke_test.cpp`) exercises the happy paths — create, add nodes, add edges, depth-first traversal, cascading removal, DOT export round-trip, and topological-order / cycle detection. The full contract suite lives in a separate change so that it can cover the entire surface without folding the review into this one.

## Test plan

- [ ] `cmake -S . -B build && cmake --build build --target vigine` succeeds in Debug.
- [ ] `cmake --build build --target vigine --config Release` succeeds.
- [ ] `ctest --test-dir build --output-on-failure` passes the five `DefaultGraphSmoke.*` cases.
- [ ] No warnings at the repo's default level (clean locally under clang 18 with `-Wall -Wextra -Wpedantic`; MSVC warnings-clean verified on the repo's CI).
- [ ] `grep -q "class AbstractGraph" include/vigine/graph/abstractgraph.h` and `grep -q "class DefaultGraph final" src/graph/defaultgraph.h` succeed.

Closes #86
