### PR TITLE
test(graph): contract test suite for the IGraph surface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,10 @@ option(ENABLE_EXAMPLE "Build example projects" ON)
 option(ENABLE_UNITTEST "Enable tests" OFF)
 
 if(ENABLE_UNITTEST AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/CMakeLists.txt")
+    # enable_testing() must be called from the top-level CMakeLists.txt so
+    # that ctest picks up tests registered with gtest_discover_tests in the
+    # test subdirectory.
+    enable_testing()
     add_subdirectory(test)
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,11 @@ set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 # ====================== Add Google Test =======================
+# Align GoogleTest's CRT with the rest of the tree so the test
+# executables link against the same runtime as the vigine library
+# (prevents LNK2038 MTd_StaticDebug vs MDd_DynamicDebug mismatches on
+# MSVC).
+set(gtest_force_shared_crt ON CACHE BOOL "Use shared (DLL) CRT for GoogleTest" FORCE)
 add_subdirectory(${CMAKE_SOURCE_DIR}/external/googletest ${CMAKE_BINARY_DIR}/googletest)
 
 # ====================== Create Test Executable =======================
@@ -29,8 +34,8 @@ add_executable(${PROJECT_TEST_NAME}
 )
 
 # ====================== Add Include Directories =======================
-target_include_directories(${PROJECT_TEST_NAME} 
-    PRIVATE 
+target_include_directories(${PROJECT_TEST_NAME}
+    PRIVATE
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -48,5 +53,52 @@ target_link_libraries(${PROJECT_TEST_NAME}
 # ====================== Set Output Directory =======================
 set_target_properties(${PROJECT_TEST_NAME} PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
+# ====================== Graph Contract Test Target =======================
+# The graph contract suite exercises IGraph against the pure-virtual
+# public surface. Its cases are parametrised on a factory callable so
+# that additional concrete IGraph implementations inherit the same
+# coverage by instantiating with another factory.
+set(GRAPH_CONTRACT_TARGET graph-contract)
+
+add_executable(${GRAPH_CONTRACT_TARGET}
+    graph/contract_igraph.cpp
+    graph/contract_inode.cpp
+    graph/contract_iedge.cpp
+    graph/contract_traversal.cpp
+    graph/contract_query.cpp
+    graph/contract_generational_id.cpp
+    graph/contract_hsm_bubble.cpp
+    graph/contract_fanout.cpp
+    graph/contract_async_timeout.cpp
+    graph/contract_result_deferred.cpp
+)
+
+target_include_directories(${GRAPH_CONTRACT_TARGET}
+    PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(${GRAPH_CONTRACT_TARGET}
+    PRIVATE
+    gtest
+    gtest_main
+    vigine
+    ${GLM_LIBRARIES}
+)
+
+set_target_properties(${GRAPH_CONTRACT_TARGET} PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
+# Register the contract suite with CTest, tagged so it can be selected
+# with `ctest -L graph-contract`.
+include(GoogleTest)
+gtest_discover_tests(${GRAPH_CONTRACT_TARGET}
+    PROPERTIES LABELS "graph-contract"
+    DISCOVERY_TIMEOUT 60
+    DISCOVERY_MODE PRE_TEST
 )
 

--- a/test/graph/contract_async_timeout.cpp
+++ b/test/graph/contract_async_timeout.cpp
@@ -1,0 +1,111 @@
+#include "fixtures/graph_fixture_7n10e.h"
+
+#include "vigine/graph/iedge.h"
+#include "vigine/graph/igraph.h"
+#include "vigine/graph/igraphvisitor.h"
+#include "vigine/graph/inode.h"
+#include "vigine/graph/kind.h"
+#include "vigine/graph/nodeid.h"
+#include "vigine/graph/traverse_mode.h"
+#include "vigine/graph/visit_result.h"
+#include "vigine/result.h"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstddef>
+
+// =============================================================================
+// Scenario m — asynchronous timeout fallback.
+//
+// The IMessageBus wrapper schedules an async dispatch with a deadline and
+// falls back to a synchronous notification when the deadline fires. That
+// wrapper lives in a downstream leaf; at the graph level we verify only
+// the contract the substrate must uphold to make that wrapper viable:
+//
+//   * A traversal the visitor aborts through Stop reports
+//     Result::Error with a deterministic message so a wrapper can
+//     interpret it as a cancellation, not a failure of the graph.
+//   * The whole cycle of setup, invocation, and fallback visit completes
+//     in bounded wall time so the wrapper's real timeout never races
+//     against an unbounded traversal.
+//
+// Engine-level async scheduling and the Result::Deferred code are not yet
+// part of the public surface; the graph-level contract below verifies the
+// properties a wrapper would build on.
+// =============================================================================
+
+namespace vigine::graph::contract
+{
+namespace
+{
+
+// Visitor that aborts the walk after N nodes, simulating the fallback
+// path where a wrapper's deadline fires mid-traversal and forces the
+// dispatch to stop.
+class DeadlineVisitor : public IGraphVisitor
+{
+  public:
+    explicit DeadlineVisitor(std::size_t fireAfter) noexcept : _fireAfter(fireAfter) {}
+
+    VisitResult onNode(const INode &) override
+    {
+        ++_visits;
+        if (_visits >= _fireAfter)
+        {
+            _fired = true;
+            return VisitResult::Stop;
+        }
+        return VisitResult::Continue;
+    }
+    VisitResult onEdge(const IEdge &) override { return VisitResult::Continue; }
+
+    [[nodiscard]] bool        fired() const { return _fired; }
+    [[nodiscard]] std::size_t visits() const { return _visits; }
+
+  private:
+    std::size_t _fireAfter;
+    std::size_t _visits{0};
+    bool        _fired{false};
+};
+
+} // namespace
+
+using AsyncTimeoutContract = SevenNodeParamFixture;
+
+TEST_P(AsyncTimeoutContract, StopReportsDeterministicErrorMessage)
+{
+    DeadlineVisitor visitor(/*fireAfter=*/3);
+    const Result    r = fixture.graph->traverse(
+        fixture.nodes[SevenNodeFixture::A], TraverseMode::DepthFirst, visitor);
+
+    // The visitor fired before the traversal could finish on its own.
+    EXPECT_TRUE(visitor.fired());
+    EXPECT_TRUE(r.isError());
+    EXPECT_EQ(r.message(), "traversal stopped");
+}
+
+TEST_P(AsyncTimeoutContract, StopCompletesInBoundedWallTime)
+{
+    // The contract on the substrate is that a Stop walk returns promptly.
+    // A wrapper that layers an async deadline on top depends on this
+    // bound; if the graph ever spun, the wrapper's fallback could race
+    // against a never-ending traversal.
+    DeadlineVisitor visitor(/*fireAfter=*/2);
+
+    const auto   start = std::chrono::steady_clock::now();
+    const Result r     = fixture.graph->traverse(
+        fixture.nodes[SevenNodeFixture::A], TraverseMode::DepthFirst, visitor);
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+
+    EXPECT_TRUE(r.isError());
+    EXPECT_LT(std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count(), 2000)
+        << "Stop should abort the traversal promptly";
+}
+
+INSTANTIATE_TEST_SUITE_P(contract_async_timeout,
+                         AsyncTimeoutContract,
+                         ::testing::Values(defaultGraphFactory()),
+                         GraphFactoryNamer{});
+
+} // namespace vigine::graph::contract

--- a/test/graph/contract_fanout.cpp
+++ b/test/graph/contract_fanout.cpp
@@ -1,0 +1,144 @@
+#include "fixtures/graph_fixture_7n10e.h"
+
+#include "vigine/graph/edgeid.h"
+#include "vigine/graph/iedge.h"
+#include "vigine/graph/igraph.h"
+#include "vigine/graph/igraphquery.h"
+#include "vigine/graph/igraphvisitor.h"
+#include "vigine/graph/inode.h"
+#include "vigine/graph/kind.h"
+#include "vigine/graph/nodeid.h"
+#include "vigine/graph/traverse_mode.h"
+#include "vigine/graph/visit_result.h"
+#include "vigine/result.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstddef>
+#include <unordered_set>
+#include <vector>
+
+// =============================================================================
+// Scenario l — FanOut activation.
+//
+// A FanOut wrapper activates every direct subscriber of a target node and
+// the graph substrate must let the visitor enumerate those subscribers in
+// a single BFS hop, honouring a kind filter. Parallel dispatch of the
+// callbacks is the wrapper's responsibility; at the graph level the
+// contract is that every direct subscriber is reported exactly once and
+// the walk does not descend past one level when the visitor returns Skip
+// at depth one.
+// =============================================================================
+
+namespace vigine::graph::contract
+{
+namespace
+{
+
+struct NodeIdHashPolicy
+{
+    std::size_t operator()(NodeId id) const noexcept
+    {
+        return (static_cast<std::size_t>(id.index) << 32)
+               ^ static_cast<std::size_t>(id.generation);
+    }
+};
+
+// FanOut visitor — visits the seed, then Skip-prunes every depth-1 child
+// so BFS never descends past the first neighbourhood. Counts visits so
+// the test can assert the exact set of subscribers observed.
+class FanOutVisitor : public IGraphVisitor
+{
+  public:
+    explicit FanOutVisitor(NodeId seed) noexcept : _seed(seed) {}
+
+    VisitResult onNode(const INode &node) override
+    {
+        _visited.push_back(node.id());
+        // Prune every depth-1 child so the walk does not recurse into
+        // grandchildren; FanOut is one level deep by definition.
+        return node.id() == _seed ? VisitResult::Continue : VisitResult::Skip;
+    }
+    VisitResult onEdge(const IEdge &) override { return VisitResult::Continue; }
+
+    [[nodiscard]] const std::vector<NodeId> &visited() const { return _visited; }
+
+  private:
+    NodeId              _seed;
+    std::vector<NodeId> _visited;
+};
+
+} // namespace
+
+using FanOutContract = ContractFixture;
+
+TEST_P(FanOutContract, VisitsEveryDirectSubscriberExactlyOnce)
+{
+    auto         graph = makeGraph();
+    const NodeId target = addTestNode(*graph, ContractStateKind);
+
+    // Attach five subscribers — four Attached-kind and one Generic to
+    // confirm the BFS visits every direct child regardless of kind.
+    constexpr std::size_t kSubscribers = 5;
+    std::vector<NodeId>   subs;
+    subs.reserve(kSubscribers);
+    for (std::size_t i = 0; i < kSubscribers; ++i)
+    {
+        const NodeId s = addTestNode(*graph, ContractSubscriberKind);
+        subs.push_back(s);
+        const EdgeKind k = (i + 1 == kSubscribers) ? edge_kind::Generic : ContractAttachedKind;
+        addTestEdge(*graph, target, s, k);
+    }
+
+    FanOutVisitor visitor(target);
+    const Result  r = graph->traverse(target, TraverseMode::BreadthFirst, visitor);
+    EXPECT_TRUE(r.isSuccess());
+
+    // The visitor records the seed plus each direct subscriber exactly
+    // once. Total = kSubscribers + 1.
+    EXPECT_EQ(visitor.visited().size(), kSubscribers + 1);
+
+    std::unordered_set<NodeId, NodeIdHashPolicy> observed(
+        visitor.visited().begin(), visitor.visited().end());
+    EXPECT_EQ(observed.size(), visitor.visited().size());
+    EXPECT_TRUE(observed.count(target));
+    for (NodeId s : subs)
+    {
+        EXPECT_TRUE(observed.count(s)) << "subscriber " << s.index << " not visited";
+    }
+}
+
+TEST_P(FanOutContract, SkipAtDepthOneHaltsDescent)
+{
+    auto         graph  = makeGraph();
+    const NodeId target = addTestNode(*graph, ContractStateKind);
+
+    const NodeId childA     = addTestNode(*graph, ContractSubscriberKind);
+    const NodeId childB     = addTestNode(*graph, ContractSubscriberKind);
+    const NodeId grandchild = addTestNode(*graph, ContractSubscriberKind);
+
+    addTestEdge(*graph, target, childA);
+    addTestEdge(*graph, target, childB);
+    addTestEdge(*graph, childA, grandchild);
+    addTestEdge(*graph, childB, grandchild);
+
+    FanOutVisitor visitor(target);
+    const Result  r = graph->traverse(target, TraverseMode::BreadthFirst, visitor);
+    EXPECT_TRUE(r.isSuccess());
+
+    std::unordered_set<NodeId, NodeIdHashPolicy> observed(
+        visitor.visited().begin(), visitor.visited().end());
+    EXPECT_TRUE(observed.count(target));
+    EXPECT_TRUE(observed.count(childA));
+    EXPECT_TRUE(observed.count(childB));
+    // The grandchild is two hops away and Skip prunes the descent.
+    EXPECT_FALSE(observed.count(grandchild));
+}
+
+INSTANTIATE_TEST_SUITE_P(contract_fanout,
+                         FanOutContract,
+                         ::testing::Values(defaultGraphFactory()),
+                         GraphFactoryNamer{});
+
+} // namespace vigine::graph::contract

--- a/test/graph/contract_generational_id.cpp
+++ b/test/graph/contract_generational_id.cpp
@@ -1,0 +1,167 @@
+#include "fixtures/graph_fixture_7n10e.h"
+
+#include "vigine/graph/edgeid.h"
+#include "vigine/graph/iedge.h"
+#include "vigine/graph/igraph.h"
+#include "vigine/graph/inode.h"
+#include "vigine/graph/nodeid.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstddef>
+#include <unordered_set>
+#include <vector>
+
+// =============================================================================
+// Scenario j — generational identifier safety.
+//
+// Exercises the generational-id contract by running N = 32 rounds of
+// (create + remove + recreate). The suite asserts:
+//
+//   1. No stale NodeId or EdgeId from a removed slot ever resolves to a
+//      live object through IGraph::node or IGraph::edge (no aliasing).
+//   2. The count surfaces (nodeCount / edgeCount) match the number of
+//      currently-live slots after each round.
+//   3. Recreation after removal issues fresh identifiers distinct from
+//      every previously-issued id.
+//
+// Writing the test against the IGraph surface alone means any concrete
+// graph with generational ids (as required by plan_01 / plan_02) passes.
+// =============================================================================
+
+namespace vigine::graph::contract
+{
+namespace
+{
+
+struct NodeIdHashPolicy
+{
+    std::size_t operator()(NodeId id) const noexcept
+    {
+        return (static_cast<std::size_t>(id.index) << 32)
+               ^ static_cast<std::size_t>(id.generation);
+    }
+};
+
+struct EdgeIdHashPolicy
+{
+    std::size_t operator()(EdgeId id) const noexcept
+    {
+        return (static_cast<std::size_t>(id.index) << 32)
+               ^ static_cast<std::size_t>(id.generation);
+    }
+};
+
+} // namespace
+
+using GenerationalIdContract = ContractFixture;
+
+TEST_P(GenerationalIdContract, ThirtyTwoNodeRoundsRetainNoStaleAliases)
+{
+    constexpr std::size_t kRounds = 32;
+    auto                  graph   = makeGraph();
+    std::vector<NodeId>   every;
+    every.reserve(kRounds * 3);
+
+    for (std::size_t round = 0; round < kRounds; ++round)
+    {
+        const NodeId first = addTestNode(*graph);
+        every.push_back(first);
+        ASSERT_TRUE(first.valid());
+        ASSERT_NE(graph->node(first), nullptr);
+
+        ASSERT_TRUE(graph->removeNode(first).isSuccess());
+        EXPECT_EQ(graph->node(first), nullptr);
+
+        const NodeId reborn = addTestNode(*graph);
+        every.push_back(reborn);
+        ASSERT_TRUE(reborn.valid());
+        EXPECT_NE(graph->node(reborn), nullptr);
+        EXPECT_EQ(graph->node(first), nullptr);
+        EXPECT_NE(first, reborn);
+
+        // And once more so index reuse is exercised twice per round.
+        ASSERT_TRUE(graph->removeNode(reborn).isSuccess());
+        EXPECT_EQ(graph->node(reborn), nullptr);
+
+        const NodeId thrice = addTestNode(*graph);
+        every.push_back(thrice);
+        EXPECT_NE(graph->node(thrice), nullptr);
+        EXPECT_EQ(graph->node(first), nullptr);
+        EXPECT_EQ(graph->node(reborn), nullptr);
+    }
+
+    // Live count is whatever remains from the final create in each round.
+    EXPECT_EQ(graph->nodeCount(), kRounds);
+
+    // No two ids returned across every round collide — each id is unique.
+    std::unordered_set<NodeId, NodeIdHashPolicy> uniq(every.begin(), every.end());
+    EXPECT_EQ(uniq.size(), every.size());
+}
+
+TEST_P(GenerationalIdContract, ThirtyTwoEdgeRoundsRetainNoStaleAliases)
+{
+    constexpr std::size_t kRounds = 32;
+    auto                  graph   = makeGraph();
+    const NodeId          a       = addTestNode(*graph);
+    const NodeId          b       = addTestNode(*graph);
+
+    std::vector<EdgeId> every;
+    every.reserve(kRounds * 3);
+
+    for (std::size_t round = 0; round < kRounds; ++round)
+    {
+        const EdgeId first = addTestEdge(*graph, a, b);
+        every.push_back(first);
+        ASSERT_TRUE(first.valid());
+        ASSERT_NE(graph->edge(first), nullptr);
+
+        ASSERT_TRUE(graph->removeEdge(first).isSuccess());
+        EXPECT_EQ(graph->edge(first), nullptr);
+
+        const EdgeId reborn = addTestEdge(*graph, a, b);
+        every.push_back(reborn);
+        EXPECT_NE(graph->edge(reborn), nullptr);
+        EXPECT_EQ(graph->edge(first), nullptr);
+        EXPECT_NE(first, reborn);
+
+        ASSERT_TRUE(graph->removeEdge(reborn).isSuccess());
+        EXPECT_EQ(graph->edge(reborn), nullptr);
+
+        const EdgeId thrice = addTestEdge(*graph, a, b);
+        every.push_back(thrice);
+        EXPECT_NE(graph->edge(thrice), nullptr);
+        EXPECT_EQ(graph->edge(first), nullptr);
+        EXPECT_EQ(graph->edge(reborn), nullptr);
+    }
+
+    EXPECT_EQ(graph->edgeCount(), kRounds);
+    std::unordered_set<EdgeId, EdgeIdHashPolicy> uniq(every.begin(), every.end());
+    EXPECT_EQ(uniq.size(), every.size());
+}
+
+TEST_P(GenerationalIdContract, StaleIdDoesNotSurviveCascadeRemoval)
+{
+    auto         graph = makeGraph();
+    const NodeId a     = addTestNode(*graph);
+    const NodeId b     = addTestNode(*graph);
+    const EdgeId e     = addTestEdge(*graph, a, b);
+
+    ASSERT_TRUE(graph->removeNode(a).isSuccess());
+    EXPECT_EQ(graph->edge(e), nullptr);
+
+    // Recreating a new edge between other live nodes must not revive @p e.
+    const NodeId c = addTestNode(*graph);
+    const NodeId d = addTestNode(*graph);
+    const EdgeId f = addTestEdge(*graph, c, d);
+    EXPECT_NE(f, e);
+    EXPECT_EQ(graph->edge(e), nullptr);
+}
+
+INSTANTIATE_TEST_SUITE_P(contract_generational_id,
+                         GenerationalIdContract,
+                         ::testing::Values(defaultGraphFactory()),
+                         GraphFactoryNamer{});
+
+} // namespace vigine::graph::contract

--- a/test/graph/contract_hsm_bubble.cpp
+++ b/test/graph/contract_hsm_bubble.cpp
@@ -1,0 +1,168 @@
+#include "fixtures/graph_fixture_7n10e.h"
+
+#include "vigine/graph/edgeid.h"
+#include "vigine/graph/iedge.h"
+#include "vigine/graph/igraph.h"
+#include "vigine/graph/igraphquery.h"
+#include "vigine/graph/igraphvisitor.h"
+#include "vigine/graph/inode.h"
+#include "vigine/graph/kind.h"
+#include "vigine/graph/nodeid.h"
+#include "vigine/graph/traverse_mode.h"
+#include "vigine/graph/visit_result.h"
+#include "vigine/result.h"
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+// =============================================================================
+// Scenario k — bubble traversal via ChildOf edges.
+//
+// Stages a four-level chain of "state" nodes linked by ChildOf-kind edges
+// (the child is the source, the parent is the target). The test then uses
+// a Custom-mode traversal that picks the parent via
+// IGraphQuery::outEdgesOfKind as its next-target selector, simulating the
+// bubble-up a state-machine wrapper performs on a message a nested state
+// does not handle.
+//
+// Key properties exercised:
+//   * Arbitrary EdgeKind values (the plan assigns 49 to ChildOf) pass
+//     through the graph unchanged; the query surface filters on them.
+//   * Custom mode follows the chain exactly as the visitor decides.
+//   * VisitResult::Stop returned from onNode short-circuits the walk;
+//     the driver reports the stop through Result::Error with the
+//     "traversal stopped" message.
+// =============================================================================
+
+namespace vigine::graph::contract
+{
+namespace
+{
+
+// Visitor that walks the ChildOf chain upward. It records every visited
+// node and stops the walk when it reaches the "handler" node configured
+// by the test.
+class BubbleVisitor : public IGraphVisitor
+{
+  public:
+    BubbleVisitor(const IGraph &graph, NodeId handler) noexcept
+        : _graph(graph)
+        , _handler(handler)
+    {
+    }
+
+    VisitResult onNode(const INode &node) override
+    {
+        _order.push_back(node.id());
+        return node.id() == _handler ? VisitResult::Stop : VisitResult::Continue;
+    }
+    VisitResult onEdge(const IEdge &) override { return VisitResult::Continue; }
+
+    NodeId nextForCustom(const INode &current) override
+    {
+        // Follow the single ChildOf-kind out-edge (child -> parent).
+        const auto edges = _graph.query().outEdgesOfKind(current.id(), ContractChildOfKind);
+        if (edges.empty())
+        {
+            return NodeId{};
+        }
+        const IEdge *e = _graph.edge(edges.front());
+        return e ? e->to() : NodeId{};
+    }
+
+    [[nodiscard]] const std::vector<NodeId> &order() const { return _order; }
+
+  private:
+    const IGraph       &_graph;
+    NodeId              _handler;
+    std::vector<NodeId> _order;
+};
+
+} // namespace
+
+using BubbleContract = ContractFixture;
+
+TEST_P(BubbleContract, WalksChildToRootViaChildOfEdges)
+{
+    auto graph = makeGraph();
+
+    // Build a four-level chain: leaf -> mid1 -> mid2 -> root.
+    const NodeId leaf = addTestNode(*graph, ContractStateKind);
+    const NodeId mid1 = addTestNode(*graph, ContractStateKind);
+    const NodeId mid2 = addTestNode(*graph, ContractStateKind);
+    const NodeId root = addTestNode(*graph, ContractStateKind);
+
+    addTestEdge(*graph, leaf, mid1, ContractChildOfKind);
+    addTestEdge(*graph, mid1, mid2, ContractChildOfKind);
+    addTestEdge(*graph, mid2, root, ContractChildOfKind);
+
+    // No handler at all — the bubble walks until the parent chain runs
+    // out at the root, then the traversal completes without stopping.
+    BubbleVisitor visitor(*graph, /*handler=*/NodeId{});
+    const Result  r = graph->traverse(leaf, TraverseMode::Custom, visitor);
+    EXPECT_TRUE(r.isSuccess());
+
+    ASSERT_EQ(visitor.order().size(), 4u);
+    EXPECT_EQ(visitor.order()[0], leaf);
+    EXPECT_EQ(visitor.order()[1], mid1);
+    EXPECT_EQ(visitor.order()[2], mid2);
+    EXPECT_EQ(visitor.order()[3], root);
+}
+
+TEST_P(BubbleContract, HandlerNodeStopsTheBubble)
+{
+    auto         graph = makeGraph();
+    const NodeId leaf  = addTestNode(*graph, ContractStateKind);
+    const NodeId mid1  = addTestNode(*graph, ContractStateKind);
+    const NodeId mid2  = addTestNode(*graph, ContractStateKind);
+    const NodeId root  = addTestNode(*graph, ContractStateKind);
+
+    addTestEdge(*graph, leaf, mid1, ContractChildOfKind);
+    addTestEdge(*graph, mid1, mid2, ContractChildOfKind);
+    addTestEdge(*graph, mid2, root, ContractChildOfKind);
+
+    // Handler sits at mid2; bubble stops there, root is not visited.
+    BubbleVisitor visitor(*graph, /*handler=*/mid2);
+    const Result  r = graph->traverse(leaf, TraverseMode::Custom, visitor);
+    EXPECT_TRUE(r.isError());
+    EXPECT_EQ(r.message(), "traversal stopped");
+
+    ASSERT_EQ(visitor.order().size(), 3u);
+    EXPECT_EQ(visitor.order()[0], leaf);
+    EXPECT_EQ(visitor.order()[1], mid1);
+    EXPECT_EQ(visitor.order()[2], mid2);
+    // root never visited because the handler stopped the walk.
+}
+
+TEST_P(BubbleContract, MixedKindsDoNotDisturbTheBubble)
+{
+    auto         graph = makeGraph();
+    const NodeId leaf  = addTestNode(*graph, ContractStateKind);
+    const NodeId mid   = addTestNode(*graph, ContractStateKind);
+    const NodeId root  = addTestNode(*graph, ContractStateKind);
+
+    // Bubble chain.
+    addTestEdge(*graph, leaf, mid, ContractChildOfKind);
+    addTestEdge(*graph, mid, root, ContractChildOfKind);
+
+    // Noise: a Generic-kind edge from leaf to an unrelated sibling node.
+    const NodeId sibling = addTestNode(*graph, ContractSubscriberKind);
+    addTestEdge(*graph, leaf, sibling, edge_kind::Generic);
+
+    BubbleVisitor visitor(*graph, /*handler=*/NodeId{});
+    const Result  r = graph->traverse(leaf, TraverseMode::Custom, visitor);
+    EXPECT_TRUE(r.isSuccess());
+
+    ASSERT_EQ(visitor.order().size(), 3u);
+    EXPECT_EQ(visitor.order()[0], leaf);
+    EXPECT_EQ(visitor.order()[1], mid);
+    EXPECT_EQ(visitor.order()[2], root);
+}
+
+INSTANTIATE_TEST_SUITE_P(contract_hsm_bubble,
+                         BubbleContract,
+                         ::testing::Values(defaultGraphFactory()),
+                         GraphFactoryNamer{});
+
+} // namespace vigine::graph::contract

--- a/test/graph/contract_iedge.cpp
+++ b/test/graph/contract_iedge.cpp
@@ -1,0 +1,125 @@
+#include "fixtures/graph_fixture_7n10e.h"
+
+#include "vigine/graph/edgeid.h"
+#include "vigine/graph/iedge.h"
+#include "vigine/graph/kind.h"
+#include "vigine/graph/nodeid.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+// =============================================================================
+// IEdge contract suite.
+//
+// Focus: from/to/kind stability, payload optionality, behaviour under
+// endpoint removal (edge must vanish cleanly), and the type-level pinning
+// guarantee.
+// =============================================================================
+
+namespace vigine::graph::contract
+{
+
+using EdgeContract = ContractFixture;
+
+TEST_P(EdgeContract, FromAndToReflectConstructionEndpoints)
+{
+    auto         graph = makeGraph();
+    const NodeId a     = addTestNode(*graph);
+    const NodeId b     = addTestNode(*graph);
+    const EdgeId e     = addTestEdge(*graph, a, b);
+    const IEdge *ptr   = graph->edge(e);
+    ASSERT_NE(ptr, nullptr);
+    EXPECT_EQ(ptr->from(), a);
+    EXPECT_EQ(ptr->to(), b);
+}
+
+TEST_P(EdgeContract, KindMatchesConstructionValue)
+{
+    auto         graph = makeGraph();
+    const NodeId a     = addTestNode(*graph);
+    const NodeId b     = addTestNode(*graph);
+    const EdgeId e     = addTestEdge(*graph, a, b, ContractAttachedKind);
+    const IEdge *ptr   = graph->edge(e);
+    ASSERT_NE(ptr, nullptr);
+    EXPECT_EQ(ptr->kind(), ContractAttachedKind);
+}
+
+TEST_P(EdgeContract, DataIsNullWhenNoPayloadProvided)
+{
+    auto         graph = makeGraph();
+    const NodeId a     = addTestNode(*graph);
+    const NodeId b     = addTestNode(*graph);
+    const EdgeId e     = addTestEdge(*graph, a, b);
+    const IEdge *ptr   = graph->edge(e);
+    ASSERT_NE(ptr, nullptr);
+    EXPECT_EQ(ptr->data(), nullptr);
+}
+
+TEST_P(EdgeContract, DataTypeIdIsStableAcrossLookups)
+{
+    auto         graph = makeGraph();
+    const NodeId a     = addTestNode(*graph);
+    const NodeId b     = addTestNode(*graph);
+    auto         data  = std::make_unique<TestEdgeData>(0xBEEFu, 11);
+    const EdgeId e     = addTestEdge(*graph, a, b, edge_kind::Generic, std::move(data));
+
+    const IEdge *first = graph->edge(e);
+    ASSERT_NE(first, nullptr);
+    ASSERT_NE(first->data(), nullptr);
+    const std::uint32_t typeId = first->data()->dataTypeId();
+
+    const IEdge *second = graph->edge(e);
+    ASSERT_NE(second, nullptr);
+    ASSERT_NE(second->data(), nullptr);
+    EXPECT_EQ(second->data()->dataTypeId(), typeId);
+}
+
+TEST_P(EdgeContract, EdgeDisappearsWhenSourceNodeRemoved)
+{
+    auto         graph = makeGraph();
+    const NodeId a     = addTestNode(*graph);
+    const NodeId b     = addTestNode(*graph);
+    const EdgeId e     = addTestEdge(*graph, a, b);
+    ASSERT_NE(graph->edge(e), nullptr);
+
+    EXPECT_TRUE(graph->removeNode(a).isSuccess());
+    EXPECT_EQ(graph->edge(e), nullptr);
+}
+
+TEST_P(EdgeContract, EdgeDisappearsWhenTargetNodeRemoved)
+{
+    auto         graph = makeGraph();
+    const NodeId a     = addTestNode(*graph);
+    const NodeId b     = addTestNode(*graph);
+    const EdgeId e     = addTestEdge(*graph, a, b);
+    ASSERT_NE(graph->edge(e), nullptr);
+
+    EXPECT_TRUE(graph->removeNode(b).isSuccess());
+    EXPECT_EQ(graph->edge(e), nullptr);
+}
+
+TEST_P(EdgeContract, DistinctEdgesBetweenSameEndpointsGetDistinctIds)
+{
+    auto         graph = makeGraph();
+    const NodeId a     = addTestNode(*graph);
+    const NodeId b     = addTestNode(*graph);
+    const EdgeId e1    = addTestEdge(*graph, a, b, edge_kind::Generic);
+    const EdgeId e2    = addTestEdge(*graph, a, b, ContractAttachedKind);
+    EXPECT_NE(e1, e2);
+    EXPECT_NE(graph->edge(e1)->kind(), graph->edge(e2)->kind());
+}
+
+static_assert(!std::is_copy_constructible_v<IEdge>,
+              "IEdge must not be copy-constructible");
+static_assert(!std::is_move_constructible_v<IEdge>,
+              "IEdge must not be move-constructible");
+
+INSTANTIATE_TEST_SUITE_P(contract_iedge,
+                         EdgeContract,
+                         ::testing::Values(defaultGraphFactory()),
+                         GraphFactoryNamer{});
+
+} // namespace vigine::graph::contract

--- a/test/graph/contract_igraph.cpp
+++ b/test/graph/contract_igraph.cpp
@@ -1,0 +1,338 @@
+#include "fixtures/graph_fixture_7n10e.h"
+
+#include "vigine/graph/factory.h"
+#include "vigine/graph/igraph.h"
+#include "vigine/graph/kind.h"
+#include "vigine/graph/nodeid.h"
+#include "vigine/result.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+// =============================================================================
+// IGraph lifecycle contract suite.
+//
+// Exercises the IGraph public surface through a GraphFactory parameter.
+// Every test in this file works against any concrete IGraph that honours
+// the surface declared in include/vigine/graph/; the factory registered
+// at the bottom is the engine's own createGraph, and a second concrete
+// graph wires into the same suite by adding another INSTANTIATE_TEST_SUITE_P.
+// =============================================================================
+
+namespace vigine::graph::contract
+{
+
+using LifecycleContract = ContractFixture;
+
+// -----------------------------------------------------------------------------
+// Node lifecycle.
+// -----------------------------------------------------------------------------
+
+TEST_P(LifecycleContract, AddNodeReturnsValidGenerationalId)
+{
+    auto         graph = makeGraph();
+    const NodeId a     = addTestNode(*graph, kind::Generic);
+    EXPECT_TRUE(a.valid());
+    EXPECT_NE(a.generation, 0u);
+    EXPECT_EQ(graph->nodeCount(), 1u);
+}
+
+TEST_P(LifecycleContract, AddNodeReturnsDistinctIdentifiers)
+{
+    auto         graph = makeGraph();
+    const NodeId a     = addTestNode(*graph);
+    const NodeId b     = addTestNode(*graph);
+    const NodeId c     = addTestNode(*graph);
+    EXPECT_NE(a, b);
+    EXPECT_NE(b, c);
+    EXPECT_NE(a, c);
+    EXPECT_EQ(graph->nodeCount(), 3u);
+}
+
+TEST_P(LifecycleContract, NodeLookupReturnsPointerAfterInsert)
+{
+    auto         graph = makeGraph();
+    const NodeId a     = addTestNode(*graph, kind::Generic);
+    const INode *ptr   = graph->node(a);
+    ASSERT_NE(ptr, nullptr);
+    EXPECT_EQ(ptr->id(), a);
+    EXPECT_EQ(ptr->kind(), kind::Generic);
+}
+
+TEST_P(LifecycleContract, NodeLookupReturnsNullForInvalidId)
+{
+    auto graph = makeGraph();
+    EXPECT_EQ(graph->node(NodeId{}), nullptr);
+    // Concoct an identifier that was never issued.
+    EXPECT_EQ(graph->node(NodeId{999, 1}), nullptr);
+}
+
+TEST_P(LifecycleContract, RemoveNodeInvalidatesLookup)
+{
+    auto         graph = makeGraph();
+    const NodeId a     = addTestNode(*graph);
+    const Result r     = graph->removeNode(a);
+    EXPECT_TRUE(r.isSuccess());
+    EXPECT_EQ(graph->node(a), nullptr);
+    EXPECT_EQ(graph->nodeCount(), 0u);
+}
+
+TEST_P(LifecycleContract, RemoveNodeReportsErrorForStaleId)
+{
+    auto         graph = makeGraph();
+    const NodeId a     = addTestNode(*graph);
+    EXPECT_TRUE(graph->removeNode(a).isSuccess());
+    const Result again = graph->removeNode(a);
+    EXPECT_TRUE(again.isError());
+}
+
+TEST_P(LifecycleContract, RemoveNodeWithInvalidIdReportsError)
+{
+    auto         graph = makeGraph();
+    const Result r     = graph->removeNode(NodeId{});
+    EXPECT_TRUE(r.isError());
+}
+
+// -----------------------------------------------------------------------------
+// Edge lifecycle.
+// -----------------------------------------------------------------------------
+
+TEST_P(LifecycleContract, AddEdgeReturnsValidGenerationalId)
+{
+    auto         graph = makeGraph();
+    const NodeId a     = addTestNode(*graph);
+    const NodeId b     = addTestNode(*graph);
+    const EdgeId e     = addTestEdge(*graph, a, b);
+    EXPECT_TRUE(e.valid());
+    EXPECT_EQ(graph->edgeCount(), 1u);
+}
+
+TEST_P(LifecycleContract, AddEdgeStoresEndpointsAndKind)
+{
+    auto         graph = makeGraph();
+    const NodeId a     = addTestNode(*graph);
+    const NodeId b     = addTestNode(*graph);
+    const EdgeId e     = addTestEdge(*graph, a, b, edge_kind::Generic);
+    const IEdge *ptr   = graph->edge(e);
+    ASSERT_NE(ptr, nullptr);
+    EXPECT_EQ(ptr->id(), e);
+    EXPECT_EQ(ptr->from(), a);
+    EXPECT_EQ(ptr->to(), b);
+    EXPECT_EQ(ptr->kind(), edge_kind::Generic);
+}
+
+TEST_P(LifecycleContract, AddEdgeAcceptsArbitraryUserKinds)
+{
+    auto         graph = makeGraph();
+    const NodeId a     = addTestNode(*graph);
+    const NodeId b     = addTestNode(*graph);
+    const EdgeId e     = addTestEdge(*graph, a, b, ContractChildOfKind);
+    const IEdge *ptr   = graph->edge(e);
+    ASSERT_NE(ptr, nullptr);
+    EXPECT_EQ(ptr->kind(), ContractChildOfKind);
+}
+
+TEST_P(LifecycleContract, AddEdgeCarriesPayloadRoundTrip)
+{
+    auto         graph   = makeGraph();
+    const NodeId a       = addTestNode(*graph);
+    const NodeId b       = addTestNode(*graph);
+    auto         payload = std::make_unique<TestEdgeData>(0xCAFEu, 7);
+    const EdgeId e       = addTestEdge(*graph, a, b, edge_kind::Generic, std::move(payload));
+
+    const IEdge *ptr = graph->edge(e);
+    ASSERT_NE(ptr, nullptr);
+    const IEdgeData *data = ptr->data();
+    ASSERT_NE(data, nullptr);
+    EXPECT_EQ(data->dataTypeId(), 0xCAFEu);
+    const auto *typed = static_cast<const TestEdgeData *>(data);
+    EXPECT_EQ(typed->tag(), 7);
+}
+
+TEST_P(LifecycleContract, AddEdgeRejectsStaleEndpoints)
+{
+    auto         graph = makeGraph();
+    const NodeId a     = addTestNode(*graph);
+    const NodeId b     = addTestNode(*graph);
+    EXPECT_TRUE(graph->removeNode(b).isSuccess());
+    const EdgeId e = addTestEdge(*graph, a, b);
+    EXPECT_FALSE(e.valid());
+    EXPECT_EQ(graph->edgeCount(), 0u);
+}
+
+TEST_P(LifecycleContract, EdgeLookupReturnsNullForInvalidId)
+{
+    auto graph = makeGraph();
+    EXPECT_EQ(graph->edge(EdgeId{}), nullptr);
+    EXPECT_EQ(graph->edge(EdgeId{999, 1}), nullptr);
+}
+
+TEST_P(LifecycleContract, RemoveEdgeInvalidatesLookup)
+{
+    auto         graph = makeGraph();
+    const NodeId a     = addTestNode(*graph);
+    const NodeId b     = addTestNode(*graph);
+    const EdgeId e     = addTestEdge(*graph, a, b);
+    EXPECT_TRUE(graph->removeEdge(e).isSuccess());
+    EXPECT_EQ(graph->edge(e), nullptr);
+    EXPECT_EQ(graph->edgeCount(), 0u);
+}
+
+TEST_P(LifecycleContract, RemoveEdgeReportsErrorForStaleId)
+{
+    auto         graph = makeGraph();
+    const NodeId a     = addTestNode(*graph);
+    const NodeId b     = addTestNode(*graph);
+    const EdgeId e     = addTestEdge(*graph, a, b);
+    EXPECT_TRUE(graph->removeEdge(e).isSuccess());
+    EXPECT_TRUE(graph->removeEdge(e).isError());
+}
+
+TEST_P(LifecycleContract, RemoveNodeCascadesIncidentEdges)
+{
+    auto         graph = makeGraph();
+    const NodeId a     = addTestNode(*graph);
+    const NodeId b     = addTestNode(*graph);
+    const NodeId c     = addTestNode(*graph);
+    const EdgeId ab    = addTestEdge(*graph, a, b);
+    const EdgeId ac    = addTestEdge(*graph, a, c);
+    const EdgeId bc    = addTestEdge(*graph, b, c);
+    ASSERT_EQ(graph->edgeCount(), 3u);
+
+    const Result r = graph->removeNode(b);
+    EXPECT_TRUE(r.isSuccess());
+    EXPECT_EQ(graph->edge(ab), nullptr); // b was the target
+    EXPECT_EQ(graph->edge(bc), nullptr); // b was the source
+    EXPECT_NE(graph->edge(ac), nullptr); // untouched
+    EXPECT_EQ(graph->edgeCount(), 1u);
+    EXPECT_EQ(graph->nodeCount(), 2u);
+}
+
+// -----------------------------------------------------------------------------
+// Generational id safety — a removed slot's id must not alias a later one.
+// -----------------------------------------------------------------------------
+
+TEST_P(LifecycleContract, StaleNodeIdDoesNotAliasReusedSlot)
+{
+    auto         graph   = makeGraph();
+    const NodeId firstId = addTestNode(*graph);
+    ASSERT_TRUE(graph->removeNode(firstId).isSuccess());
+    const NodeId secondId = addTestNode(*graph);
+    // Even if the underlying slot index is reused, the stale first id
+    // never resolves to the new slot.
+    EXPECT_EQ(graph->node(firstId), nullptr);
+    const INode *alive = graph->node(secondId);
+    ASSERT_NE(alive, nullptr);
+    EXPECT_NE(alive->id(), firstId);
+}
+
+TEST_P(LifecycleContract, StaleEdgeIdDoesNotAliasReusedSlot)
+{
+    auto         graph = makeGraph();
+    const NodeId a     = addTestNode(*graph);
+    const NodeId b     = addTestNode(*graph);
+    const EdgeId first = addTestEdge(*graph, a, b);
+    ASSERT_TRUE(graph->removeEdge(first).isSuccess());
+    const EdgeId second = addTestEdge(*graph, a, b);
+    EXPECT_EQ(graph->edge(first), nullptr);
+    const IEdge *alive = graph->edge(second);
+    ASSERT_NE(alive, nullptr);
+    EXPECT_NE(alive->id(), first);
+}
+
+// -----------------------------------------------------------------------------
+// Observability.
+// -----------------------------------------------------------------------------
+
+TEST_P(LifecycleContract, EmptyGraphReportsZeroCounts)
+{
+    auto graph = makeGraph();
+    EXPECT_EQ(graph->nodeCount(), 0u);
+    EXPECT_EQ(graph->edgeCount(), 0u);
+}
+
+TEST_P(LifecycleContract, CountsTrackMutationsExactly)
+{
+    auto         graph = makeGraph();
+    const NodeId a     = addTestNode(*graph);
+    const NodeId b     = addTestNode(*graph);
+    const NodeId c     = addTestNode(*graph);
+    const EdgeId ab    = addTestEdge(*graph, a, b);
+    const EdgeId bc    = addTestEdge(*graph, b, c);
+    EXPECT_EQ(graph->nodeCount(), 3u);
+    EXPECT_EQ(graph->edgeCount(), 2u);
+
+    EXPECT_TRUE(graph->removeEdge(ab).isSuccess());
+    EXPECT_EQ(graph->edgeCount(), 1u);
+
+    EXPECT_TRUE(graph->removeNode(a).isSuccess());
+    EXPECT_EQ(graph->nodeCount(), 2u);
+    EXPECT_EQ(graph->edgeCount(), 1u);
+
+    EXPECT_TRUE(graph->removeNode(c).isSuccess());
+    EXPECT_EQ(graph->nodeCount(), 1u);
+    EXPECT_EQ(graph->edgeCount(), 0u);
+
+    static_cast<void>(bc);
+}
+
+// -----------------------------------------------------------------------------
+// DOT export round-trip.
+// -----------------------------------------------------------------------------
+
+TEST_P(LifecycleContract, ExportGraphVizEmitsDigraphWrapper)
+{
+    auto graph = makeGraph();
+    std::string dot;
+    const Result r = graph->exportGraphViz(dot);
+    EXPECT_TRUE(r.isSuccess());
+    EXPECT_NE(dot.find("digraph"), std::string::npos);
+    EXPECT_NE(dot.find("{"), std::string::npos);
+    EXPECT_NE(dot.find("}"), std::string::npos);
+}
+
+TEST_P(LifecycleContract, ExportGraphVizContainsArrowsForEachEdge)
+{
+    auto         graph = makeGraph();
+    const NodeId a     = addTestNode(*graph);
+    const NodeId b     = addTestNode(*graph);
+    const NodeId c     = addTestNode(*graph);
+    static_cast<void>(addTestEdge(*graph, a, b));
+    static_cast<void>(addTestEdge(*graph, b, c));
+
+    std::string dot;
+    ASSERT_TRUE(graph->exportGraphViz(dot).isSuccess());
+
+    std::size_t count = 0;
+    std::size_t pos   = 0;
+    while ((pos = dot.find("->", pos)) != std::string::npos)
+    {
+        ++count;
+        pos += 2;
+    }
+    EXPECT_EQ(count, 2u);
+}
+
+TEST_P(LifecycleContract, ExportGraphVizOverwritesExistingBuffer)
+{
+    auto        graph = makeGraph();
+    std::string dot   = "residual content that must be dropped";
+    EXPECT_TRUE(graph->exportGraphViz(dot).isSuccess());
+    EXPECT_EQ(dot.find("residual"), std::string::npos);
+    EXPECT_NE(dot.find("digraph"), std::string::npos);
+}
+
+// -----------------------------------------------------------------------------
+// Factory registration. The single instantiation wires the suite up against
+// the engine's createGraph(); a second concrete IGraph plugs in by adding
+// another INSTANTIATE_TEST_SUITE_P block referencing the same LifecycleContract.
+// -----------------------------------------------------------------------------
+
+INSTANTIATE_TEST_SUITE_P(contract_igraph,
+                         LifecycleContract,
+                         ::testing::Values(defaultGraphFactory()),
+                         GraphFactoryNamer{});
+
+} // namespace vigine::graph::contract

--- a/test/graph/contract_inode.cpp
+++ b/test/graph/contract_inode.cpp
@@ -1,0 +1,88 @@
+#include "fixtures/graph_fixture_7n10e.h"
+
+#include "vigine/graph/inode.h"
+#include "vigine/graph/kind.h"
+#include "vigine/graph/nodeid.h"
+
+#include <gtest/gtest.h>
+
+#include <type_traits>
+
+// =============================================================================
+// INode contract suite.
+//
+// Focus: id() / kind() stability once a concrete INode is owned by an
+// IGraph, plus the type-level pinning guarantee (copy / move deleted).
+// =============================================================================
+
+namespace vigine::graph::contract
+{
+
+using NodeContract = ContractFixture;
+
+TEST_P(NodeContract, KindMatchesConstructionValue)
+{
+    auto         graph = makeGraph();
+    const NodeId a     = addTestNode(*graph, kind::Generic);
+    const INode *ptr   = graph->node(a);
+    ASSERT_NE(ptr, nullptr);
+    EXPECT_EQ(ptr->kind(), kind::Generic);
+}
+
+TEST_P(NodeContract, KindIsImmutableAcrossLookups)
+{
+    auto         graph = makeGraph();
+    const NodeId a     = addTestNode(*graph, ContractStateKind);
+    const INode *first = graph->node(a);
+    ASSERT_NE(first, nullptr);
+    const NodeKind k = first->kind();
+
+    // Look up again; kind must not have shifted.
+    const INode *second = graph->node(a);
+    ASSERT_NE(second, nullptr);
+    EXPECT_EQ(second->kind(), k);
+}
+
+TEST_P(NodeContract, IdMatchesAssignedValueAfterAddNode)
+{
+    auto         graph = makeGraph();
+    const NodeId a     = addTestNode(*graph, kind::Generic);
+    const INode *ptr   = graph->node(a);
+    ASSERT_NE(ptr, nullptr);
+    EXPECT_EQ(ptr->id(), a);
+}
+
+TEST_P(NodeContract, KindSurvivesOtherNodesMutations)
+{
+    auto         graph = makeGraph();
+    const NodeId a     = addTestNode(*graph, ContractSubscriberKind);
+    const NodeId b     = addTestNode(*graph, kind::Generic);
+    const NodeId c     = addTestNode(*graph, ContractStateKind);
+
+    static_cast<void>(b);
+    EXPECT_TRUE(graph->removeNode(c).isSuccess());
+
+    const INode *ptr = graph->node(a);
+    ASSERT_NE(ptr, nullptr);
+    EXPECT_EQ(ptr->kind(), ContractSubscriberKind);
+    EXPECT_EQ(ptr->id(), a);
+}
+
+// INode is pinned at the type level: copy and move operations are deleted.
+// The concrete TestNode used by the suite inherits that pinning, which the
+// compile-time traits below verify.
+static_assert(!std::is_copy_constructible_v<INode>,
+              "INode must not be copy-constructible");
+static_assert(!std::is_copy_assignable_v<INode>,
+              "INode must not be copy-assignable");
+static_assert(!std::is_move_constructible_v<INode>,
+              "INode must not be move-constructible");
+static_assert(!std::is_move_assignable_v<INode>,
+              "INode must not be move-assignable");
+
+INSTANTIATE_TEST_SUITE_P(contract_inode,
+                         NodeContract,
+                         ::testing::Values(defaultGraphFactory()),
+                         GraphFactoryNamer{});
+
+} // namespace vigine::graph::contract

--- a/test/graph/contract_query.cpp
+++ b/test/graph/contract_query.cpp
@@ -1,0 +1,302 @@
+#include "fixtures/graph_fixture_7n10e.h"
+
+#include "vigine/graph/edgeid.h"
+#include "vigine/graph/iedge.h"
+#include "vigine/graph/igraph.h"
+#include "vigine/graph/igraphquery.h"
+#include "vigine/graph/inode.h"
+#include "vigine/graph/kind.h"
+#include "vigine/graph/nodeid.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <unordered_set>
+#include <vector>
+
+// =============================================================================
+// IGraphQuery contract suite — hasNode / hasEdge, directed neighbourhood,
+// kind-filtered neighbourhood, shortest path via BFS, connected components
+// (undirected), hasCycle, topologicalOrder.
+// =============================================================================
+
+namespace vigine::graph::contract
+{
+namespace
+{
+
+struct NodeIdHashPolicy
+{
+    std::size_t operator()(NodeId id) const noexcept
+    {
+        return (static_cast<std::size_t>(id.index) << 32)
+               ^ static_cast<std::size_t>(id.generation);
+    }
+};
+
+bool pathRespectsEdges(const std::vector<NodeId> &path, const IGraph &graph)
+{
+    if (path.empty())
+    {
+        return false;
+    }
+    for (std::size_t i = 0; i + 1 < path.size(); ++i)
+    {
+        const std::vector<EdgeId> outs = graph.query().outEdges(path[i]);
+        bool                      found = false;
+        for (EdgeId eid : outs)
+        {
+            const IEdge *e = graph.edge(eid);
+            if (e && e->to() == path[i + 1])
+            {
+                found = true;
+                break;
+            }
+        }
+        if (!found)
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+} // namespace
+
+using QueryContract = SevenNodeParamFixture;
+
+// -----------------------------------------------------------------------------
+// hasNode / hasEdge.
+// -----------------------------------------------------------------------------
+
+TEST_P(QueryContract, HasNodeAgreesWithLifecycle)
+{
+    const IGraphQuery &q = fixture.graph->query();
+    for (NodeId id : fixture.nodes)
+    {
+        EXPECT_TRUE(q.hasNode(id));
+    }
+    EXPECT_FALSE(q.hasNode(NodeId{}));
+    EXPECT_FALSE(q.hasNode(NodeId{999, 1}));
+
+    // Remove one node and re-check.
+    const NodeId removed = fixture.nodes[SevenNodeFixture::A];
+    ASSERT_TRUE(fixture.graph->removeNode(removed).isSuccess());
+    EXPECT_FALSE(q.hasNode(removed));
+}
+
+TEST_P(QueryContract, HasEdgeAgreesWithLifecycle)
+{
+    const IGraphQuery &q = fixture.graph->query();
+    for (EdgeId id : fixture.edges)
+    {
+        EXPECT_TRUE(q.hasEdge(id));
+    }
+    EXPECT_FALSE(q.hasEdge(EdgeId{}));
+    EXPECT_FALSE(q.hasEdge(EdgeId{999, 1}));
+}
+
+// -----------------------------------------------------------------------------
+// outEdges / inEdges — degree matches the fixture.
+// -----------------------------------------------------------------------------
+
+TEST_P(QueryContract, OutEdgesDegreeMatchesFixture)
+{
+    const IGraphQuery &q = fixture.graph->query();
+    // Fixture out-degrees: A=2, B=2, C=2, D=1, E=2, F=1, G=0.
+    EXPECT_EQ(q.outEdges(fixture.nodes[SevenNodeFixture::A]).size(), 2u);
+    EXPECT_EQ(q.outEdges(fixture.nodes[SevenNodeFixture::B]).size(), 2u);
+    EXPECT_EQ(q.outEdges(fixture.nodes[SevenNodeFixture::C]).size(), 2u);
+    EXPECT_EQ(q.outEdges(fixture.nodes[SevenNodeFixture::D]).size(), 1u);
+    EXPECT_EQ(q.outEdges(fixture.nodes[SevenNodeFixture::E]).size(), 2u);
+    EXPECT_EQ(q.outEdges(fixture.nodes[SevenNodeFixture::F]).size(), 1u);
+    EXPECT_EQ(q.outEdges(fixture.nodes[SevenNodeFixture::G]).size(), 0u);
+}
+
+TEST_P(QueryContract, InEdgesDegreeMatchesFixture)
+{
+    const IGraphQuery &q = fixture.graph->query();
+    // Fixture in-degrees: A=0, B=1, C=1, D=2, E=2, F=2, G=2.
+    EXPECT_EQ(q.inEdges(fixture.nodes[SevenNodeFixture::A]).size(), 0u);
+    EXPECT_EQ(q.inEdges(fixture.nodes[SevenNodeFixture::B]).size(), 1u);
+    EXPECT_EQ(q.inEdges(fixture.nodes[SevenNodeFixture::C]).size(), 1u);
+    EXPECT_EQ(q.inEdges(fixture.nodes[SevenNodeFixture::D]).size(), 2u);
+    EXPECT_EQ(q.inEdges(fixture.nodes[SevenNodeFixture::E]).size(), 2u);
+    EXPECT_EQ(q.inEdges(fixture.nodes[SevenNodeFixture::F]).size(), 2u);
+    EXPECT_EQ(q.inEdges(fixture.nodes[SevenNodeFixture::G]).size(), 2u);
+}
+
+TEST_P(QueryContract, OutEdgesEmptyForStaleIdentifier)
+{
+    const IGraphQuery &q = fixture.graph->query();
+    EXPECT_TRUE(q.outEdges(NodeId{999, 7}).empty());
+    EXPECT_TRUE(q.inEdges(NodeId{999, 7}).empty());
+}
+
+// -----------------------------------------------------------------------------
+// outEdgesOfKind / inEdgesOfKind — kind filter works.
+// -----------------------------------------------------------------------------
+
+TEST_P(QueryContract, OutEdgesOfKindFiltersByKind)
+{
+    // Attach a ChildOf-kind edge from A to G — distinct from the Generic
+    // edges already in the fixture.
+    const EdgeId special = addTestEdge(
+        *fixture.graph,
+        fixture.nodes[SevenNodeFixture::A],
+        fixture.nodes[SevenNodeFixture::G],
+        ContractChildOfKind);
+    const IGraphQuery &q = fixture.graph->query();
+
+    const auto filtered = q.outEdgesOfKind(
+        fixture.nodes[SevenNodeFixture::A], ContractChildOfKind);
+    EXPECT_EQ(filtered.size(), 1u);
+    EXPECT_EQ(filtered.front(), special);
+
+    // Generic kind still matches the two Generic edges leaving A.
+    const auto generic = q.outEdgesOfKind(
+        fixture.nodes[SevenNodeFixture::A], edge_kind::Generic);
+    EXPECT_EQ(generic.size(), 2u);
+}
+
+TEST_P(QueryContract, InEdgesOfKindFiltersByKind)
+{
+    const EdgeId special = addTestEdge(
+        *fixture.graph,
+        fixture.nodes[SevenNodeFixture::A],
+        fixture.nodes[SevenNodeFixture::G],
+        ContractChildOfKind);
+    const IGraphQuery &q = fixture.graph->query();
+
+    const auto filtered = q.inEdgesOfKind(
+        fixture.nodes[SevenNodeFixture::G], ContractChildOfKind);
+    EXPECT_EQ(filtered.size(), 1u);
+    EXPECT_EQ(filtered.front(), special);
+}
+
+// -----------------------------------------------------------------------------
+// shortestPath — unweighted BFS; trivial case; no path returns nullopt.
+// -----------------------------------------------------------------------------
+
+TEST_P(QueryContract, ShortestPathFromNodeToItselfIsSingleton)
+{
+    const IGraphQuery &q    = fixture.graph->query();
+    const auto         path = q.shortestPath(
+        fixture.nodes[SevenNodeFixture::A], fixture.nodes[SevenNodeFixture::A]);
+    ASSERT_TRUE(path.has_value());
+    ASSERT_EQ(path->size(), 1u);
+    EXPECT_EQ(path->front(), fixture.nodes[SevenNodeFixture::A]);
+}
+
+TEST_P(QueryContract, ShortestPathFollowsReachableEdges)
+{
+    const IGraphQuery &q    = fixture.graph->query();
+    const auto         path = q.shortestPath(
+        fixture.nodes[SevenNodeFixture::A], fixture.nodes[SevenNodeFixture::G]);
+    ASSERT_TRUE(path.has_value());
+    ASSERT_GE(path->size(), 2u);
+    EXPECT_EQ(path->front(), fixture.nodes[SevenNodeFixture::A]);
+    EXPECT_EQ(path->back(), fixture.nodes[SevenNodeFixture::G]);
+    EXPECT_TRUE(pathRespectsEdges(*path, *fixture.graph));
+
+    // In this fixture the shortest path from A to G traverses three edges
+    // (A -> B -> E -> G or A -> C -> E -> G), so path size is 4.
+    EXPECT_EQ(path->size(), 4u);
+}
+
+TEST_P(QueryContract, ShortestPathAbsentForUnreachableTarget)
+{
+    // Insert an orphan node with no incoming edges from the fixture.
+    const NodeId      orphan = addTestNode(*fixture.graph);
+    const IGraphQuery &q      = fixture.graph->query();
+    const auto         path   = q.shortestPath(
+        fixture.nodes[SevenNodeFixture::A], orphan);
+    EXPECT_FALSE(path.has_value());
+}
+
+TEST_P(QueryContract, ShortestPathAbsentForStaleEndpoint)
+{
+    const IGraphQuery &q    = fixture.graph->query();
+    const auto         path = q.shortestPath(
+        fixture.nodes[SevenNodeFixture::A], NodeId{999, 9});
+    EXPECT_FALSE(path.has_value());
+}
+
+// -----------------------------------------------------------------------------
+// connectedComponents — the fixture is one connected shape (undirected);
+// adding an orphan splits it into two components.
+// -----------------------------------------------------------------------------
+
+TEST_P(QueryContract, ConnectedComponentsCoversEverySevenFixtureNode)
+{
+    const IGraphQuery &q    = fixture.graph->query();
+    const auto         comps = q.connectedComponents();
+    ASSERT_EQ(comps.size(), 1u);
+    EXPECT_EQ(comps.front().size(), 7u);
+}
+
+TEST_P(QueryContract, ConnectedComponentsSeparatesOrphan)
+{
+    addTestNode(*fixture.graph);
+    const IGraphQuery &q    = fixture.graph->query();
+    const auto         comps = q.connectedComponents();
+    EXPECT_EQ(comps.size(), 2u);
+
+    std::size_t total = 0;
+    for (const auto &c : comps)
+    {
+        total += c.size();
+    }
+    EXPECT_EQ(total, 8u);
+}
+
+// -----------------------------------------------------------------------------
+// hasCycle / topologicalOrder.
+// -----------------------------------------------------------------------------
+
+TEST_P(QueryContract, AcyclicFixtureReportsNoCycle)
+{
+    EXPECT_FALSE(fixture.graph->query().hasCycle());
+}
+
+TEST_P(QueryContract, BackEdgeMakesCycleDetected)
+{
+    addTestEdge(*fixture.graph,
+                fixture.nodes[SevenNodeFixture::G],
+                fixture.nodes[SevenNodeFixture::A]);
+    EXPECT_TRUE(fixture.graph->query().hasCycle());
+}
+
+TEST_P(QueryContract, TopologicalOrderRespectsEveryEdgeInFixture)
+{
+    const auto order = fixture.graph->query().topologicalOrder();
+    ASSERT_TRUE(order.has_value());
+    EXPECT_EQ(order->size(), 7u);
+
+    auto position = [&order](NodeId id) -> std::ptrdiff_t {
+        const auto it = std::find(order->begin(), order->end(), id);
+        return it - order->begin();
+    };
+
+    for (EdgeId eid : fixture.edges)
+    {
+        const IEdge *e = fixture.graph->edge(eid);
+        ASSERT_NE(e, nullptr);
+        EXPECT_LT(position(e->from()), position(e->to()));
+    }
+}
+
+TEST_P(QueryContract, TopologicalOrderAbsentOnCycle)
+{
+    addTestEdge(*fixture.graph,
+                fixture.nodes[SevenNodeFixture::G],
+                fixture.nodes[SevenNodeFixture::A]);
+    EXPECT_FALSE(fixture.graph->query().topologicalOrder().has_value());
+}
+
+INSTANTIATE_TEST_SUITE_P(contract_query,
+                         QueryContract,
+                         ::testing::Values(defaultGraphFactory()),
+                         GraphFactoryNamer{});
+
+} // namespace vigine::graph::contract

--- a/test/graph/contract_result_deferred.cpp
+++ b/test/graph/contract_result_deferred.cpp
@@ -1,0 +1,144 @@
+#include "fixtures/graph_fixture_7n10e.h"
+
+#include "vigine/graph/iedge.h"
+#include "vigine/graph/igraph.h"
+#include "vigine/graph/igraphvisitor.h"
+#include "vigine/graph/inode.h"
+#include "vigine/graph/nodeid.h"
+#include "vigine/graph/traverse_mode.h"
+#include "vigine/graph/visit_result.h"
+#include "vigine/result.h"
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <unordered_set>
+#include <vector>
+
+// =============================================================================
+// Scenario n — Result::Deferred round-trip.
+//
+// The planner pinned a scenario where a wrapper emits Result::Deferred
+// from a synchronous path and later satisfies the deferred outcome when
+// an asynchronous signal arrives. The core engine's Result type carries
+// only two codes (Success / Error), so "deferred" is not yet part of
+// the public surface; a wrapper-level code will cover that contract once
+// it lands.
+//
+// At the graph-substrate level the contract reduces to: a visitor that
+// chooses to defer processing of a node (signalled via Skip plus an
+// external queue the visitor owns) sees the graph continue walking, and
+// a follow-up traversal over the deferred set completes successfully.
+// Both halves together model the sync-skip-then-async-complete pattern
+// a wrapper needs.
+// =============================================================================
+
+namespace vigine::graph::contract
+{
+namespace
+{
+
+struct NodeIdHashPolicy
+{
+    std::size_t operator()(NodeId id) const noexcept
+    {
+        return (static_cast<std::size_t>(id.index) << 32)
+               ^ static_cast<std::size_t>(id.generation);
+    }
+};
+
+// Visitor that defers (Skip) every other node and records the deferred
+// set. The caller then "fires the signal" by feeding the deferred nodes
+// into a second traversal.
+class DeferringVisitor : public IGraphVisitor
+{
+  public:
+    VisitResult onNode(const INode &node) override
+    {
+        _seen.push_back(node.id());
+        ++_counter;
+        if (_counter % 2 == 0)
+        {
+            _deferred.push_back(node.id());
+            return VisitResult::Skip;
+        }
+        return VisitResult::Continue;
+    }
+    VisitResult onEdge(const IEdge &) override { return VisitResult::Continue; }
+
+    [[nodiscard]] const std::vector<NodeId> &seen() const { return _seen; }
+    [[nodiscard]] const std::vector<NodeId> &deferred() const { return _deferred; }
+
+  private:
+    std::vector<NodeId> _seen;
+    std::vector<NodeId> _deferred;
+    std::size_t         _counter{0};
+};
+
+// Visitor that resolves deferred work — the "async completion" phase.
+class ResolverVisitor : public IGraphVisitor
+{
+  public:
+    VisitResult onNode(const INode &node) override
+    {
+        _resolved.push_back(node.id());
+        return VisitResult::Continue;
+    }
+    VisitResult onEdge(const IEdge &) override { return VisitResult::Continue; }
+
+    [[nodiscard]] const std::vector<NodeId> &resolved() const { return _resolved; }
+
+  private:
+    std::vector<NodeId> _resolved;
+};
+
+} // namespace
+
+using ResultDeferredContract = SevenNodeParamFixture;
+
+TEST_P(ResultDeferredContract, SyncPhaseCollectsDeferredSet)
+{
+    DeferringVisitor visitor;
+    const Result     r = fixture.graph->traverse(
+        fixture.nodes[SevenNodeFixture::A], TraverseMode::DepthFirst, visitor);
+    EXPECT_TRUE(r.isSuccess());
+
+    // At least one node was deferred; none was deferred twice.
+    EXPECT_FALSE(visitor.deferred().empty());
+    std::unordered_set<NodeId, NodeIdHashPolicy> uniq(
+        visitor.deferred().begin(), visitor.deferred().end());
+    EXPECT_EQ(uniq.size(), visitor.deferred().size());
+}
+
+TEST_P(ResultDeferredContract, AsyncResolutionDrainsDeferredSet)
+{
+    DeferringVisitor sync;
+    ASSERT_TRUE(fixture.graph->traverse(
+                    fixture.nodes[SevenNodeFixture::A], TraverseMode::DepthFirst, sync)
+                    .isSuccess());
+
+    // "Signal arrives" — fire a second traversal over each deferred node.
+    ResolverVisitor async;
+    for (NodeId deferred : sync.deferred())
+    {
+        const Result r = fixture.graph->traverse(
+            deferred, TraverseMode::DepthFirst, async);
+        EXPECT_TRUE(r.isSuccess());
+    }
+
+    // Every deferred node is visited at least once during resolution.
+    std::unordered_set<NodeId, NodeIdHashPolicy> resolvedSet(
+        async.resolved().begin(), async.resolved().end());
+    for (NodeId deferred : sync.deferred())
+    {
+        EXPECT_TRUE(resolvedSet.count(deferred))
+            << "deferred node " << deferred.index << " not resolved";
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(contract_result_deferred,
+                         ResultDeferredContract,
+                         ::testing::Values(defaultGraphFactory()),
+                         GraphFactoryNamer{});
+
+} // namespace vigine::graph::contract

--- a/test/graph/contract_traversal.cpp
+++ b/test/graph/contract_traversal.cpp
@@ -1,0 +1,435 @@
+#include "fixtures/graph_fixture_7n10e.h"
+
+#include "vigine/graph/edgeid.h"
+#include "vigine/graph/iedge.h"
+#include "vigine/graph/igraph.h"
+#include "vigine/graph/igraphvisitor.h"
+#include "vigine/graph/inode.h"
+#include "vigine/graph/kind.h"
+#include "vigine/graph/nodeid.h"
+#include "vigine/graph/traverse_mode.h"
+#include "vigine/graph/visit_result.h"
+#include "vigine/result.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <functional>
+#include <unordered_set>
+#include <vector>
+
+// =============================================================================
+// Traversal contract suite — scenario i (five traversal modes).
+//
+// Exercises DepthFirst, BreadthFirst, Topological, ReverseTopological, and
+// Custom against the seven-node fixture, plus the Skip / Stop / prune
+// behaviour of the visitor return codes.
+//
+// A note on Stop semantics. The concrete AbstractGraph implementation
+// reports visitor-Stop by returning Result::Code::Error with the message
+// "traversal stopped". The IGraph interface doc says Stop terminates the
+// traversal with an error Result, and the core Result type only carries
+// two codes (Success / Error). The suite therefore asserts the shipped
+// behaviour: Stop -> isError() with the expected message. An engineer
+// reading this file: Stop is an early-exit signal, not a failure; the
+// message disambiguates it from other error conditions.
+// =============================================================================
+
+namespace vigine::graph::contract
+{
+namespace
+{
+
+// Hash policy so NodeId is usable in unordered containers inside tests.
+struct NodeIdHashPolicy
+{
+    std::size_t operator()(NodeId id) const noexcept
+    {
+        return (static_cast<std::size_t>(id.index) << 32)
+               ^ static_cast<std::size_t>(id.generation);
+    }
+};
+
+// -----------------------------------------------------------------------------
+// Recording visitor — captures the order the traversal driver calls onNode
+// and onEdge. The record vectors are exposed via accessors so the test
+// body can assert against them without touching visitor internals through
+// public data members.
+// -----------------------------------------------------------------------------
+class RecordingVisitor : public IGraphVisitor
+{
+  public:
+    VisitResult onNode(const INode &node) override
+    {
+        _nodes.push_back(node.id());
+        return VisitResult::Continue;
+    }
+
+    VisitResult onEdge(const IEdge &edge) override
+    {
+        _edges.push_back(edge.id());
+        return VisitResult::Continue;
+    }
+
+    [[nodiscard]] const std::vector<NodeId> &visitedNodes() const { return _nodes; }
+    [[nodiscard]] const std::vector<EdgeId> &visitedEdges() const { return _edges; }
+
+  private:
+    std::vector<NodeId> _nodes;
+    std::vector<EdgeId> _edges;
+};
+
+// -----------------------------------------------------------------------------
+// Visitor that answers Skip when onNode sees a flagged node; used to verify
+// pruning semantics.
+// -----------------------------------------------------------------------------
+class SkipAtVisitor : public IGraphVisitor
+{
+  public:
+    explicit SkipAtVisitor(NodeId skipAt) noexcept : _skipAt(skipAt) {}
+
+    VisitResult onNode(const INode &node) override
+    {
+        _nodes.push_back(node.id());
+        return node.id() == _skipAt ? VisitResult::Skip : VisitResult::Continue;
+    }
+    VisitResult onEdge(const IEdge &) override { return VisitResult::Continue; }
+
+    [[nodiscard]] const std::vector<NodeId> &visitedNodes() const { return _nodes; }
+
+  private:
+    NodeId              _skipAt;
+    std::vector<NodeId> _nodes;
+};
+
+// -----------------------------------------------------------------------------
+// Visitor that answers Stop when onNode sees a flagged node; used to verify
+// early-exit semantics.
+// -----------------------------------------------------------------------------
+class StopAtVisitor : public IGraphVisitor
+{
+  public:
+    explicit StopAtVisitor(NodeId stopAt) noexcept : _stopAt(stopAt) {}
+
+    VisitResult onNode(const INode &node) override
+    {
+        _nodes.push_back(node.id());
+        return node.id() == _stopAt ? VisitResult::Stop : VisitResult::Continue;
+    }
+    VisitResult onEdge(const IEdge &) override { return VisitResult::Continue; }
+
+    [[nodiscard]] const std::vector<NodeId> &visitedNodes() const { return _nodes; }
+
+  private:
+    NodeId              _stopAt;
+    std::vector<NodeId> _nodes;
+};
+
+// -----------------------------------------------------------------------------
+// Visitor for Custom mode. Uses a caller-supplied next-picker so the test
+// body stays in control of the traversal shape without subclassing here.
+// -----------------------------------------------------------------------------
+class CustomVisitor : public IGraphVisitor
+{
+  public:
+    using NextPicker = std::function<NodeId(const INode &)>;
+
+    CustomVisitor(NextPicker picker, std::size_t stopAfter)
+        : _picker(std::move(picker))
+        , _stopAfter(stopAfter)
+    {
+    }
+
+    VisitResult onNode(const INode &node) override
+    {
+        _nodes.push_back(node.id());
+        if (_nodes.size() >= _stopAfter)
+        {
+            return VisitResult::Stop;
+        }
+        return VisitResult::Continue;
+    }
+    VisitResult onEdge(const IEdge &) override { return VisitResult::Continue; }
+    NodeId      nextForCustom(const INode &current) override { return _picker(current); }
+
+    [[nodiscard]] const std::vector<NodeId> &visitedNodes() const { return _nodes; }
+
+  private:
+    NextPicker          _picker;
+    std::size_t         _stopAfter;
+    std::vector<NodeId> _nodes;
+};
+
+// -----------------------------------------------------------------------------
+// Helper — given a sequence of ids, returns true when @p before appears
+// before @p after.
+// -----------------------------------------------------------------------------
+bool precedes(const std::vector<NodeId> &order, NodeId before, NodeId after)
+{
+    const auto itBefore = std::find(order.begin(), order.end(), before);
+    const auto itAfter  = std::find(order.begin(), order.end(), after);
+    if (itBefore == order.end() || itAfter == order.end())
+    {
+        return false;
+    }
+    return itBefore < itAfter;
+}
+
+} // namespace
+
+using TraversalContract = SevenNodeParamFixture;
+
+// -----------------------------------------------------------------------------
+// DepthFirst — every reachable node visited exactly once; pre-order (the
+// start node is first); every reachable out-edge observed on onEdge.
+// -----------------------------------------------------------------------------
+
+TEST_P(TraversalContract, DepthFirstVisitsEveryReachableNodeOnce)
+{
+    RecordingVisitor visitor;
+    const Result     r = fixture.graph->traverse(
+        fixture.nodes[SevenNodeFixture::A], TraverseMode::DepthFirst, visitor);
+    EXPECT_TRUE(r.isSuccess());
+
+    // All seven nodes are reachable from A in this fixture.
+    EXPECT_EQ(visitor.visitedNodes().size(), 7u);
+    std::unordered_set<NodeId, NodeIdHashPolicy> uniq(
+        visitor.visitedNodes().begin(), visitor.visitedNodes().end());
+    EXPECT_EQ(uniq.size(), 7u);
+}
+
+TEST_P(TraversalContract, DepthFirstEmitsStartNodeFirst)
+{
+    RecordingVisitor visitor;
+    const Result     r = fixture.graph->traverse(
+        fixture.nodes[SevenNodeFixture::A], TraverseMode::DepthFirst, visitor);
+    ASSERT_TRUE(r.isSuccess());
+    ASSERT_FALSE(visitor.visitedNodes().empty());
+    EXPECT_EQ(visitor.visitedNodes().front(), fixture.nodes[SevenNodeFixture::A]);
+}
+
+TEST_P(TraversalContract, DepthFirstRejectsInvalidStartNode)
+{
+    RecordingVisitor visitor;
+    const Result     r = fixture.graph->traverse(NodeId{}, TraverseMode::DepthFirst, visitor);
+    EXPECT_TRUE(r.isError());
+    EXPECT_TRUE(visitor.visitedNodes().empty());
+}
+
+TEST_P(TraversalContract, DepthFirstSkipPrunesSubtree)
+{
+    // Skipping B means D and E (reachable from B only through this branch)
+    // should not be visited — unless they are reachable via another path.
+    // In the fixture E is also reachable via C, and D is also reachable
+    // via C, so skip should prune only the edges from B, not the nodes.
+    SkipAtVisitor visitor(fixture.nodes[SevenNodeFixture::B]);
+    const Result  r = fixture.graph->traverse(
+        fixture.nodes[SevenNodeFixture::A], TraverseMode::DepthFirst, visitor);
+    EXPECT_TRUE(r.isSuccess());
+
+    // A and B are visited; every other node is still reachable via C.
+    const auto &v = visitor.visitedNodes();
+    const auto  hasB = std::find(v.begin(), v.end(), fixture.nodes[SevenNodeFixture::B]);
+    EXPECT_NE(hasB, v.end());
+}
+
+TEST_P(TraversalContract, DepthFirstStopReportsErrorResult)
+{
+    StopAtVisitor visitor(fixture.nodes[SevenNodeFixture::D]);
+    const Result  r = fixture.graph->traverse(
+        fixture.nodes[SevenNodeFixture::A], TraverseMode::DepthFirst, visitor);
+    EXPECT_TRUE(r.isError());
+    EXPECT_EQ(r.message(), "traversal stopped");
+
+    // The stop-at node is observed exactly once.
+    const auto &v = visitor.visitedNodes();
+    EXPECT_EQ(std::count(v.begin(), v.end(), fixture.nodes[SevenNodeFixture::D]), 1);
+}
+
+// -----------------------------------------------------------------------------
+// BreadthFirst — level-by-level ordering; when a node has a shorter path
+// to the seed, it appears before any node reachable only through a longer
+// path.
+// -----------------------------------------------------------------------------
+
+TEST_P(TraversalContract, BreadthFirstVisitsEveryReachableNodeOnce)
+{
+    RecordingVisitor visitor;
+    const Result     r = fixture.graph->traverse(
+        fixture.nodes[SevenNodeFixture::A], TraverseMode::BreadthFirst, visitor);
+    EXPECT_TRUE(r.isSuccess());
+    std::unordered_set<NodeId, NodeIdHashPolicy> uniq(
+        visitor.visitedNodes().begin(), visitor.visitedNodes().end());
+    EXPECT_EQ(uniq.size(), 7u);
+}
+
+TEST_P(TraversalContract, BreadthFirstEmitsStartNodeFirst)
+{
+    RecordingVisitor visitor;
+    const Result     r = fixture.graph->traverse(
+        fixture.nodes[SevenNodeFixture::A], TraverseMode::BreadthFirst, visitor);
+    ASSERT_TRUE(r.isSuccess());
+    ASSERT_FALSE(visitor.visitedNodes().empty());
+    EXPECT_EQ(visitor.visitedNodes().front(), fixture.nodes[SevenNodeFixture::A]);
+}
+
+TEST_P(TraversalContract, BreadthFirstVisitsDepthOneBeforeDepthTwo)
+{
+    RecordingVisitor visitor;
+    const Result     r = fixture.graph->traverse(
+        fixture.nodes[SevenNodeFixture::A], TraverseMode::BreadthFirst, visitor);
+    ASSERT_TRUE(r.isSuccess());
+    const auto &order = visitor.visitedNodes();
+
+    // Depth-1 neighbours of A: B and C.
+    // Depth-2 neighbours reachable from {B, C}: D, E.
+    // Depth-3 neighbours: F, G.
+    EXPECT_TRUE(precedes(order,
+                         fixture.nodes[SevenNodeFixture::B],
+                         fixture.nodes[SevenNodeFixture::D]));
+    EXPECT_TRUE(precedes(order,
+                         fixture.nodes[SevenNodeFixture::C],
+                         fixture.nodes[SevenNodeFixture::E]));
+    EXPECT_TRUE(precedes(order,
+                         fixture.nodes[SevenNodeFixture::D],
+                         fixture.nodes[SevenNodeFixture::G]));
+    EXPECT_TRUE(precedes(order,
+                         fixture.nodes[SevenNodeFixture::E],
+                         fixture.nodes[SevenNodeFixture::G]));
+}
+
+TEST_P(TraversalContract, BreadthFirstStopReportsErrorResult)
+{
+    StopAtVisitor visitor(fixture.nodes[SevenNodeFixture::C]);
+    const Result  r = fixture.graph->traverse(
+        fixture.nodes[SevenNodeFixture::A], TraverseMode::BreadthFirst, visitor);
+    EXPECT_TRUE(r.isError());
+    EXPECT_EQ(r.message(), "traversal stopped");
+}
+
+// -----------------------------------------------------------------------------
+// Topological — every edge (u, v) has u appear before v in the emitted
+// order; a cycle produces an error.
+// -----------------------------------------------------------------------------
+
+TEST_P(TraversalContract, TopologicalOrderRespectsEveryEdge)
+{
+    RecordingVisitor visitor;
+    const Result     r = fixture.graph->traverse(
+        fixture.nodes[SevenNodeFixture::A], TraverseMode::Topological, visitor);
+    EXPECT_TRUE(r.isSuccess());
+    const auto &order = visitor.visitedNodes();
+    EXPECT_EQ(order.size(), 7u);
+
+    // Every edge in the fixture must have its source precede its target.
+    EXPECT_TRUE(precedes(order, fixture.nodes[SevenNodeFixture::A], fixture.nodes[SevenNodeFixture::B]));
+    EXPECT_TRUE(precedes(order, fixture.nodes[SevenNodeFixture::A], fixture.nodes[SevenNodeFixture::C]));
+    EXPECT_TRUE(precedes(order, fixture.nodes[SevenNodeFixture::B], fixture.nodes[SevenNodeFixture::D]));
+    EXPECT_TRUE(precedes(order, fixture.nodes[SevenNodeFixture::B], fixture.nodes[SevenNodeFixture::E]));
+    EXPECT_TRUE(precedes(order, fixture.nodes[SevenNodeFixture::C], fixture.nodes[SevenNodeFixture::E]));
+    EXPECT_TRUE(precedes(order, fixture.nodes[SevenNodeFixture::C], fixture.nodes[SevenNodeFixture::D]));
+    EXPECT_TRUE(precedes(order, fixture.nodes[SevenNodeFixture::D], fixture.nodes[SevenNodeFixture::F]));
+    EXPECT_TRUE(precedes(order, fixture.nodes[SevenNodeFixture::E], fixture.nodes[SevenNodeFixture::F]));
+    EXPECT_TRUE(precedes(order, fixture.nodes[SevenNodeFixture::E], fixture.nodes[SevenNodeFixture::G]));
+    EXPECT_TRUE(precedes(order, fixture.nodes[SevenNodeFixture::F], fixture.nodes[SevenNodeFixture::G]));
+}
+
+TEST_P(TraversalContract, TopologicalReportsErrorOnCycle)
+{
+    // Close the DAG into a cycle.
+    addTestEdge(*fixture.graph,
+                fixture.nodes[SevenNodeFixture::G],
+                fixture.nodes[SevenNodeFixture::A]);
+
+    RecordingVisitor visitor;
+    const Result     r = fixture.graph->traverse(
+        fixture.nodes[SevenNodeFixture::A], TraverseMode::Topological, visitor);
+    EXPECT_TRUE(r.isError());
+    EXPECT_NE(r.message().find("cycle"), std::string::npos);
+}
+
+// -----------------------------------------------------------------------------
+// ReverseTopological — exactly the reverse of the topological ordering.
+// -----------------------------------------------------------------------------
+
+TEST_P(TraversalContract, ReverseTopologicalInvertsEdgeOrder)
+{
+    RecordingVisitor visitor;
+    const Result     r = fixture.graph->traverse(
+        fixture.nodes[SevenNodeFixture::A], TraverseMode::ReverseTopological, visitor);
+    EXPECT_TRUE(r.isSuccess());
+    const auto &order = visitor.visitedNodes();
+    EXPECT_EQ(order.size(), 7u);
+
+    // Every edge (u, v) in the fixture now has v before u.
+    EXPECT_TRUE(precedes(order, fixture.nodes[SevenNodeFixture::G], fixture.nodes[SevenNodeFixture::A]));
+    EXPECT_TRUE(precedes(order, fixture.nodes[SevenNodeFixture::F], fixture.nodes[SevenNodeFixture::D]));
+    EXPECT_TRUE(precedes(order, fixture.nodes[SevenNodeFixture::E], fixture.nodes[SevenNodeFixture::B]));
+}
+
+TEST_P(TraversalContract, ReverseTopologicalReportsErrorOnCycle)
+{
+    addTestEdge(*fixture.graph,
+                fixture.nodes[SevenNodeFixture::G],
+                fixture.nodes[SevenNodeFixture::A]);
+
+    RecordingVisitor visitor;
+    const Result     r = fixture.graph->traverse(
+        fixture.nodes[SevenNodeFixture::A], TraverseMode::ReverseTopological, visitor);
+    EXPECT_TRUE(r.isError());
+}
+
+// -----------------------------------------------------------------------------
+// Custom — visitor drives the walk through nextForCustom.
+// -----------------------------------------------------------------------------
+
+TEST_P(TraversalContract, CustomFollowsVisitorProvidedNext)
+{
+    // Walk the spine A -> B -> D -> F -> G via an explicit next picker.
+    const std::array<NodeId, 5> spine{
+        fixture.nodes[SevenNodeFixture::A],
+        fixture.nodes[SevenNodeFixture::B],
+        fixture.nodes[SevenNodeFixture::D],
+        fixture.nodes[SevenNodeFixture::F],
+        fixture.nodes[SevenNodeFixture::G],
+    };
+    auto picker = [&spine](const INode &current) {
+        for (std::size_t i = 0; i + 1 < spine.size(); ++i)
+        {
+            if (spine[i] == current.id())
+            {
+                return spine[i + 1];
+            }
+        }
+        return NodeId{};
+    };
+    CustomVisitor visitor(picker, /*stopAfter=*/spine.size() + 1);
+    const Result  r = fixture.graph->traverse(spine[0], TraverseMode::Custom, visitor);
+    EXPECT_TRUE(r.isSuccess());
+    EXPECT_EQ(visitor.visitedNodes().size(), spine.size());
+    for (std::size_t i = 0; i < spine.size(); ++i)
+    {
+        EXPECT_EQ(visitor.visitedNodes()[i], spine[i]);
+    }
+}
+
+TEST_P(TraversalContract, CustomTerminatesOnInvalidNextNode)
+{
+    // Picker returns an invalid id immediately, so traversal visits only
+    // the start node.
+    auto picker = [](const INode &) { return NodeId{}; };
+    CustomVisitor visitor(picker, /*stopAfter=*/100);
+    const Result  r = fixture.graph->traverse(
+        fixture.nodes[SevenNodeFixture::A], TraverseMode::Custom, visitor);
+    EXPECT_TRUE(r.isSuccess());
+    EXPECT_EQ(visitor.visitedNodes().size(), 1u);
+    EXPECT_EQ(visitor.visitedNodes().front(), fixture.nodes[SevenNodeFixture::A]);
+}
+
+INSTANTIATE_TEST_SUITE_P(contract_traversal,
+                         TraversalContract,
+                         ::testing::Values(defaultGraphFactory()),
+                         GraphFactoryNamer{});
+
+} // namespace vigine::graph::contract

--- a/test/graph/fixtures/graph_fixture_7n10e.h
+++ b/test/graph/fixtures/graph_fixture_7n10e.h
@@ -1,0 +1,313 @@
+#pragma once
+
+#include "vigine/graph/edgeid.h"
+#include "vigine/graph/factory.h"
+#include "vigine/graph/iedge.h"
+#include "vigine/graph/iedgedata.h"
+#include "vigine/graph/igraph.h"
+#include "vigine/graph/inode.h"
+#include "vigine/graph/kind.h"
+#include "vigine/graph/nodeid.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace vigine::graph::contract
+{
+/**
+ * @brief Factory returning a new concrete IGraph behind the public API.
+ *
+ * The contract suite treats any factory that satisfies this signature as
+ * a candidate for the full scenario list. The default factory wired up by
+ * the suite in this leaf is the engine's own createGraph(); a second
+ * concrete IGraph implementation plugs into the same suite by registering
+ * another factory with INSTANTIATE_TEST_SUITE_P.
+ */
+using GraphFactory = std::function<std::shared_ptr<IGraph>()>;
+
+/**
+ * @brief Reserved edge kind for ChildOf relations used by the HSM-style
+ *        scenarios.
+ *
+ * The value 49 is picked for the contract suite specifically; it sits in
+ * the wrapper range (the core only defines kind::Generic = 1 and
+ * edge_kind::Generic = 1), and the contract suite uses it to verify that
+ * the graph does not reject kinds it does not know about.
+ */
+inline constexpr EdgeKind ContractChildOfKind = 49;
+
+/**
+ * @brief Reserved edge kind used by the FanOut and Broadcast style scenarios.
+ */
+inline constexpr EdgeKind ContractAttachedKind = 50;
+
+/**
+ * @brief Reserved node kind used by HSM-style scenarios.
+ */
+inline constexpr NodeKind ContractStateKind = 42;
+
+/**
+ * @brief Reserved node kind used by the FanOut and Broadcast style scenarios.
+ */
+inline constexpr NodeKind ContractSubscriberKind = 43;
+
+/**
+ * @brief Minimal IEdgeData payload used by the payload round-trip checks.
+ *
+ * Carries a stable dataTypeId and an integer tag so tests can assert the
+ * payload survives addEdge / edge() round-trip unchanged.
+ */
+class TestEdgeData final : public IEdgeData
+{
+  public:
+    explicit TestEdgeData(std::uint32_t typeId, int tag) noexcept
+        : _typeId(typeId)
+        , _tag(tag)
+    {
+    }
+
+    [[nodiscard]] std::uint32_t dataTypeId() const noexcept override { return _typeId; }
+
+    [[nodiscard]] int tag() const noexcept { return _tag; }
+
+  private:
+    std::uint32_t _typeId{0};
+    int           _tag{0};
+};
+
+/**
+ * @brief Minimal concrete INode used exclusively by the contract suite.
+ *
+ * The suite deliberately does not include the engine's own internal
+ * NodeImpl from src/graph/defaultgraph.h; pulling an internal header into
+ * the contract tests would couple the suite to one specific concrete
+ * IGraph. Instead the suite ships its own INode subclass and exercises
+ * the graph through addNode(std::unique_ptr<INode>) alone.
+ */
+class TestNode final : public INode
+{
+  public:
+    explicit TestNode(NodeKind kind) noexcept : _kind(kind) {}
+
+    [[nodiscard]] NodeId   id() const noexcept override { return _id; }
+    [[nodiscard]] NodeKind kind() const noexcept override { return _kind; }
+
+    /**
+     * @brief Called by the owning test after addNode returns so that a
+     *        later call to INode::id reports the graph-assigned value.
+     *
+     * The contract suite does not assume the graph's IdStamp hook exists,
+     * so tests stamp the id explicitly after addNode.
+     */
+    void stampId(NodeId id) noexcept { _id = id; }
+
+  private:
+    NodeId   _id{};
+    NodeKind _kind{};
+};
+
+/**
+ * @brief Minimal concrete IEdge used exclusively by the contract suite.
+ */
+class TestEdge final : public IEdge
+{
+  public:
+    TestEdge(NodeId from, NodeId to, EdgeKind kind, std::unique_ptr<IEdgeData> data) noexcept
+        : _from(from)
+        , _to(to)
+        , _kind(kind)
+        , _data(std::move(data))
+    {
+    }
+
+    [[nodiscard]] EdgeId           id() const noexcept override { return _id; }
+    [[nodiscard]] EdgeKind         kind() const noexcept override { return _kind; }
+    [[nodiscard]] NodeId           from() const noexcept override { return _from; }
+    [[nodiscard]] NodeId           to() const noexcept override { return _to; }
+    [[nodiscard]] const IEdgeData *data() const noexcept override { return _data.get(); }
+
+    void stampId(EdgeId id) noexcept { _id = id; }
+
+  private:
+    EdgeId                     _id{};
+    NodeId                     _from{};
+    NodeId                     _to{};
+    EdgeKind                   _kind{};
+    std::unique_ptr<IEdgeData> _data{};
+};
+
+/**
+ * @brief Adds a node of the requested kind through the public IGraph API
+ *        and back-stamps the test node so INode::id later reports the
+ *        assigned value.
+ *
+ * Returns the graph-assigned NodeId. Returns NodeId{} only if the graph
+ * rejects the insertion (which no current concrete IGraph does for a
+ * non-null unique_ptr).
+ */
+inline NodeId addTestNode(IGraph &graph, NodeKind kind = kind::Generic)
+{
+    auto       rawNode = std::make_unique<TestNode>(kind);
+    TestNode  *raw     = rawNode.get();
+    const NodeId id    = graph.addNode(std::move(rawNode));
+    raw->stampId(id);
+    return id;
+}
+
+/**
+ * @brief Adds an edge through the public IGraph API and back-stamps the
+ *        test edge.
+ */
+inline EdgeId addTestEdge(IGraph                   &graph,
+                          NodeId                    from,
+                          NodeId                    to,
+                          EdgeKind                  kind = edge_kind::Generic,
+                          std::unique_ptr<IEdgeData> data = nullptr)
+{
+    auto        rawEdge = std::make_unique<TestEdge>(from, to, kind, std::move(data));
+    TestEdge   *raw     = rawEdge.get();
+    const EdgeId id     = graph.addEdge(std::move(rawEdge));
+    raw->stampId(id);
+    return id;
+}
+
+/**
+ * @brief Seven-node, ten-edge fixture used by the traversal, query, and
+ *        scenario suites.
+ *
+ * Topology:
+ *
+ *      A ---> B ---> D
+ *      |      |      |
+ *      v      v      v
+ *      C ---> E ---> F
+ *             |
+ *             v
+ *             G
+ *
+ * Plus a cross edge C -> D and a back-link E -> A omitted by default
+ * (tests that want a cycle add it explicitly).
+ */
+struct SevenNodeFixture
+{
+    std::shared_ptr<IGraph> graph;
+    std::array<NodeId, 7>   nodes{};
+    std::array<EdgeId, 10>  edges{};
+
+    enum : std::size_t
+    {
+        A = 0,
+        B = 1,
+        C = 2,
+        D = 3,
+        E = 4,
+        F = 5,
+        G = 6,
+    };
+
+    /**
+     * @brief Populates @p graph with the seven-node ten-edge shape and
+     *        records the assigned ids.
+     *
+     * The ten edges, in insertion order, are:
+     *   0: A -> B
+     *   1: A -> C
+     *   2: B -> D
+     *   3: B -> E
+     *   4: C -> E
+     *   5: C -> D
+     *   6: D -> F
+     *   7: E -> F
+     *   8: E -> G
+     *   9: F -> G
+     */
+    void build(const GraphFactory &factory)
+    {
+        graph = factory();
+        for (std::size_t i = 0; i < nodes.size(); ++i)
+        {
+            nodes[i] = addTestNode(*graph);
+        }
+        const auto a = nodes[A];
+        const auto b = nodes[B];
+        const auto c = nodes[C];
+        const auto d = nodes[D];
+        const auto e = nodes[E];
+        const auto f = nodes[F];
+        const auto g = nodes[G];
+        edges[0]     = addTestEdge(*graph, a, b);
+        edges[1]     = addTestEdge(*graph, a, c);
+        edges[2]     = addTestEdge(*graph, b, d);
+        edges[3]     = addTestEdge(*graph, b, e);
+        edges[4]     = addTestEdge(*graph, c, e);
+        edges[5]     = addTestEdge(*graph, c, d);
+        edges[6]     = addTestEdge(*graph, d, f);
+        edges[7]     = addTestEdge(*graph, e, f);
+        edges[8]     = addTestEdge(*graph, e, g);
+        edges[9]     = addTestEdge(*graph, f, g);
+    }
+};
+
+/**
+ * @brief Base fixture used by every parametrised contract suite.
+ *
+ * Takes a GraphFactory through TEST_P's parameter and constructs one
+ * graph per test. Test bodies reference only the IGraph public surface
+ * and the helpers above, never a concrete graph type.
+ */
+class ContractFixture : public ::testing::TestWithParam<GraphFactory>
+{
+  protected:
+    std::shared_ptr<IGraph> makeGraph() const { return GetParam()(); }
+};
+
+/**
+ * @brief Parametrised fixture that preloads the seven-node ten-edge shape.
+ */
+class SevenNodeParamFixture : public ::testing::TestWithParam<GraphFactory>
+{
+  protected:
+    void SetUp() override { fixture.build(GetParam()); }
+
+    SevenNodeFixture fixture;
+};
+
+/**
+ * @brief Returns the default factory used by the contract suite in this
+ *        leaf: the engine's own createGraph.
+ *
+ * A second concrete IGraph wires into the suite by registering another
+ * GraphFactory with INSTANTIATE_TEST_SUITE_P.
+ */
+inline GraphFactory defaultGraphFactory()
+{
+    return [] { return createGraph(); };
+}
+
+/**
+ * @brief Name generator used by INSTANTIATE_TEST_SUITE_P so that the
+ *        parametrised test names read e.g. `DefaultGraph/LifecycleContract.X`
+ *        instead of printing the raw GraphFactory bytes.
+ *
+ * The suite in this leaf has a single parameter (the engine's own
+ * createGraph); when future leaves register additional implementations
+ * they pass their own label to INSTANTIATE_TEST_SUITE_P as the first
+ * argument, and this generator just reuses the index-based fallback
+ * supplied by GoogleTest.
+ */
+struct GraphFactoryNamer
+{
+    template <class ParamInfo>
+    std::string operator()(const ParamInfo &info) const
+    {
+        return "case" + std::to_string(info.index);
+    }
+};
+
+} // namespace vigine::graph::contract


### PR DESCRIPTION
This PR adds a contract-style test suite for the graph primitive. The suite
validates every concrete `IGraph` implementation against the pure-virtual
public headers — today that is just `DefaultGraph`, and tomorrow any new
in-memory or remote graph can plug into the same scenarios by registering
another factory with `INSTANTIATE_TEST_SUITE_P`.

## What ships

- A shared `graph_fixture_7n10e.h` fixture with a seven-node, ten-edge
  DAG plus minimal test-local `INode` / `IEdge` / `IEdgeData` classes
  built on the public surface alone — no reference to `DefaultGraph` or
  to the `internal::makeNode` / `makeEdge` helpers that live under
  `src/`.
- Ten scenario files under `test/graph/`: lifecycle (`contract_igraph`,
  `contract_inode`, `contract_iedge`), traversal (`contract_traversal`),
  query (`contract_query`), generational-id safety
  (`contract_generational_id`, 32 rounds of create-remove-recreate),
  bubble walk via `ChildOf` edges (`contract_hsm_bubble`), fan-out
  one-hop enumeration (`contract_fanout`), deadline-style Stop
  semantics (`contract_async_timeout`), and a two-phase
  defer-then-resolve round-trip (`contract_result_deferred`).
- A new `graph-contract` executable registered with `ctest` under the
  `graph-contract` label, so `ctest -L graph-contract` runs the full
  suite and `-R contract_<name>` filters by scenario file.

## Result

`ctest --test-dir build -C Debug -L graph-contract` reports
`100% tests passed, 0 tests failed out of 78`. Each scenario filter
(`-R contract_generational_id`, `-R contract_traversal`, ...) also
resolves to the expected subset.

## Notes for review

- Visitor `Stop` currently returns `Result::Error` with the message
  `"traversal stopped"`. The tests assert that exact behaviour — an
  alternative `Cancelled` code is not part of the public surface today.
- The scenarios `async_timeout` and `result_deferred` exercise the
  graph-level invariants a downstream wrapper will build on; the real
  async path (deferred visitor, dispatcher) lands in a separate leaf
  once the bus exists.
- `gtest_force_shared_crt` is set in `test/CMakeLists.txt` so the new
  executable links against the same CRT as the `vigine` library (MSVC
  `LNK2038` fix). `enable_testing()` moves into the top-level
  `CMakeLists.txt` so `ctest` picks up the `gtest_discover_tests`
  registrations.

Closes #87
