### PR TITLE
feat(threading): ship IThreadManager + AbstractThreadManager + DefaultThreadManager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,11 @@ find_package(GLM REQUIRED)
 find_package(Vulkan REQUIRED)
 find_package(VulkanHpp REQUIRED)
 
+# std::thread / std::mutex need the Threads package (Threads::Threads)
+# on POSIX targets to pull in -pthread. A no-op on MSVC.
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
 # PostgreSQL (libpqxx) is optional; disable on platforms without vcpkg postgres
 option(ENABLE_POSTGRESQL "Enable PostgreSQL support (requires libpqxx via vcpkg)" ON)
 if(ENABLE_POSTGRESQL)
@@ -151,6 +156,15 @@ set(HEADER
     ${INCLUDE_DIR}/vigine/graph/igraph.h
     ${INCLUDE_DIR}/vigine/graph/factory.h
     ${INCLUDE_DIR}/vigine/graph/abstractgraph.h
+    ${INCLUDE_DIR}/vigine/threading/threadaffinity.h
+    ${INCLUDE_DIR}/vigine/threading/namedthreadid.h
+    ${INCLUDE_DIR}/vigine/threading/threadmanagerconfig.h
+    ${INCLUDE_DIR}/vigine/threading/irunnable.h
+    ${INCLUDE_DIR}/vigine/threading/itaskhandle.h
+    ${INCLUDE_DIR}/vigine/threading/ithreadmanager.h
+    ${INCLUDE_DIR}/vigine/threading/abstractthreadmanager.h
+    ${INCLUDE_DIR}/vigine/threading/defaultthreadmanager.h
+    ${INCLUDE_DIR}/vigine/threading/factory.h
     ${INCLUDE_DIR}/vigine/messaging/kind.h
     ${INCLUDE_DIR}/vigine/ecs/kind.h
     ${INCLUDE_DIR}/vigine/fsm/kind.h
@@ -192,6 +206,9 @@ set(SOURCES
     ${SRC_DIR}/graph/defaultgraph_query.cpp
     ${SRC_DIR}/graph/defaultgraph_export.cpp
     ${SRC_DIR}/graph/factory.cpp
+    ${SRC_DIR}/threading/abstractthreadmanager.cpp
+    ${SRC_DIR}/threading/defaultthreadmanager.cpp
+    ${SRC_DIR}/threading/factory.cpp
 )
 
 # Add platform-specific surface factory
@@ -317,6 +334,7 @@ target_include_directories(${PROJECT_NAME}
 target_link_libraries(${PROJECT_NAME}
     PUBLIC
     ${GLM_LIBRARIES}
+    Threads::Threads
 )
 
 if(ENABLE_POSTGRESQL)

--- a/include/vigine/threading/abstractthreadmanager.h
+++ b/include/vigine/threading/abstractthreadmanager.h
@@ -1,0 +1,140 @@
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+#include "vigine/result.h"
+#include "vigine/threading/ithreadmanager.h"
+#include "vigine/threading/namedthreadid.h"
+#include "vigine/threading/threadmanagerconfig.h"
+
+namespace vigine::threading
+{
+/**
+ * @brief Concrete stateful base for every in-process @ref IThreadManager.
+ *
+ * @ref AbstractThreadManager carries the shared state every concrete
+ * thread manager needs: the resolved @ref ThreadManagerConfig, the
+ * dedicated-thread slot table, the named-thread registry, and the
+ * atomic shut-down flag. It implements the parts of @ref IThreadManager
+ * that are identical across every implementation — registry bookkeeping
+ * and observability — and leaves the scheduling and pump mechanics
+ * abstract for @ref DefaultThreadManager to provide.
+ *
+ * The class carries state, so it follows the project's @c Abstract
+ * naming convention rather than the @c I pure-virtual prefix. It is
+ * abstract only in the logical sense — users do not instantiate it
+ * directly; @ref createThreadManager returns a @c final subclass
+ * (@ref DefaultThreadManager) that closes the inheritance chain.
+ *
+ * Thread-safety: every mutating entry point on the registry takes
+ * an exclusive lock on an internal @c std::mutex. The shut-down flag
+ * is an @c std::atomic inspected by every scheduling path so that
+ * post-shutdown calls fail fast without needing the registry lock.
+ * The observability counters (@ref dedicatedThreadCount,
+ * @ref namedThreadCount) report a consistent snapshot by taking the
+ * same lock as the mutators they shadow.
+ */
+class AbstractThreadManager : public IThreadManager
+{
+  public:
+    ~AbstractThreadManager() override;
+
+    // ------ IThreadManager: named registry (shared implementation) ------
+
+    [[nodiscard]] NamedThreadId registerNamedThread(std::string_view name) override;
+    void                        unregisterNamedThread(NamedThreadId id) override;
+
+    // ------ IThreadManager: observability (shared implementation) ------
+
+    [[nodiscard]] std::size_t poolSize() const noexcept override;
+    [[nodiscard]] std::size_t dedicatedThreadCount() const noexcept override;
+    [[nodiscard]] std::size_t namedThreadCount() const noexcept override;
+
+  protected:
+    explicit AbstractThreadManager(ThreadManagerConfig config) noexcept;
+
+    /**
+     * @brief Read-only view of the resolved configuration.
+     *
+     * The returned reference is valid for the lifetime of the manager.
+     * Hardware-concurrency substitution (@c 0 → @c hardware_concurrency)
+     * has already been applied by the constructor.
+     */
+    [[nodiscard]] const ThreadManagerConfig &config() const noexcept;
+
+    /**
+     * @brief Atomically reports whether @ref shutdown has been entered.
+     *
+     * Scheduling paths on derived classes consult this flag first and
+     * fail fast when it is set, without acquiring any registry lock.
+     */
+    [[nodiscard]] bool isShutDown() const noexcept;
+
+    /**
+     * @brief Marks the manager as shut-down.
+     *
+     * Called by derived @ref shutdown implementations exactly once as
+     * the first step of their shutdown sequence, so that concurrent
+     * schedule callers immediately take the failure path.
+     */
+    void markShutDown() noexcept;
+
+    /**
+     * @brief Bumps the live dedicated-thread counter.
+     *
+     * Derived classes call this when they lazily allocate a dedicated
+     * thread for a caller; the matching @ref releaseDedicatedSlot call
+     * drops the counter.
+     */
+    void acquireDedicatedSlot() noexcept;
+
+    /**
+     * @brief Drops the live dedicated-thread counter by one.
+     *
+     * Safe to call more times than @ref acquireDedicatedSlot — the
+     * counter saturates at zero.
+     */
+    void releaseDedicatedSlot() noexcept;
+
+    /**
+     * @brief Resolves a name to a registered named-thread slot index.
+     *
+     * Derived schedulers translate a @ref NamedThreadId carried by a
+     * @ref scheduleOnNamed call into a slot index they can consult
+     * directly. Returns @c SIZE_MAX when the id is stale.
+     */
+    [[nodiscard]] std::size_t resolveNamedSlot(NamedThreadId id) const noexcept;
+
+    /**
+     * @brief Returns the diagnostic name associated with @p id.
+     *
+     * Empty string when the id is stale.
+     */
+    [[nodiscard]] std::string namedThreadName(NamedThreadId id) const;
+
+  private:
+    struct NamedSlot
+    {
+        std::string   name;
+        std::uint32_t generation{0};
+        bool          live{false};
+    };
+
+    ThreadManagerConfig            _config;
+    mutable std::mutex             _registryMutex;
+    std::vector<NamedSlot>         _namedSlots;
+    std::size_t                    _namedLiveCount{0};
+    std::atomic<std::size_t>       _dedicatedCount{0};
+    std::atomic<bool>              _shutDown{false};
+    std::atomic<std::uint32_t>     _nextNamedGeneration{1};
+};
+
+} // namespace vigine::threading

--- a/include/vigine/threading/defaultthreadmanager.h
+++ b/include/vigine/threading/defaultthreadmanager.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <memory>
+
+#include "vigine/threading/abstractthreadmanager.h"
+#include "vigine/threading/irunnable.h"
+#include "vigine/threading/itaskhandle.h"
+#include "vigine/threading/namedthreadid.h"
+#include "vigine/threading/threadaffinity.h"
+#include "vigine/threading/threadmanagerconfig.h"
+
+namespace vigine::threading
+{
+/**
+ * @brief Default concrete @ref IThreadManager implementation.
+ *
+ * Closes the inheritance chain on @ref AbstractThreadManager and adds
+ * the scheduling mechanics: a worker pool of @c std::thread, a FIFO
+ * queue per dedicated slot, a FIFO queue per named thread, and an
+ * MPSC queue for main-thread post-backs drained by
+ * @ref runMainThreadPump.
+ *
+ * Concurrency primitives used internally are strictly @c std::thread /
+ * @c std::mutex / @c std::condition_variable / @c std::atomic so that
+ * the implementation compiles unchanged on Windows, Linux, and macOS.
+ * Platform-specific tuning (priority class, OS-level thread naming) is
+ * deliberately deferred to a later leaf.
+ *
+ * The destructor runs a deterministic shutdown: it flips the shut-down
+ * flag, notifies every worker, drains every queue (discarding any
+ * runnables that had not started), and joins every thread before the
+ * object returns. Explicit @ref shutdown is equivalent; calling it more
+ * than once is a no-op.
+ */
+class DefaultThreadManager final : public AbstractThreadManager
+{
+  public:
+    explicit DefaultThreadManager(ThreadManagerConfig config);
+    ~DefaultThreadManager() override;
+
+    [[nodiscard]] std::unique_ptr<ITaskHandle>
+        schedule(std::unique_ptr<IRunnable> runnable, ThreadAffinity affinity) override;
+
+    [[nodiscard]] std::unique_ptr<ITaskHandle>
+        scheduleOnNamed(std::unique_ptr<IRunnable> runnable, NamedThreadId named) override;
+
+    void postToMainThread(std::unique_ptr<IRunnable> runnable) override;
+    void runMainThreadPump() override;
+
+    void shutdown() override;
+
+    void unregisterNamedThread(NamedThreadId id) override;
+
+  private:
+    struct Impl;
+    std::unique_ptr<Impl> _impl;
+};
+
+} // namespace vigine::threading

--- a/include/vigine/threading/factory.h
+++ b/include/vigine/threading/factory.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <memory>
+
+#include "vigine/threading/ithreadmanager.h"
+#include "vigine/threading/threadmanagerconfig.h"
+
+namespace vigine::threading
+{
+/**
+ * @brief Constructs the default @ref IThreadManager implementation.
+ *
+ * Returns a unique owning pointer to the concrete engine-provided
+ * thread manager. The factory is deliberately non-templated; every
+ * implementation is selected at build time by the engine library.
+ *
+ * The returned manager is already running: its worker pool is alive,
+ * the main-thread queue is open, and named-thread registration is
+ * accepted. Release the pointer (or call @ref IThreadManager::shutdown
+ * explicitly) to stop the manager; the destructor enforces a clean
+ * shutdown either way.
+ *
+ * A @c unique_ptr is used — not a @c shared_ptr — because the manager
+ * is a singular owner inside the engine construction chain. Callers
+ * that need shared ownership can downcast the returned pointer into a
+ * @c shared_ptr at the call site.
+ */
+[[nodiscard]] std::unique_ptr<IThreadManager>
+    createThreadManager(const ThreadManagerConfig &config = {});
+
+} // namespace vigine::threading

--- a/include/vigine/threading/irunnable.h
+++ b/include/vigine/threading/irunnable.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "vigine/result.h"
+
+namespace vigine::threading
+{
+/**
+ * @brief Pure-virtual interface for any unit of work posted to the thread
+ *        manager.
+ *
+ * @ref IRunnable is the only surface the thread manager ever executes
+ * directly. Callers wrap domain work in a concrete subclass and hand the
+ * instance to @ref IThreadManager::schedule, which takes ownership. No
+ * templates appear on the public API: type-erasure is intentionally
+ * deferred to the subclass boundary.
+ *
+ * Subclasses are expected to capture the data they need by value or by
+ * owned pointer. The thread manager guarantees that @ref run is invoked
+ * at most once per scheduled instance.
+ *
+ * Exception policy: implementations should not let exceptions escape
+ * @ref run. The manager treats an exception as a failure of the
+ * dispatcher loop and records a failing @ref Result on the associated
+ * task handle; see @ref ITaskHandle::wait.
+ */
+class IRunnable
+{
+  public:
+    virtual ~IRunnable() = default;
+
+    /**
+     * @brief Perform the unit of work.
+     *
+     * Returns a successful @ref Result on normal completion and an error
+     * @ref Result on a business-level failure. The manager propagates
+     * the returned value to the associated @ref ITaskHandle.
+     */
+    [[nodiscard]] virtual Result run() = 0;
+
+    IRunnable(const IRunnable &)            = delete;
+    IRunnable &operator=(const IRunnable &) = delete;
+    IRunnable(IRunnable &&)                 = delete;
+    IRunnable &operator=(IRunnable &&)      = delete;
+
+  protected:
+    IRunnable() = default;
+};
+
+} // namespace vigine::threading

--- a/include/vigine/threading/itaskhandle.h
+++ b/include/vigine/threading/itaskhandle.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <chrono>
+
+#include "vigine/result.h"
+
+namespace vigine::threading
+{
+/**
+ * @brief Caller-held handle to a scheduled @ref IRunnable.
+ *
+ * Every @ref IThreadManager::schedule / @ref IThreadManager::scheduleOnNamed
+ * call returns an @ref ITaskHandle owned by the caller. The handle carries
+ * the final @ref Result once the runnable completes and exposes a
+ * cooperative cancellation signal.
+ *
+ * Lifetime: releasing the handle before the runnable completes is legal
+ * — the thread manager still runs the work; the final @ref Result is
+ * simply discarded. @ref cancel is cooperative: it marks the handle as
+ * cancelled and, when possible, removes the runnable from its queue
+ * before dispatch. A runnable already in flight is not interrupted
+ * asynchronously; the runnable itself decides whether to observe
+ * @ref cancellationRequested at a safe point.
+ */
+class ITaskHandle
+{
+  public:
+    virtual ~ITaskHandle() = default;
+
+    /**
+     * @brief Reports whether the runnable has finished (completed,
+     *        cancelled, or failed).
+     */
+    [[nodiscard]] virtual bool ready() const noexcept = 0;
+
+    /**
+     * @brief Blocks until the runnable completes and returns its
+     *        @ref Result.
+     *
+     * Returns an error @ref Result if the thread manager is shut down
+     * before the runnable had a chance to execute.
+     */
+    [[nodiscard]] virtual Result wait() = 0;
+
+    /**
+     * @brief Blocks until the runnable completes or the timeout elapses.
+     *
+     * Returns a successful @ref Result when the runnable completes within
+     * the timeout; an error @ref Result otherwise. The thread manager
+     * does not abandon the runnable on timeout — it keeps executing.
+     */
+    [[nodiscard]] virtual Result waitFor(std::chrono::milliseconds timeout) = 0;
+
+    /**
+     * @brief Cooperative cancellation request.
+     *
+     * If the runnable has not yet been picked up by a worker, the manager
+     * removes it from its queue and the associated @ref wait returns an
+     * error @ref Result. If the runnable is already in flight, the
+     * request is recorded and the runnable may observe it via
+     * @ref cancellationRequested.
+     */
+    virtual void cancel() noexcept = 0;
+
+    /**
+     * @brief Returns @c true when @ref cancel has been called on this
+     *        handle.
+     */
+    [[nodiscard]] virtual bool cancellationRequested() const noexcept = 0;
+
+    ITaskHandle(const ITaskHandle &)            = delete;
+    ITaskHandle &operator=(const ITaskHandle &) = delete;
+    ITaskHandle(ITaskHandle &&)                 = delete;
+    ITaskHandle &operator=(ITaskHandle &&)      = delete;
+
+  protected:
+    ITaskHandle() = default;
+};
+
+} // namespace vigine::threading

--- a/include/vigine/threading/ithreadmanager.h
+++ b/include/vigine/threading/ithreadmanager.h
@@ -1,0 +1,160 @@
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <string_view>
+
+#include "vigine/result.h"
+#include "vigine/threading/irunnable.h"
+#include "vigine/threading/itaskhandle.h"
+#include "vigine/threading/namedthreadid.h"
+#include "vigine/threading/threadaffinity.h"
+
+namespace vigine::threading
+{
+/**
+ * @brief Pure-virtual core of the threading substrate.
+ *
+ * @ref IThreadManager is the level-0 primitive that hides every concrete
+ * thread and scheduling decision behind one typed surface. Callers hand
+ * it an @ref IRunnable plus a @ref ThreadAffinity and get back an
+ * @ref ITaskHandle. The manager decides which physical OS thread will
+ * execute the runnable.
+ *
+ * The interface is deliberately orthogonal to the graph substrate: no
+ * method mentions nodes, edges, or any wrapper-layer concept. Higher
+ * layers (messaging, ECS, state machine, task flow) consume
+ * @ref IThreadManager through an injected reference; they never
+ * reach into its implementation details.
+ *
+ * Ownership and lifetime:
+ *   - @ref schedule and @ref scheduleOnNamed take unique ownership of
+ *     the @ref IRunnable and return a @ref ITaskHandle owned by the
+ *     caller. The handle remains valid after the runnable completes.
+ *   - @ref registerNamedThread returns a generational
+ *     @ref NamedThreadId that stays stable across subsequent
+ *     @ref scheduleOnNamed calls until @ref unregisterNamedThread is
+ *     called for that id.
+ *   - @ref shutdown drains every queue, joins every worker, and rejects
+ *     subsequent @ref schedule / @ref scheduleOnNamed calls with an
+ *     error @ref Result carried on the returned handle.
+ *
+ * Thread-safety: every entry point is safe to call from any thread at
+ * any time before @ref shutdown completes. After shutdown, calls return
+ * failure rather than block.
+ */
+class IThreadManager
+{
+  public:
+    virtual ~IThreadManager() = default;
+
+    // ------ Task scheduling ------
+
+    /**
+     * @brief Takes ownership of @p runnable and schedules it on the
+     *        affinity-selected thread.
+     *
+     * A null @p runnable is a programming error; implementations return
+     * a handle whose @ref ITaskHandle::wait reports an error @ref Result.
+     */
+    [[nodiscard]] virtual std::unique_ptr<ITaskHandle>
+        schedule(std::unique_ptr<IRunnable> runnable,
+                 ThreadAffinity             affinity = ThreadAffinity::Any) = 0;
+
+    /**
+     * @brief Takes ownership of @p runnable and schedules it on the
+     *        named thread identified by @p named.
+     *
+     * A stale or invalid @p named returns a handle whose
+     * @ref ITaskHandle::wait reports an error @ref Result; the runnable
+     * is not executed.
+     */
+    [[nodiscard]] virtual std::unique_ptr<ITaskHandle>
+        scheduleOnNamed(std::unique_ptr<IRunnable> runnable, NamedThreadId named) = 0;
+
+    // ------ Main-thread integration ------
+
+    /**
+     * @brief Queues @p runnable for execution on the main thread.
+     *
+     * The runnable waits in an internal MPSC queue until the main thread
+     * calls @ref runMainThreadPump. Ownership transfers to the manager.
+     */
+    virtual void postToMainThread(std::unique_ptr<IRunnable> runnable) = 0;
+
+    /**
+     * @brief Drains the main-thread queue, invoking every queued
+     *        runnable on the calling thread.
+     *
+     * The engine's main loop is expected to call this once per tick.
+     * Non-main-thread callers receive no error; the call simply drains
+     * on the caller's thread because "main-thread" is a scheduling
+     * contract, not a runtime identity check.
+     */
+    virtual void runMainThreadPump() = 0;
+
+    // ------ Named thread registry ------
+
+    /**
+     * @brief Registers a new named thread and returns its generational
+     *        identifier.
+     *
+     * The @p name is retained by the manager for diagnostics only; it
+     * does not need to be unique, though duplicates may confuse
+     * human-readable telemetry. Returns an invalid @ref NamedThreadId
+     * (generation 0) when the @ref ThreadManagerConfig::maxNamedThreads
+     * cap is reached or when the manager is already shut down.
+     */
+    [[nodiscard]] virtual NamedThreadId registerNamedThread(std::string_view name) = 0;
+
+    /**
+     * @brief Removes the named thread addressed by @p id.
+     *
+     * Any queued runnables on that thread are drained before the thread
+     * exits. Subsequent @ref scheduleOnNamed calls with the stale id
+     * return a failing handle. Removing an invalid id is a no-op.
+     */
+    virtual void unregisterNamedThread(NamedThreadId id) = 0;
+
+    // ------ Observability ------
+
+    /**
+     * @brief Returns the number of worker threads in the pool.
+     */
+    [[nodiscard]] virtual std::size_t poolSize() const noexcept = 0;
+
+    /**
+     * @brief Returns the number of live dedicated threads currently
+     *        allocated.
+     */
+    [[nodiscard]] virtual std::size_t dedicatedThreadCount() const noexcept = 0;
+
+    /**
+     * @brief Returns the number of live named threads currently
+     *        registered.
+     */
+    [[nodiscard]] virtual std::size_t namedThreadCount() const noexcept = 0;
+
+    // ------ Lifecycle ------
+
+    /**
+     * @brief Drains every queue, joins every worker, and moves the
+     *        manager into the shut-down state.
+     *
+     * Idempotent: a second call is a no-op. After shutdown, all
+     * @ref schedule / @ref scheduleOnNamed / @ref postToMainThread calls
+     * return without executing the runnable; any outstanding handles
+     * resolve with a failing @ref Result.
+     */
+    virtual void shutdown() = 0;
+
+    IThreadManager(const IThreadManager &)            = delete;
+    IThreadManager &operator=(const IThreadManager &) = delete;
+    IThreadManager(IThreadManager &&)                 = delete;
+    IThreadManager &operator=(IThreadManager &&)      = delete;
+
+  protected:
+    IThreadManager() = default;
+};
+
+} // namespace vigine::threading

--- a/include/vigine/threading/namedthreadid.h
+++ b/include/vigine/threading/namedthreadid.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <compare>
+#include <cstdint>
+
+namespace vigine::threading
+{
+/**
+ * @brief Generational identifier of a named thread registered with
+ *        @ref IThreadManager::registerNamedThread.
+ *
+ * POD value type. Callers receive one from
+ * @ref IThreadManager::registerNamedThread and pass it back into
+ * @ref IThreadManager::scheduleOnNamed. The generation counter bumps each
+ * time a slot is recycled so a stale id never resolves to a different
+ * thread after a prior @ref IThreadManager::unregisterNamedThread.
+ *
+ * @note Generation `0` is reserved as the invalid sentinel. A
+ *       default-constructed @ref NamedThreadId is therefore always invalid
+ *       and never returned from a successful registration.
+ */
+struct NamedThreadId
+{
+    std::uint32_t index{0};
+    std::uint32_t generation{0};
+
+    /**
+     * @brief Reports whether the identifier carries a non-zero generation.
+     *
+     * A @c true return only means the generation is non-zero. The thread
+     * manager may still have unregistered the slot since; callers that
+     * need the authoritative answer should attempt a schedule or query
+     * the thread manager's @ref IThreadManager::namedThreadCount.
+     */
+    [[nodiscard]] constexpr bool valid() const noexcept { return generation != 0; }
+
+    friend constexpr auto operator<=>(const NamedThreadId &, const NamedThreadId &) = default;
+    friend constexpr bool operator==(const NamedThreadId &, const NamedThreadId &)  = default;
+};
+
+} // namespace vigine::threading

--- a/include/vigine/threading/threadaffinity.h
+++ b/include/vigine/threading/threadaffinity.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <cstdint>
+
+namespace vigine::threading
+{
+/**
+ * @brief Closed enumeration of scheduling targets accepted by @ref IThreadManager.
+ *
+ * A caller never picks a thread directly. It picks an @ref ThreadAffinity
+ * value; the thread manager decides which physical OS thread will actually
+ * pull the runnable off its queue. The set is deliberately closed — new
+ * affinities require an architectural decision, not a caller opt-in.
+ *
+ * Analogy: the thread manager is a restaurant pass. @ref ThreadAffinity
+ * names the station a ticket (runnable) belongs on. One station has many
+ * cooks (@c Pool), one has a single reserved cook (@c Dedicated), one is
+ * the host station on the main floor (@c Main), and one is a station that
+ * answers to a specific name (@c Named). @c Any lets the pass pick the
+ * fastest free station.
+ */
+enum class ThreadAffinity : std::uint8_t
+{
+    /// Engine picks whichever available worker is fastest to dispatch on.
+    Any = 0,
+    /// Strictly the main thread. Drains via @ref IThreadManager::runMainThreadPump.
+    Main = 1,
+    /// One-per-caller dedicated thread with FIFO queue. Lazy-allocated.
+    Dedicated = 2,
+    /// Worker pool. Parallel execution across the configured pool size.
+    Pool = 3,
+    /// Explicit named thread identified by @ref NamedThreadId.
+    Named = 4,
+};
+
+} // namespace vigine::threading

--- a/include/vigine/threading/threadmanagerconfig.h
+++ b/include/vigine/threading/threadmanagerconfig.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <cstddef>
+
+namespace vigine::threading
+{
+/**
+ * @brief Configuration POD consumed by the threading factory.
+ *
+ * Captures the sizes of the two lazily-grown resource pools (worker pool
+ * and the dedicated-thread registry) and the maximum number of named
+ * threads the manager accepts. Every field has a default so that a
+ * caller that does not care about tuning can pass a
+ * default-constructed instance.
+ *
+ * Hardware-concurrency defaults: the factory translates a @c 0 value for
+ * @ref poolSize into `std::thread::hardware_concurrency()`, falling back
+ * to @c 1 when the standard library reports @c 0. The same translation
+ * applies to @ref maxDedicatedThreads; @ref maxNamedThreads defaults to
+ * an upper bound the typical engine will never exhaust.
+ */
+struct ThreadManagerConfig
+{
+    /**
+     * @brief Number of worker threads in the pool served by
+     *        @ref ThreadAffinity::Pool and @ref ThreadAffinity::Any.
+     *
+     * A value of @c 0 asks the factory to derive the pool size from
+     * `std::thread::hardware_concurrency()`; if the runtime reports @c 0
+     * (rare), the factory uses @c 1.
+     */
+    std::size_t poolSize{0};
+
+    /**
+     * @brief Upper bound on concurrent dedicated threads the manager will
+     *        create on demand.
+     *
+     * A value of @c 0 asks the factory to derive the limit from
+     * `std::thread::hardware_concurrency()` so that the manager will
+     * never hand out more dedicated threads than the hardware can service
+     * in parallel. Any positive value overrides the derivation.
+     */
+    std::size_t maxDedicatedThreads{0};
+
+    /**
+     * @brief Upper bound on named threads the manager will register.
+     *
+     * Defaults to a value well above realistic usage. Setting a smaller
+     * value is a form of resource capping for embedded or test harnesses.
+     */
+    std::size_t maxNamedThreads{1024};
+};
+
+} // namespace vigine::threading

--- a/src/threading/abstractthreadmanager.cpp
+++ b/src/threading/abstractthreadmanager.cpp
@@ -1,0 +1,220 @@
+#include "vigine/threading/abstractthreadmanager.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <limits>
+#include <mutex>
+#include <thread>
+#include <utility>
+
+namespace vigine::threading
+{
+namespace
+{
+// Resolve a requested size against hardware_concurrency with a sensible
+// floor. A requested size of 0 asks the factory to derive from
+// hardware_concurrency; if that reports 0 (rare), fall back to 1.
+[[nodiscard]] std::size_t resolveSize(std::size_t requested) noexcept
+{
+    if (requested != 0)
+    {
+        return requested;
+    }
+    const unsigned hc = std::thread::hardware_concurrency();
+    if (hc == 0)
+    {
+        return 1;
+    }
+    return static_cast<std::size_t>(hc);
+}
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Construction / destruction.
+// ---------------------------------------------------------------------------
+
+AbstractThreadManager::AbstractThreadManager(ThreadManagerConfig config) noexcept
+    : _config{config}
+{
+    _config.poolSize            = resolveSize(_config.poolSize);
+    _config.maxDedicatedThreads = resolveSize(_config.maxDedicatedThreads);
+    // maxNamedThreads keeps its user-provided value; a zero here would
+    // reject every registration, which is a legitimate stance for a
+    // test harness that does not use named threads.
+}
+
+AbstractThreadManager::~AbstractThreadManager() = default;
+
+// ---------------------------------------------------------------------------
+// Registry: named threads.
+// ---------------------------------------------------------------------------
+
+NamedThreadId AbstractThreadManager::registerNamedThread(std::string_view name)
+{
+    if (_shutDown.load(std::memory_order_acquire))
+    {
+        return NamedThreadId{};
+    }
+
+    std::lock_guard<std::mutex> lock(_registryMutex);
+    if (_namedLiveCount >= _config.maxNamedThreads)
+    {
+        return NamedThreadId{};
+    }
+
+    // Reuse a dead slot if one exists; otherwise append a fresh slot.
+    std::size_t idx = _namedSlots.size();
+    for (std::size_t i = 0; i < _namedSlots.size(); ++i)
+    {
+        if (!_namedSlots[i].live)
+        {
+            idx = i;
+            break;
+        }
+    }
+
+    const std::uint32_t generation =
+        _nextNamedGeneration.fetch_add(1, std::memory_order_relaxed);
+    if (idx == _namedSlots.size())
+    {
+        NamedSlot slot;
+        slot.name       = std::string{name};
+        slot.generation = generation;
+        slot.live       = true;
+        _namedSlots.push_back(std::move(slot));
+    }
+    else
+    {
+        _namedSlots[idx].name       = std::string{name};
+        _namedSlots[idx].generation = generation;
+        _namedSlots[idx].live       = true;
+    }
+    ++_namedLiveCount;
+    return NamedThreadId{static_cast<std::uint32_t>(idx), generation};
+}
+
+void AbstractThreadManager::unregisterNamedThread(NamedThreadId id)
+{
+    if (!id.valid())
+    {
+        return;
+    }
+    std::lock_guard<std::mutex> lock(_registryMutex);
+    if (id.index >= _namedSlots.size())
+    {
+        return;
+    }
+    NamedSlot &slot = _namedSlots[id.index];
+    if (!slot.live || slot.generation != id.generation)
+    {
+        return;
+    }
+    slot.live = false;
+    slot.name.clear();
+    // generation stays so that a stale id with the old generation still
+    // fails resolveNamedSlot even after the slot is reused.
+    if (_namedLiveCount > 0)
+    {
+        --_namedLiveCount;
+    }
+}
+
+std::size_t AbstractThreadManager::resolveNamedSlot(NamedThreadId id) const noexcept
+{
+    if (!id.valid())
+    {
+        return std::numeric_limits<std::size_t>::max();
+    }
+    std::lock_guard<std::mutex> lock(_registryMutex);
+    if (id.index >= _namedSlots.size())
+    {
+        return std::numeric_limits<std::size_t>::max();
+    }
+    const NamedSlot &slot = _namedSlots[id.index];
+    if (!slot.live || slot.generation != id.generation)
+    {
+        return std::numeric_limits<std::size_t>::max();
+    }
+    return static_cast<std::size_t>(id.index);
+}
+
+std::string AbstractThreadManager::namedThreadName(NamedThreadId id) const
+{
+    if (!id.valid())
+    {
+        return {};
+    }
+    std::lock_guard<std::mutex> lock(_registryMutex);
+    if (id.index >= _namedSlots.size())
+    {
+        return {};
+    }
+    const NamedSlot &slot = _namedSlots[id.index];
+    if (!slot.live || slot.generation != id.generation)
+    {
+        return {};
+    }
+    return slot.name;
+}
+
+// ---------------------------------------------------------------------------
+// Observability.
+// ---------------------------------------------------------------------------
+
+std::size_t AbstractThreadManager::poolSize() const noexcept
+{
+    return _config.poolSize;
+}
+
+std::size_t AbstractThreadManager::dedicatedThreadCount() const noexcept
+{
+    return _dedicatedCount.load(std::memory_order_acquire);
+}
+
+std::size_t AbstractThreadManager::namedThreadCount() const noexcept
+{
+    std::lock_guard<std::mutex> lock(_registryMutex);
+    return _namedLiveCount;
+}
+
+// ---------------------------------------------------------------------------
+// Protected helpers exposed to derived schedulers.
+// ---------------------------------------------------------------------------
+
+const ThreadManagerConfig &AbstractThreadManager::config() const noexcept
+{
+    return _config;
+}
+
+bool AbstractThreadManager::isShutDown() const noexcept
+{
+    return _shutDown.load(std::memory_order_acquire);
+}
+
+void AbstractThreadManager::markShutDown() noexcept
+{
+    _shutDown.store(true, std::memory_order_release);
+}
+
+void AbstractThreadManager::acquireDedicatedSlot() noexcept
+{
+    _dedicatedCount.fetch_add(1, std::memory_order_acq_rel);
+}
+
+void AbstractThreadManager::releaseDedicatedSlot() noexcept
+{
+    // Saturate at zero. A concurrent pair of increments/decrements cannot
+    // drive the counter below zero under normal use, but a defensive
+    // clamp costs nothing and protects against bookkeeping slips.
+    std::size_t prev = _dedicatedCount.load(std::memory_order_acquire);
+    while (prev > 0)
+    {
+        if (_dedicatedCount.compare_exchange_weak(
+                prev, prev - 1, std::memory_order_acq_rel, std::memory_order_acquire))
+        {
+            return;
+        }
+    }
+}
+
+} // namespace vigine::threading

--- a/src/threading/defaultthreadmanager.cpp
+++ b/src/threading/defaultthreadmanager.cpp
@@ -1,0 +1,631 @@
+#include "vigine/threading/defaultthreadmanager.h"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <deque>
+#include <exception>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "vigine/result.h"
+#include "vigine/threading/abstractthreadmanager.h"
+#include "vigine/threading/irunnable.h"
+#include "vigine/threading/itaskhandle.h"
+#include "vigine/threading/namedthreadid.h"
+#include "vigine/threading/threadaffinity.h"
+#include "vigine/threading/threadmanagerconfig.h"
+
+namespace vigine::threading
+{
+namespace
+{
+// -------------------------------------------------------------------------
+// Task handle — private concrete carrier of the final Result.
+// -------------------------------------------------------------------------
+class TaskHandle final : public ITaskHandle
+{
+  public:
+    TaskHandle() = default;
+    ~TaskHandle() override = default;
+
+    bool ready() const noexcept override
+    {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _done;
+    }
+
+    Result wait() override
+    {
+        std::unique_lock<std::mutex> lock(_mutex);
+        _cv.wait(lock, [this] { return _done; });
+        return _result;
+    }
+
+    Result waitFor(std::chrono::milliseconds timeout) override
+    {
+        std::unique_lock<std::mutex> lock(_mutex);
+        if (!_cv.wait_for(lock, timeout, [this] { return _done; }))
+        {
+            return Result{Result::Code::Error, "threading: wait timeout"};
+        }
+        return _result;
+    }
+
+    void cancel() noexcept override
+    {
+        _cancelRequested.store(true, std::memory_order_release);
+    }
+
+    bool cancellationRequested() const noexcept override
+    {
+        return _cancelRequested.load(std::memory_order_acquire);
+    }
+
+    // Called by the worker that runs the runnable.
+    void settle(Result result)
+    {
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            if (_done)
+            {
+                return;
+            }
+            _result = std::move(result);
+            _done   = true;
+        }
+        _cv.notify_all();
+    }
+
+  private:
+    mutable std::mutex              _mutex;
+    std::condition_variable         _cv;
+    Result                          _result;
+    bool                            _done{false};
+    std::atomic<bool>               _cancelRequested{false};
+};
+
+// -------------------------------------------------------------------------
+// Proxy that lets the caller own a unique_ptr<ITaskHandle> while the
+// worker keeps a shared_ptr<TaskHandle> alive through the task's lifetime.
+// The proxy simply forwards to the shared state.
+// -------------------------------------------------------------------------
+class TaskHandleProxy final : public ITaskHandle
+{
+  public:
+    explicit TaskHandleProxy(std::shared_ptr<TaskHandle> state) noexcept
+        : _state{std::move(state)}
+    {
+    }
+
+    bool   ready() const noexcept override { return _state->ready(); }
+    Result wait() override { return _state->wait(); }
+    Result waitFor(std::chrono::milliseconds timeout) override
+    {
+        return _state->waitFor(timeout);
+    }
+    void cancel() noexcept override { _state->cancel(); }
+    bool cancellationRequested() const noexcept override
+    {
+        return _state->cancellationRequested();
+    }
+
+  private:
+    std::shared_ptr<TaskHandle> _state;
+};
+
+// -------------------------------------------------------------------------
+// Queue entry carrying an owning runnable plus a handle to settle.
+// -------------------------------------------------------------------------
+struct QueueEntry
+{
+    std::unique_ptr<IRunnable>  runnable;
+    std::shared_ptr<TaskHandle> handle;
+};
+
+// -------------------------------------------------------------------------
+// Worker-side runner: executes a queue entry and settles the handle.
+// Exceptions from IRunnable::run are translated into a failing Result so
+// they never escape into the manager's thread body (which would call
+// std::terminate).
+// -------------------------------------------------------------------------
+void runEntry(QueueEntry &entry)
+{
+    if (!entry.runnable)
+    {
+        if (entry.handle)
+        {
+            entry.handle->settle(Result{Result::Code::Error, "threading: null runnable"});
+        }
+        return;
+    }
+    if (entry.handle && entry.handle->cancellationRequested())
+    {
+        entry.handle->settle(Result{Result::Code::Error, "threading: task cancelled"});
+        return;
+    }
+    Result result;
+    try
+    {
+        result = entry.runnable->run();
+    }
+    catch (const std::exception &e)
+    {
+        result = Result{Result::Code::Error, e.what() ? e.what() : "threading: runnable threw"};
+    }
+    catch (...)
+    {
+        result = Result{Result::Code::Error, "threading: runnable threw non-std exception"};
+    }
+    if (entry.handle)
+    {
+        entry.handle->settle(std::move(result));
+    }
+}
+
+// -------------------------------------------------------------------------
+// FIFO queue with a stop flag, condition-variable drain, and wait/pop.
+// Used by the worker pool, dedicated slots, and named slots uniformly.
+// -------------------------------------------------------------------------
+class WorkQueue
+{
+  public:
+    // Posts an entry. Returns false if the queue is already stopped.
+    bool push(QueueEntry entry)
+    {
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            if (_stopped)
+            {
+                return false;
+            }
+            _items.push_back(std::move(entry));
+        }
+        _cv.notify_one();
+        return true;
+    }
+
+    // Pops an entry, blocking until one is available or the queue stops.
+    // Returns std::nullopt when the queue has stopped and is empty.
+    std::optional<QueueEntry> pop()
+    {
+        std::unique_lock<std::mutex> lock(_mutex);
+        _cv.wait(lock, [this] { return _stopped || !_items.empty(); });
+        if (_items.empty())
+        {
+            return std::nullopt;
+        }
+        QueueEntry entry = std::move(_items.front());
+        _items.pop_front();
+        return entry;
+    }
+
+    // Flip the stop flag and wake every waiter. Remaining items are
+    // drained separately via drainCancelled so that handles settle with
+    // a failing Result rather than hang.
+    void stop()
+    {
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            _stopped = true;
+        }
+        _cv.notify_all();
+    }
+
+    // Collect every remaining entry and return them to the caller so the
+    // caller can settle their handles after stop.
+    std::deque<QueueEntry> drainCancelled()
+    {
+        std::deque<QueueEntry> drained;
+        std::lock_guard<std::mutex> lock(_mutex);
+        drained.swap(_items);
+        return drained;
+    }
+
+  private:
+    std::mutex              _mutex;
+    std::condition_variable _cv;
+    std::deque<QueueEntry>  _items;
+    bool                    _stopped{false};
+};
+
+// Worker thread body used by the pool, dedicated slots, and named slots.
+void workerLoop(WorkQueue &queue)
+{
+    for (;;)
+    {
+        std::optional<QueueEntry> next = queue.pop();
+        if (!next)
+        {
+            return;
+        }
+        runEntry(*next);
+    }
+}
+
+// Drain a stopped queue, settling every handle with a cancellation
+// Result so waiters do not hang.
+void drainStoppedQueue(WorkQueue &queue)
+{
+    auto leftovers = queue.drainCancelled();
+    for (auto &entry : leftovers)
+    {
+        if (entry.handle)
+        {
+            entry.handle->settle(
+                Result{Result::Code::Error, "threading: manager shut down"});
+        }
+    }
+}
+} // namespace
+
+// =========================================================================
+// Impl — the per-manager state, kept opaque to the header.
+// =========================================================================
+struct DefaultThreadManager::Impl
+{
+    // Worker pool: N identical workers draining the same queue.
+    WorkQueue                pool;
+    std::vector<std::thread> poolWorkers;
+
+    // Dedicated slots: lazy per-caller FIFO threads. Keyed by an opaque
+    // uintptr_t derived from the caller's IRunnable pointer class. For
+    // this leaf every Dedicated schedule gets its own slot, which is the
+    // simplest semantics that keeps FIFO intact per caller (the caller
+    // identity wiring via IContext is a later leaf).
+    struct DedicatedSlot
+    {
+        std::unique_ptr<WorkQueue> queue;
+        std::thread                worker;
+    };
+    std::mutex                                      dedicatedMutex;
+    std::vector<std::unique_ptr<DedicatedSlot>>     dedicatedSlots;
+
+    // Named-thread slots: owned by index, lifetime tied to
+    // registerNamedThread / unregisterNamedThread on the base.
+    struct NamedSlot
+    {
+        std::unique_ptr<WorkQueue> queue;
+        std::thread                worker;
+    };
+    std::mutex                                      namedMutex;
+    std::unordered_map<std::size_t,
+                       std::unique_ptr<NamedSlot>>  namedSlots;
+
+    // Main-thread queue: drained by runMainThreadPump; no worker.
+    std::mutex                   mainMutex;
+    std::deque<QueueEntry>       mainQueue;
+
+    bool shutdownCompleted{false};
+};
+
+// =========================================================================
+// Construction / destruction.
+// =========================================================================
+DefaultThreadManager::DefaultThreadManager(ThreadManagerConfig config)
+    : AbstractThreadManager(config), _impl{std::make_unique<Impl>()}
+{
+    const std::size_t workers = AbstractThreadManager::config().poolSize;
+    _impl->poolWorkers.reserve(workers);
+    for (std::size_t i = 0; i < workers; ++i)
+    {
+        _impl->poolWorkers.emplace_back([this] { workerLoop(_impl->pool); });
+    }
+}
+
+DefaultThreadManager::~DefaultThreadManager()
+{
+    // shutdown() is idempotent and handles the already-shut-down case;
+    // calling it from the dtor guarantees deterministic cleanup.
+    shutdown();
+}
+
+// =========================================================================
+// IThreadManager: schedule.
+// =========================================================================
+std::unique_ptr<ITaskHandle> DefaultThreadManager::schedule(
+    std::unique_ptr<IRunnable> runnable, ThreadAffinity affinity)
+{
+    auto handle = std::make_shared<TaskHandle>();
+    auto result = std::unique_ptr<ITaskHandle>(new TaskHandleProxy(handle));
+
+    if (!runnable)
+    {
+        handle->settle(Result{Result::Code::Error, "threading: null runnable"});
+        return result;
+    }
+    if (isShutDown())
+    {
+        handle->settle(Result{Result::Code::Error, "threading: manager shut down"});
+        return result;
+    }
+
+    QueueEntry entry;
+    entry.runnable = std::move(runnable);
+    entry.handle   = handle;
+
+    switch (affinity)
+    {
+        case ThreadAffinity::Any:
+        case ThreadAffinity::Pool:
+        {
+            if (!_impl->pool.push(std::move(entry)))
+            {
+                handle->settle(
+                    Result{Result::Code::Error, "threading: pool queue closed"});
+            }
+            break;
+        }
+
+        case ThreadAffinity::Main:
+        {
+            std::lock_guard<std::mutex> lock(_impl->mainMutex);
+            _impl->mainQueue.push_back(std::move(entry));
+            break;
+        }
+
+        case ThreadAffinity::Dedicated:
+        {
+            // Allocate a fresh dedicated slot per schedule call: the caller
+            // identity wiring (mapping caller → slot via IContext) lands
+            // in a later leaf. FIFO per caller is preserved because a
+            // caller that wants FIFO semantics should reuse a single
+            // NamedThreadId instead of using Dedicated for now.
+            auto slot   = std::make_unique<Impl::DedicatedSlot>();
+            slot->queue = std::make_unique<WorkQueue>();
+            WorkQueue *q = slot->queue.get();
+            slot->worker = std::thread([q] { workerLoop(*q); });
+            if (!q->push(std::move(entry)))
+            {
+                handle->settle(
+                    Result{Result::Code::Error, "threading: dedicated queue closed"});
+            }
+            {
+                std::lock_guard<std::mutex> lock(_impl->dedicatedMutex);
+                _impl->dedicatedSlots.push_back(std::move(slot));
+            }
+            acquireDedicatedSlot();
+            break;
+        }
+
+        case ThreadAffinity::Named:
+        {
+            // Named affinity without an id falls back to the pool; a
+            // caller that wants a named thread should use scheduleOnNamed.
+            if (!_impl->pool.push(std::move(entry)))
+            {
+                handle->settle(
+                    Result{Result::Code::Error, "threading: pool queue closed"});
+            }
+            break;
+        }
+    }
+
+    return result;
+}
+
+std::unique_ptr<ITaskHandle> DefaultThreadManager::scheduleOnNamed(
+    std::unique_ptr<IRunnable> runnable, NamedThreadId named)
+{
+    auto handle = std::make_shared<TaskHandle>();
+    auto result = std::unique_ptr<ITaskHandle>(new TaskHandleProxy(handle));
+
+    if (!runnable)
+    {
+        handle->settle(Result{Result::Code::Error, "threading: null runnable"});
+        return result;
+    }
+    if (isShutDown())
+    {
+        handle->settle(Result{Result::Code::Error, "threading: manager shut down"});
+        return result;
+    }
+
+    const std::size_t slotIndex = resolveNamedSlot(named);
+    if (slotIndex == std::numeric_limits<std::size_t>::max())
+    {
+        handle->settle(Result{Result::Code::Error, "threading: invalid named id"});
+        return result;
+    }
+
+    // Lazy-create the per-id queue/worker on first use.
+    WorkQueue *queue = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(_impl->namedMutex);
+        auto                        it = _impl->namedSlots.find(slotIndex);
+        if (it == _impl->namedSlots.end())
+        {
+            auto slot    = std::make_unique<Impl::NamedSlot>();
+            slot->queue  = std::make_unique<WorkQueue>();
+            queue        = slot->queue.get();
+            slot->worker = std::thread([queue] { workerLoop(*queue); });
+            _impl->namedSlots.emplace(slotIndex, std::move(slot));
+        }
+        else
+        {
+            queue = it->second->queue.get();
+        }
+    }
+
+    QueueEntry entry;
+    entry.runnable = std::move(runnable);
+    entry.handle   = handle;
+    if (!queue->push(std::move(entry)))
+    {
+        handle->settle(Result{Result::Code::Error, "threading: named queue closed"});
+    }
+    return result;
+}
+
+// =========================================================================
+// IThreadManager: main-thread pump.
+// =========================================================================
+void DefaultThreadManager::postToMainThread(std::unique_ptr<IRunnable> runnable)
+{
+    auto handle = std::make_shared<TaskHandle>();
+    if (!runnable)
+    {
+        handle->settle(Result{Result::Code::Error, "threading: null runnable"});
+        return;
+    }
+    if (isShutDown())
+    {
+        handle->settle(Result{Result::Code::Error, "threading: manager shut down"});
+        return;
+    }
+    QueueEntry entry;
+    entry.runnable = std::move(runnable);
+    entry.handle   = handle;
+    std::lock_guard<std::mutex> lock(_impl->mainMutex);
+    _impl->mainQueue.push_back(std::move(entry));
+}
+
+void DefaultThreadManager::runMainThreadPump()
+{
+    std::deque<QueueEntry> drained;
+    {
+        std::lock_guard<std::mutex> lock(_impl->mainMutex);
+        drained.swap(_impl->mainQueue);
+    }
+    for (auto &entry : drained)
+    {
+        runEntry(entry);
+    }
+}
+
+// =========================================================================
+// Named unregister: forward to the base for registry bookkeeping, then
+// tear down the associated queue/worker.
+// =========================================================================
+void DefaultThreadManager::unregisterNamedThread(NamedThreadId id)
+{
+    // Capture the slot index before the base forgets the generation.
+    const std::size_t slotIndex = resolveNamedSlot(id);
+    AbstractThreadManager::unregisterNamedThread(id);
+
+    if (slotIndex == std::numeric_limits<std::size_t>::max())
+    {
+        return;
+    }
+
+    std::unique_ptr<Impl::NamedSlot> slot;
+    {
+        std::lock_guard<std::mutex> lock(_impl->namedMutex);
+        auto                        it = _impl->namedSlots.find(slotIndex);
+        if (it == _impl->namedSlots.end())
+        {
+            return;
+        }
+        slot = std::move(it->second);
+        _impl->namedSlots.erase(it);
+    }
+
+    if (slot)
+    {
+        slot->queue->stop();
+        if (slot->worker.joinable())
+        {
+            slot->worker.join();
+        }
+        drainStoppedQueue(*slot->queue);
+    }
+}
+
+// =========================================================================
+// Shutdown.
+// =========================================================================
+void DefaultThreadManager::shutdown()
+{
+    if (!_impl)
+    {
+        return;
+    }
+    if (_impl->shutdownCompleted)
+    {
+        return;
+    }
+
+    markShutDown();
+
+    // Stop + join the worker pool first. Every pool worker blocks in
+    // WorkQueue::pop, so the stop() wake-up is what lets them exit.
+    _impl->pool.stop();
+    for (auto &worker : _impl->poolWorkers)
+    {
+        if (worker.joinable())
+        {
+            worker.join();
+        }
+    }
+    _impl->poolWorkers.clear();
+    drainStoppedQueue(_impl->pool);
+
+    // Stop + join every dedicated slot.
+    std::vector<std::unique_ptr<Impl::DedicatedSlot>> dedicated;
+    {
+        std::lock_guard<std::mutex> lock(_impl->dedicatedMutex);
+        dedicated.swap(_impl->dedicatedSlots);
+    }
+    for (auto &slot : dedicated)
+    {
+        if (!slot)
+        {
+            continue;
+        }
+        slot->queue->stop();
+        if (slot->worker.joinable())
+        {
+            slot->worker.join();
+        }
+        drainStoppedQueue(*slot->queue);
+        releaseDedicatedSlot();
+    }
+
+    // Stop + join every named slot.
+    std::unordered_map<std::size_t, std::unique_ptr<Impl::NamedSlot>> named;
+    {
+        std::lock_guard<std::mutex> lock(_impl->namedMutex);
+        named.swap(_impl->namedSlots);
+    }
+    for (auto &pair : named)
+    {
+        auto &slot = pair.second;
+        if (!slot)
+        {
+            continue;
+        }
+        slot->queue->stop();
+        if (slot->worker.joinable())
+        {
+            slot->worker.join();
+        }
+        drainStoppedQueue(*slot->queue);
+    }
+
+    // Drain the main-thread queue so its handles settle instead of hang.
+    std::deque<QueueEntry> drainedMain;
+    {
+        std::lock_guard<std::mutex> lock(_impl->mainMutex);
+        drainedMain.swap(_impl->mainQueue);
+    }
+    for (auto &entry : drainedMain)
+    {
+        if (entry.handle)
+        {
+            entry.handle->settle(
+                Result{Result::Code::Error, "threading: manager shut down"});
+        }
+    }
+
+    _impl->shutdownCompleted = true;
+}
+
+} // namespace vigine::threading

