### PR TITLE
feat(kinds): declare wrapper NodeKind/EdgeKind constants for messaging, service, ECS, state/taskflow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,10 @@ set(HEADER
     ${INCLUDE_DIR}/vigine/graph/igraph.h
     ${INCLUDE_DIR}/vigine/graph/factory.h
     ${INCLUDE_DIR}/vigine/graph/abstractgraph.h
+    ${INCLUDE_DIR}/vigine/messaging/kind.h
+    ${INCLUDE_DIR}/vigine/ecs/kind.h
+    ${INCLUDE_DIR}/vigine/fsm/kind.h
+    ${INCLUDE_DIR}/vigine/taskflow/kind.h
 )
 
 set(SOURCES

--- a/include/vigine/ecs/kind.h
+++ b/include/vigine/ecs/kind.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <vigine/graph/kind.h>
+
+// wrapper-kind-waiver: engine-concept kind constants in a wrapper subspace.
+
+namespace vigine::ecs
+{
+/**
+ * @brief Node kind constants owned by the ECS wrapper.
+ *
+ * Carved out of the reserved range `[32..47]` in the graph substrate. Every
+ * ECS-specific node carries one of these tags so the core graph stays free
+ * of engine-specific concepts (see @ref vigine::graph::NodeKind).
+ */
+namespace kind
+{
+inline constexpr vigine::graph::NodeKind Entity = 32;
+inline constexpr vigine::graph::NodeKind Component = 33;
+} // namespace kind
+
+/**
+ * @brief Edge kind constants owned by the ECS wrapper.
+ *
+ * Carved out of the reserved range `[32..47]` in the graph substrate.
+ */
+namespace edge_kind
+{
+inline constexpr vigine::graph::EdgeKind Attached = 32;
+} // namespace edge_kind
+
+} // namespace vigine::ecs

--- a/include/vigine/fsm/kind.h
+++ b/include/vigine/fsm/kind.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <vigine/graph/kind.h>
+
+// wrapper-kind-waiver: engine-concept kind constants in a wrapper subspace.
+
+namespace vigine::fsm
+{
+/**
+ * @brief Node kind constants owned by the state machine wrapper.
+ *
+ * Carved out of the reserved range `[48..63]` in the graph substrate. Every
+ * state-machine node carries one of these tags so the core graph stays free
+ * of engine-specific concepts (see @ref vigine::graph::NodeKind).
+ */
+namespace kind
+{
+inline constexpr vigine::graph::NodeKind State = 48;
+} // namespace kind
+
+/**
+ * @brief Edge kind constants owned by the state machine wrapper.
+ *
+ * Carved out of the reserved range `[48..63]` in the graph substrate.
+ * `ChildOf` models the parent/child relationship inside a hierarchical state
+ * machine; `Transition` models a labelled transition between sibling states.
+ */
+namespace edge_kind
+{
+inline constexpr vigine::graph::EdgeKind Transition = 48;
+inline constexpr vigine::graph::EdgeKind ChildOf = 49;
+} // namespace edge_kind
+
+} // namespace vigine::fsm

--- a/include/vigine/messaging/kind.h
+++ b/include/vigine/messaging/kind.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <vigine/graph/kind.h>
+
+// wrapper-kind-waiver: engine-concept kind constants in a wrapper subspace.
+
+namespace vigine::messaging
+{
+/**
+ * @brief Node kind constants owned by the messaging wrapper.
+ *
+ * Carved out of the reserved range `[16..31]` in the graph substrate. Every
+ * messaging-specific node carries one of these tags so the core graph stays
+ * free of engine-specific concepts (see @ref vigine::graph::NodeKind).
+ */
+namespace kind
+{
+inline constexpr vigine::graph::NodeKind Target = 16;
+inline constexpr vigine::graph::NodeKind Subscription = 17;
+} // namespace kind
+
+/**
+ * @brief Edge kind constants owned by the messaging wrapper.
+ *
+ * Carved out of the reserved range `[16..31]` in the graph substrate.
+ */
+namespace edge_kind
+{
+inline constexpr vigine::graph::EdgeKind Subscription = 16;
+} // namespace edge_kind
+
+} // namespace vigine::messaging

--- a/include/vigine/taskflow/kind.h
+++ b/include/vigine/taskflow/kind.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <vigine/graph/kind.h>
+
+// wrapper-kind-waiver: engine-concept kind constants in a wrapper subspace.
+
+namespace vigine::taskflow
+{
+/**
+ * @brief Node kind constants owned by the task flow wrapper.
+ *
+ * Carved out of the reserved range `[64..79]` in the graph substrate. Every
+ * task-flow node carries one of these tags so the core graph stays free of
+ * engine-specific concepts (see @ref vigine::graph::NodeKind).
+ */
+namespace kind
+{
+inline constexpr vigine::graph::NodeKind Task = 64;
+} // namespace kind
+
+/**
+ * @brief Edge kind constants owned by the task flow wrapper.
+ *
+ * Carved out of the reserved range `[64..79]` in the graph substrate.
+ */
+namespace edge_kind
+{
+inline constexpr vigine::graph::EdgeKind Transition = 64;
+} // namespace edge_kind
+
+} // namespace vigine::taskflow


### PR DESCRIPTION
## What ships

Four small public headers — one per wrapper family — that declare the
domain-specific `NodeKind` and `EdgeKind` constants the wrappers need:

- `include/vigine/messaging/kind.h` — `Target = 16`, `Subscription = 17`, edge `Subscription = 16`
- `include/vigine/ecs/kind.h` — `Entity = 32`, `Component = 33`, edge `Attached = 32`
- `include/vigine/fsm/kind.h` — `State = 48`, edges `Transition = 48` and `ChildOf = 49`
- `include/vigine/taskflow/kind.h` — `Task = 64`, edge `Transition = 64`

Each header lives in its wrapper's own namespace (`vigine::messaging::kind`,
`vigine::ecs::kind`, `vigine::fsm::kind`, `vigine::taskflow::kind`, and the
matching `edge_kind` sibling), includes only `<vigine/graph/kind.h>` for the
`NodeKind` / `EdgeKind` typedefs, and stays inside the 16-value slice the
graph substrate reserves for it (`[16..31]`, `[32..47]`, `[48..63]`,
`[64..79]` respectively).

CMake's `HEADER` list gains the four new paths so they ship with
`install(DIRECTORY include/)` already in place.

## What stays the same

- `include/vigine/graph/kind.h` is untouched — only `Generic = 1` still
  lives in the core namespace.
- No wrapper `.cpp` or test is added in this PR.
- No existing source file changes; the diff is five files (four new
  headers plus the CMake list extension).

## Acceptance

- All nine `grep -q` lines from the plan's acceptance block match in the
  four new headers.
- `cmake --build build --target vigine --config Debug` links cleanly on
  Windows MSVC 18 2026 generator (no new warnings; `/FS /utf-8` in effect).
- A throwaway probe including all four headers under `/W4 /WX`
  compiled without diagnostics, and `static_assert`s on every constant
  value confirmed the pinned numbers.

Closes #89
