### PR TITLE
build(ci): add check_naming_convention.py static checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,20 @@ jobs:
       - name: Run check_graph_purity
         run: python scripts/check_graph_purity.py --root .
 
+  naming-convention:
+    name: Naming convention check (INV-10)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run check_naming_convention
+        run: python scripts/check_naming_convention.py --root .
+
   unit-tests-scripts:
     name: Script unit tests
     runs-on: ubuntu-latest
@@ -37,3 +51,6 @@ jobs:
 
       - name: Run test_check_graph_purity
         run: pytest test/scripts/test_check_graph_purity.py -q
+
+      - name: Run test_check_naming_convention
+        run: pytest test/scripts/test_check_naming_convention.py -q

--- a/include/vigine/signal/isignalemiter.h
+++ b/include/vigine/signal/isignalemiter.h
@@ -29,7 +29,7 @@ namespace vigine
  * @see ISignal
  * @see ISignalBinder
  */
-class ISignalEmiter
+class ISignalEmiter // INV-10 EXEMPTION: predates convention; carries proxy state; rename tracked separately
 {
   public:
     /**

--- a/scripts/check_naming_convention.py
+++ b/scripts/check_naming_convention.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+"""check_naming_convention.py -- Static checker for the I/Abstract naming convention (INV-10).
+
+Scans include/vigine/**/*.h and verifies that:
+
+  Rule 1 (I-prefix): A class whose name starts with "I" followed by an
+    uppercase letter must NOT have any non-virtual method with an inline
+    body and must NOT have any underscore-prefixed data member.
+    (Special-member housekeeping -- virtual destructor = default/delete,
+    copy/move = default/delete, protected default constructor = default --
+    and virtual methods with optional-hook bodies are not counted.)
+
+  Rule 2 (Abstract-prefix): A class whose name starts with "Abstract" must
+    have AT LEAST ONE method that is not pure-virtual (= 0) and not a
+    deleted copy/move, OR at least one underscore-prefixed data member.
+    A class that is entirely pure-virtual with no state should use the I tier.
+
+Only top-level class/struct definitions are checked; forward declarations
+(no body) are skipped; nested classes inside a body are not re-checked.
+
+Waiver: when the class declaration line contains "// INV-10 EXEMPTION:"
+the entire class is skipped without error.
+
+Exit codes:
+  0 -- all checked classes conform.
+  1 -- at least one violation found (or a scan path was not found).
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+WAIVER_MARKER = "// INV-10 EXEMPTION:"
+
+DEFAULT_SCAN_DIRS: list[str] = ["include/vigine"]
+
+EXTENSIONS: frozenset[str] = frozenset({".h", ".hpp"})
+
+# ---------------------------------------------------------------------------
+# Compiled patterns
+# ---------------------------------------------------------------------------
+
+# Class/struct declaration opening line.
+_CLASS_OPEN_RE = re.compile(r"^\s*(?:class|struct)\s+(\w+)")
+
+# Pure-virtual: "= 0;"
+_PURE_VIRTUAL_RE = re.compile(r"=\s*0\s*;")
+
+# Deleted or defaulted: "= delete;" or "= default;"
+_DEL_DEF_RE = re.compile(r"=\s*(?:delete|default)\s*;")
+
+# Data member: underscore-prefixed identifier (Vigine field convention).
+# Must not look like a method (no '(' before the identifier).
+_DATA_MEMBER_RE = re.compile(
+    r"^\s*"
+    r"(?!(?:using\b|friend\b|static_assert\b|typedef\b|#|//|\*|/\*|return\b))"
+    r"[\w:*&<>,\s]+"    # type (crude)
+    r"\b(_\w+)\s*"      # _field_name
+    r"(?:[{=;]|$)",     # initialiser or end of statement
+)
+
+# A line that declares or defines a method (has parentheses) and is NOT
+# pure-virtual and NOT deleted/defaulted.  Used for the Abstract Rule 2.
+_METHOD_DECL_RE = re.compile(r"\(")   # any line with '(' is a method candidate
+
+# Comments.
+_BLOCK_COMMENT_RE = re.compile(r"^\s*/?\*")
+_LINE_COMMENT_RE  = re.compile(r"^\s*//")
+
+
+def _is_comment_line(line: str) -> bool:
+    return bool(_BLOCK_COMMENT_RE.match(line) or _LINE_COMMENT_RE.match(line))
+
+
+def _strip_comments(line: str) -> str:
+    """Strip // tail and /* ... */ blocks (crude -- ignores string literals)."""
+    line = re.sub(r"/\*.*?\*/", "", line)
+    pos = line.find("//")
+    return line[:pos] if pos >= 0 else line
+
+
+# ---------------------------------------------------------------------------
+# Class body extraction
+# ---------------------------------------------------------------------------
+
+def _extract_class_body(lines: list[str], start: int) -> tuple[list[str], int] | None:
+    """Return (body_lines, end_idx_0based) for the class opening at *start*.
+
+    Searches forward from *start* for '{'.  Returns None when a ';' is found
+    first (forward declaration) or EOF is reached without finding '{'.
+    body_lines span from the '{' line to the matching '}'.
+    """
+    depth = 0
+    body: list[str] = []
+    found_open = False
+
+    for idx in range(start, len(lines)):
+        raw = lines[idx]
+        sc  = _strip_comments(raw)
+        opens  = sc.count("{")
+        closes = sc.count("}")
+
+        if not found_open:
+            if opens > 0:
+                found_open = True
+            elif ";" in sc:
+                return None  # Forward declaration.
+
+        if found_open:
+            depth  += opens - closes
+            body.append(raw)
+            if depth <= 0:
+                return body, idx
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Class body analyser
+# ---------------------------------------------------------------------------
+
+class _ClassInfo:
+    """Structural summary of one class body for naming-convention checks.
+
+    Attributes (all at top-level scope -- depth-1 lines only):
+      has_pure_virtual             -- at least one "= 0;" method.
+      has_non_pure_non_virtual_method
+                                   -- at least one non-virtual method that is
+                                      not "= 0", "= default", or "= delete".
+                                      (Non-virtual methods with bodies count.)
+      has_any_non_delete_method    -- at least one method line that is not
+                                      "= delete" (used for Abstract Rule 2).
+      has_data_member              -- at least one underscore-prefixed field.
+    """
+
+    def __init__(self, body_lines: list[str]) -> None:
+        self.has_pure_virtual              = False
+        self.has_non_pure_non_virtual_impl = False
+        self.has_any_non_delete_method     = False
+        self.has_data_member               = False
+        self._parse(body_lines)
+
+    def _parse(self, body_lines: list[str]) -> None:
+        depth = 0  # 1 = directly inside the class being analysed.
+
+        for raw in body_lines:
+            line = raw.rstrip()
+            if _is_comment_line(line):
+                continue
+
+            sc     = _strip_comments(line)
+            opens  = sc.count("{")
+            closes = sc.count("}")
+            before = depth
+            depth += opens - closes
+            if depth < 0:
+                depth = 0
+
+            # Only inspect lines directly inside the class (before=1 or
+            # transitions through depth 1 when opens == closes == 0).
+            if before != 1:
+                continue
+
+            # -- Pure virtual --
+            if _PURE_VIRTUAL_RE.search(line):
+                self.has_pure_virtual = True
+                # A "= 0;" line cannot also be non-pure.
+                continue
+
+            # -- Deleted / defaulted special members --
+            # These are NOT counted as "non-pure implementations" for Rule 1
+            # (they are housekeeping, not semantics), but they ARE counted as
+            # "has a non-deleted method" for Rule 2.
+            if _DEL_DEF_RE.search(line):
+                if "= delete" not in line:
+                    # "= default" counts as "has a non-deleted method."
+                    self.has_any_non_delete_method = True
+                continue
+
+            # -- Method lines (have parentheses) --
+            if _METHOD_DECL_RE.search(sc):
+                # A non-pure, non-delete, non-default method.
+                self.has_any_non_delete_method = True
+                # Check whether it is non-virtual (I-prefix violation).
+                # Use the comment-stripped form so that words inside comments
+                # (e.g. "/* non-virtual body */") do not falsely match.
+                sc_nc = re.sub(r"/\*.*?\*/", "", sc)
+                if "virtual" not in sc_nc:
+                    self.has_non_pure_non_virtual_impl = True
+                continue
+
+            # -- Data members (underscore convention, no parentheses) --
+            if _DATA_MEMBER_RE.match(line) and "(" not in sc:
+                self.has_data_member = True
+
+    # -- Rule 1 helpers --
+
+    def i_prefix_ok(self) -> bool:
+        """Return True when the class is a valid I-interface.
+
+        An I-interface has:
+          - no non-virtual methods with bodies (non-pure non-virtual impl)
+          - no data members
+        Virtual methods with default bodies are tolerated (optional hook pattern).
+        """
+        return not self.has_non_pure_non_virtual_impl and not self.has_data_member
+
+    # -- Rule 2 helpers --
+
+    def abstract_prefix_ok(self) -> bool:
+        """Return True when the class legitimately uses the Abstract prefix.
+
+        An Abstract class has at least one non-deleted method (which means it
+        provides some implementation beyond pure-virtual contracts) OR at least
+        one data member.
+        """
+        return self.has_any_non_delete_method or self.has_data_member
+
+
+# ---------------------------------------------------------------------------
+# Prefix helpers
+# ---------------------------------------------------------------------------
+
+_I_PREFIX_RE       = re.compile(r"^I[A-Z]")       # IFoo
+_ABSTRACT_PREFIX_RE = re.compile(r"^Abstract\w")   # AbstractFoo
+
+
+def _has_i_prefix(name: str) -> bool:
+    return bool(_I_PREFIX_RE.match(name))
+
+
+def _has_abstract_prefix(name: str) -> bool:
+    return bool(_ABSTRACT_PREFIX_RE.match(name))
+
+
+# ---------------------------------------------------------------------------
+# File scanner
+# ---------------------------------------------------------------------------
+
+def scan_file(path: Path, quiet: bool) -> list[str]:
+    """Return list of violation strings for *path* (empty when clean)."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        msg = f"{path}: encoding error -- {exc}"
+        if not quiet:
+            print(msg, file=sys.stderr)
+        return [msg]
+
+    lines = text.splitlines()
+    violations: list[str] = []
+
+    idx = 0
+    while idx < len(lines):
+        raw    = lines[idx]
+        lineno = idx + 1
+
+        if WAIVER_MARKER in raw:
+            idx += 1
+            continue
+
+        if _is_comment_line(raw):
+            idx += 1
+            continue
+
+        m = _CLASS_OPEN_RE.match(raw)
+        if not m:
+            idx += 1
+            continue
+
+        name = m.group(1)
+
+        result = _extract_class_body(lines, idx)
+        if result is None:
+            idx += 1
+            continue
+
+        body_lines, end_idx = result
+
+        if _has_i_prefix(name):
+            info = _ClassInfo(body_lines)
+            if not info.i_prefix_ok():
+                if info.has_data_member:
+                    detail = "has data member(s)"
+                else:
+                    detail = "has non-virtual method(s) with bodies"
+                msg = (
+                    f"{path}:{lineno}: naming: '{name}' has 'I' prefix but "
+                    f"{detail} -- should be renamed to 'Abstract{name[1:]}'"
+                )
+                violations.append(msg)
+                if not quiet:
+                    print(msg)
+
+        elif _has_abstract_prefix(name):
+            info = _ClassInfo(body_lines)
+            if not info.abstract_prefix_ok():
+                suffix = name[len("Abstract"):]
+                msg = (
+                    f"{path}:{lineno}: naming: '{name}' has 'Abstract' prefix but "
+                    f"all methods are pure-virtual or deleted and there are no data "
+                    f"members -- should be renamed to 'I{suffix}'"
+                )
+                violations.append(msg)
+                if not quiet:
+                    print(msg)
+
+        idx = end_idx + 1
+
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Directory scanner
+# ---------------------------------------------------------------------------
+
+def scan_paths(scan_roots: list[Path], quiet: bool) -> tuple[int, int]:
+    """Scan all roots; return (files_scanned, violation_count)."""
+    files_scanned   = 0
+    violation_count = 0
+    for root in scan_roots:
+        if not root.exists():
+            msg = f"check_naming_convention: path not found: {root}"
+            print(msg, file=sys.stderr)
+            violation_count += 1
+            continue
+        for p in sorted(root.rglob("*")):
+            if p.suffix not in EXTENSIONS or not p.is_file():
+                continue
+            files_scanned += 1
+            hits = scan_file(p, quiet)
+            violation_count += len(hits)
+    return files_scanned, violation_count
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Check INV-10 naming convention: I-prefixed classes must be pure-virtual "
+            "interfaces; Abstract-prefixed classes must carry state or non-pure methods."
+        )
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=None,
+        help="Repo root (default: parent of the directory containing this script).",
+    )
+    parser.add_argument(
+        "--path",
+        dest="extra_paths",
+        action="append",
+        type=Path,
+        default=[],
+        help=(
+            "Additional path to scan (can be repeated). "
+            "When provided, replaces the default scan dirs."
+        ),
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress per-violation output; print only the summary line.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.root is not None:
+        repo_root = args.root.resolve()
+    else:
+        repo_root = Path(__file__).resolve().parent.parent
+
+    if args.extra_paths:
+        scan_roots = [p if p.is_absolute() else repo_root / p for p in args.extra_paths]
+    else:
+        scan_roots = [repo_root / d for d in DEFAULT_SCAN_DIRS]
+
+    files_scanned, violation_count = scan_paths(scan_roots, args.quiet)
+
+    summary = (
+        f"check_naming_convention: {files_scanned} files scanned, "
+        f"{violation_count} violations"
+    )
+    print(summary)
+
+    return 0 if violation_count == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/scripts/test_check_naming_convention.py
+++ b/test/scripts/test_check_naming_convention.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Unit tests for check_naming_convention.py -- eight cases per plan_29.
+
+Cases:
+  1. I-prefix + non-virtual method body           -> exit 1 (Rule 1 fail)
+  2. I-prefix + data member                       -> exit 1 (Rule 1 fail)
+  3. Abstract-prefix + state (data member)        -> exit 0 (Rule 2 pass)
+  4. Abstract-prefix + all pure-virtual, no state -> exit 1 (Rule 2 fail)
+  5. Waiver token on class line                   -> exit 0 (waiver respected)
+  6. Forward declaration (no body)                -> exit 0 (skipped)
+  7. Nested class inside a clean outer class      -> exit 0 (nested skipped)
+  8. Missing scan path handled gracefully         -> exit 1, message on stderr
+"""
+
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+# Add scripts/ to path so the module can be imported directly.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "scripts"))
+
+import check_naming_convention as cnc  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def write_header(tmp_dir: Path, filename: str, content: str) -> Path:
+    p = tmp_dir / filename
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(textwrap.dedent(content), encoding="utf-8")
+    return p
+
+
+def run(argv: list[str]) -> int:
+    return cnc.main(argv)
+
+
+# ---------------------------------------------------------------------------
+# Test 1 -- I-prefix + non-virtual method body (Rule 1 fail)
+# ---------------------------------------------------------------------------
+
+def test_i_prefix_non_virtual_body_fails(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    """A class named IFoo that has a non-virtual method with a body must be flagged."""
+    d = tmp_path / "include" / "vigine"
+    write_header(
+        d,
+        "bad_i.h",
+        """\
+        #pragma once
+        namespace test {
+        class IMyMixin {
+          public:
+            virtual void pure() = 0;
+            void helper() { /* non-virtual body */ }
+        };
+        }
+        """,
+    )
+    code = run(["--path", str(d)])
+    captured = capsys.readouterr()
+    assert code == 1, "Expected exit 1 for I-prefix with non-virtual body"
+    assert "IMyMixin" in captured.out
+    assert "non-virtual" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Test 2 -- I-prefix + data member (Rule 1 fail)
+# ---------------------------------------------------------------------------
+
+def test_i_prefix_data_member_fails(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    """A class named IFoo that carries a data member must be flagged."""
+    d = tmp_path / "include" / "vigine"
+    write_header(
+        d,
+        "bad_data.h",
+        """\
+        #pragma once
+        namespace test {
+        class IStateful {
+          public:
+            virtual void work() = 0;
+          private:
+            int _value{0};
+        };
+        }
+        """,
+    )
+    code = run(["--path", str(d)])
+    captured = capsys.readouterr()
+    assert code == 1, "Expected exit 1 for I-prefix with data member"
+    assert "IStateful" in captured.out
+    assert "data member" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Test 3 -- Abstract-prefix + state (data member) passes (Rule 2 pass)
+# ---------------------------------------------------------------------------
+
+def test_abstract_prefix_with_state_passes(tmp_path: Path) -> None:
+    """A class named AbstractFoo with a data member is a valid Abstract class."""
+    d = tmp_path / "include" / "vigine"
+    write_header(
+        d,
+        "good_abstract.h",
+        """\
+        #pragma once
+        namespace test {
+        class AbstractBase {
+          public:
+            virtual void work() = 0;
+            virtual ~AbstractBase() = default;
+          protected:
+            AbstractBase() = default;
+          private:
+            int _id{0};
+        };
+        }
+        """,
+    )
+    code = run(["--path", str(d), "--quiet"])
+    assert code == 0, "Expected exit 0 for Abstract-prefix with data member"
+
+
+# ---------------------------------------------------------------------------
+# Test 4 -- Abstract-prefix + all pure-virtual, no state (Rule 2 fail)
+# ---------------------------------------------------------------------------
+
+def test_abstract_prefix_all_pure_fails(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    """A class named AbstractFoo where all methods are pure-virtual and there is
+    no data member should be flagged: it belongs to the I tier."""
+    d = tmp_path / "include" / "vigine"
+    write_header(
+        d,
+        "bad_abstract.h",
+        """\
+        #pragma once
+        namespace test {
+        class AbstractPure {
+          public:
+            virtual ~AbstractPure() = delete;
+            virtual void doA() = 0;
+            virtual void doB() = 0;
+        };
+        }
+        """,
+    )
+    code = run(["--path", str(d)])
+    captured = capsys.readouterr()
+    assert code == 1, "Expected exit 1 for Abstract-prefix that is fully pure-virtual"
+    assert "AbstractPure" in captured.out
+    assert "pure-virtual" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Test 5 -- Waiver token respected
+# ---------------------------------------------------------------------------
+
+def test_waiver_respected(tmp_path: Path) -> None:
+    """A class with the waiver token on its declaration line is not reported."""
+    d = tmp_path / "include" / "vigine"
+    write_header(
+        d,
+        "waived.h",
+        """\
+        #pragma once
+        namespace test {
+        class IHasState // INV-10 EXEMPTION: predates convention
+        {
+          public:
+            virtual void work() = 0;
+          private:
+            int _field{0};
+        };
+        }
+        """,
+    )
+    code = run(["--path", str(d), "--quiet"])
+    assert code == 0, "Expected exit 0 when waiver token is present"
+
+
+# ---------------------------------------------------------------------------
+# Test 6 -- Forward declarations are skipped
+# ---------------------------------------------------------------------------
+
+def test_forward_declaration_skipped(tmp_path: Path) -> None:
+    """A forward declaration 'class IFoo;' without a body must not be flagged."""
+    d = tmp_path / "include" / "vigine"
+    write_header(
+        d,
+        "forward.h",
+        """\
+        #pragma once
+        namespace test {
+        class IForward;
+        class AbstractForward;
+        }
+        """,
+    )
+    code = run(["--path", str(d), "--quiet"])
+    assert code == 0, "Expected exit 0 for forward declarations (no body)"
+
+
+# ---------------------------------------------------------------------------
+# Test 7 -- Nested classes are not re-checked as top-level
+# ---------------------------------------------------------------------------
+
+def test_nested_classes_not_rechecked(tmp_path: Path) -> None:
+    """A nested inner class inside a valid outer class body must not cause
+    a false positive on the outer class."""
+    d = tmp_path / "include" / "vigine"
+    write_header(
+        d,
+        "nested.h",
+        """\
+        #pragma once
+        namespace test {
+        class AbstractOuter {
+          public:
+            virtual void work() = 0;
+            // Inner class: would fail if checked at top level (no state),
+            // but it must be skipped because it is nested.
+            class InnerHelper {
+              public:
+                void doThing() {}
+            };
+          protected:
+            AbstractOuter() = default;
+            virtual ~AbstractOuter() = default;
+          private:
+            int _id{0};
+        };
+        }
+        """,
+    )
+    # AbstractOuter has _id (data member) -- should pass Rule 2.
+    code = run(["--path", str(d), "--quiet"])
+    assert code == 0, "Expected exit 0 -- nested classes must not cause false positives"
+
+
+# ---------------------------------------------------------------------------
+# Test 8 -- Missing path handled gracefully (exit 1, message on stderr)
+# ---------------------------------------------------------------------------
+
+def test_missing_path_graceful(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    """A non-existent --path exits 1 with a clear message (no crash)."""
+    nonexistent = tmp_path / "does_not_exist"
+    code = run(["--path", str(nonexistent)])
+    captured = capsys.readouterr()
+    assert code == 1, "Expected exit 1 for missing scan path"
+    assert "not found" in captured.err.lower() or "not found" in captured.out.lower()


### PR DESCRIPTION
Adds a static checker script that enforces the `I` / `Abstract` naming convention on public headers in `include/vigine/`.

**Rule 1 (I-prefix):** A class named `IFoo` must not have non-virtual methods with bodies or underscore-prefixed data members. If it does, it should be `AbstractFoo`.

**Rule 2 (Abstract-prefix):** A class named `AbstractFoo` must have at least one non-deleted method or a data member. If it is entirely pure-virtual with no state, it should be `IFoo`.

Special-member housekeeping (`= default` / `= delete` on destructors and copy/move) and virtual optional-hook methods are not counted as violations. A `// INV-10 EXEMPTION:` comment on the class declaration line suppresses the check for classes that predate the convention.

One exemption added to `ISignalEmiter` — it carries a proxy data member and predates the naming convention; rename tracked separately.

**Verification:**
- `python scripts/check_naming_convention.py --root .` exits 0 on the current tree.
- `pytest test/scripts/test_check_naming_convention.py -q` — 8/8 pass.

Closes #127