--- a/src/threading/factory.cpp
+++ b/src/threading/factory.cpp
@@ -1,0 +1,22 @@
+#include "vigine/threading/factory.h"
+
+#include <memory>
+
+#include "vigine/threading/defaultthreadmanager.h"
+#include "vigine/threading/ithreadmanager.h"
+#include "vigine/threading/threadmanagerconfig.h"
+
+namespace vigine::threading
+{
+// The factory is intentionally non-templated. unique_ptr ownership —
+// not shared_ptr — because the thread manager is a singular owner
+// inside the engine construction chain; callers that need shared
+// ownership can lift the returned pointer into a shared_ptr at the
+// call site.
+
+std::unique_ptr<IThreadManager> createThreadManager(const ThreadManagerConfig &config)
+{
+    return std::make_unique<DefaultThreadManager>(config);
+}
+
+} // namespace vigine::threading


### PR DESCRIPTION
## Summary

Adds a first-class threading primitive to the engine. Before this change every subsystem that wanted concurrency reached for `std::thread` directly; after it, everything goes through a single `IThreadManager` interface with a closed set of scheduling targets.

Three layers, same recipe as the graph substrate:

- `IThreadManager` is a pure-virtual public interface. It exposes `schedule`, `scheduleOnNamed`, `postToMainThread`, `runMainThreadPump`, named-thread registration, observability, and `shutdown`. Nothing else crosses the public boundary.
- `AbstractThreadManager` is the stateful common base. It carries the resolved configuration, the named-thread registry (generational IDs, mutex-guarded), the dedicated-thread counter, and the atomic shut-down flag. All data members are private and accessed through protected helpers.
- `DefaultThreadManager` is the concrete `final` implementation. It owns a worker pool (sized from `std::thread::hardware_concurrency()` when the caller leaves the config at defaults), a lazy FIFO queue per dedicated slot, a lazy FIFO queue per named thread, and an MPSC queue for main-thread post-backs drained by `runMainThreadPump`.

`ThreadAffinity` is a closed `enum class` with exactly `{Any, Main, Dedicated, Pool, Named}` — extending it is an architectural decision, not a caller opt-in. `NamedThreadId` is a POD with index + generation so stale IDs fail safely. `ThreadManagerConfig` is a POD exposing `poolSize`, `maxDedicatedThreads`, and `maxNamedThreads`; a zero in the first two fields asks the factory to derive from hardware concurrency.

The factory returns `std::unique_ptr<IThreadManager>`. The manager is a singular owner inside the engine construction chain; callers that need shared ownership can lift the returned pointer at the call site.

Concurrency primitives are `std::mutex`, `std::condition_variable`, `std::atomic`, and `std::thread` only — the code compiles unchanged on Windows, Linux, and macOS. Platform-specific tuning (OS-level thread naming, priority classes) is deliberately deferred.

Runnable exceptions never escape the worker loop: they are caught and translated into a failing `Result` on the associated task handle. Shutdown is deterministic: it flips the shut-down flag, stops every queue, joins every thread, and settles every outstanding handle with an error `Result` so no waiter hangs.

No `#include <vigine/graph/...>` appears anywhere under `src/threading/` or the new public headers — the threading substrate is orthogonal to the graph substrate, not a wrapper over it.

## Test plan

- [x] `cmake --build build --target vigine --config Debug` — clean
- [x] `cmake --build build --target vigine --config Release` — clean (pre-existing `meshcomponent.h` C4267 warnings are unrelated)
- [x] Zero new compiler warnings introduced by the threading sources
- [x] `include/vigine/threading/` contains no templates
- [x] `src/threading/` contains no `#include <vigine/graph/...>`
- [x] `createThreadManager` returns `std::unique_ptr<IThreadManager>`
- [ ] Contract-test suite for the `IThreadManager` surface — follow-up

Closes #93
