### PR TITLE
feat(payload): ship IPayloadRegistry + PayloadTypeId + reserved ranges + Result::DuplicatePayloadId

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,10 @@ set(HEADER
     ${INCLUDE_DIR}/vigine/threading/abstractthreadmanager.h
     ${INCLUDE_DIR}/vigine/threading/defaultthreadmanager.h
     ${INCLUDE_DIR}/vigine/threading/factory.h
+    ${INCLUDE_DIR}/vigine/payload/payloadtypeid.h
+    ${INCLUDE_DIR}/vigine/payload/payloadrange.h
+    ${INCLUDE_DIR}/vigine/payload/ipayloadregistry.h
+    ${INCLUDE_DIR}/vigine/payload/factory.h
     ${INCLUDE_DIR}/vigine/messaging/kind.h
     ${INCLUDE_DIR}/vigine/ecs/kind.h
     ${INCLUDE_DIR}/vigine/fsm/kind.h
@@ -209,6 +213,11 @@ set(SOURCES
     ${SRC_DIR}/threading/abstractthreadmanager.cpp
     ${SRC_DIR}/threading/defaultthreadmanager.cpp
     ${SRC_DIR}/threading/factory.cpp
+    ${SRC_DIR}/payload/abstractpayloadregistry.h
+    ${SRC_DIR}/payload/abstractpayloadregistry.cpp
+    ${SRC_DIR}/payload/defaultpayloadregistry.h
+    ${SRC_DIR}/payload/defaultpayloadregistry.cpp
+    ${SRC_DIR}/payload/factory.cpp
 )
 
 # Add platform-specific surface factory

--- a/include/vigine/payload/factory.h
+++ b/include/vigine/payload/factory.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <memory>
+
+#include "vigine/payload/ipayloadregistry.h"
+
+namespace vigine::payload
+{
+/**
+ * @brief Constructs the default @ref IPayloadRegistry implementation.
+ *
+ * Returns a unique owning pointer to the concrete engine-provided
+ * registry. The factory is deliberately non-templated; every
+ * implementation is selected at build time by the engine library.
+ *
+ * The returned registry has its four engine-bundled ranges (Control,
+ * System, SystemExt, Reserved — see @ref payloadrange.h) pre-registered
+ * under the `vigine.core` owner, so first-use lookups for any engine
+ * identifier succeed without any application wiring.
+ *
+ * A @c unique_ptr is used — not a @c shared_ptr — because the registry
+ * is a singular owner inside the engine construction chain. Callers
+ * that need shared ownership can lift the returned pointer into a
+ * @c shared_ptr at the call site.
+ */
+[[nodiscard]] std::unique_ptr<IPayloadRegistry> createPayloadRegistry();
+
+} // namespace vigine::payload

--- a/include/vigine/payload/ipayloadregistry.h
+++ b/include/vigine/payload/ipayloadregistry.h
@@ -1,0 +1,101 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "vigine/payload/payloadtypeid.h"
+#include "vigine/result.h"
+
+namespace vigine::payload
+{
+/**
+ * @brief Pure-virtual hybrid registry for @ref PayloadTypeId ranges.
+ *
+ * @ref IPayloadRegistry governs the 32-bit payload-id space. The engine
+ * pre-registers four ranges at construction (Control, System, SystemExt,
+ * Reserved — see @ref payloadrange.h); application code registers
+ * additional ranges at runtime before first use. Every registration is
+ * validated against the current table: overlap with an already-registered
+ * range is rejected with @ref Result::Code::DuplicatePayloadId; a request
+ * outside the valid 32-bit window or straddling the Reserved/User gap is
+ * rejected with @ref Result::Code::OutOfRange.
+ *
+ * Thread-safety: implementations must be safe to call from any thread.
+ * Mutating entry points take an exclusive lock on an internal
+ * reader-writer mutex; read-only entry points take a shared lock so
+ * lookups on the hot path do not block each other. A visitor that
+ * re-enters the registry from inside @ref resolve or @ref isRegistered
+ * does not deadlock because those paths hold only a shared lock.
+ *
+ * Ownership: identifiers and owner strings are copied in by value at
+ * registration time; callers never hand lifetime to the registry.
+ */
+class IPayloadRegistry
+{
+  public:
+    virtual ~IPayloadRegistry() = default;
+
+    /**
+     * @brief Registers `[min, max]` (inclusive on both ends) under
+     *        @p owner.
+     *
+     * Returns a success @ref Result when the range was installed cleanly.
+     * Returns @ref Result::Code::DuplicatePayloadId when any identifier
+     * in the requested range is already covered by another registration.
+     * Returns @ref Result::Code::OutOfRange when @p min > @p max, when
+     * the range crosses the Reserved/User gap, or when the range
+     * straddles the engine-bundled half and the user-registered half.
+     *
+     * @p owner is copied; an empty @p owner is a programming error and
+     * the call is rejected with @ref Result::Code::OutOfRange.
+     */
+    [[nodiscard]] virtual Result
+        registerRange(PayloadTypeId    min,
+                      PayloadTypeId    max,
+                      std::string_view owner) = 0;
+
+    /**
+     * @brief Returns the owner string associated with the range that
+     *        contains @p id.
+     *
+     * Returns @c std::nullopt when @p id is not covered by any
+     * registered range. Thread-safe: safe to call concurrently with
+     * @ref registerRange and with other @ref resolve / @ref isRegistered
+     * calls.
+     */
+    [[nodiscard]] virtual std::optional<std::string>
+        resolve(PayloadTypeId id) const = 0;
+
+    /**
+     * @brief Returns @c true when @p id is covered by any registered
+     *        range.
+     *
+     * Shorthand for @ref resolve with an @c .has_value() check; exists
+     * so that hot paths avoid allocating the result string.
+     */
+    [[nodiscard]] virtual bool
+        isRegistered(PayloadTypeId id) const noexcept = 0;
+
+    /**
+     * @brief Removes every range owned by @p owner, freeing those
+     *        identifiers for future registration.
+     *
+     * Returns a success @ref Result even when @p owner holds no ranges;
+     * callers drive this on dynamic-unload paths and do not need to
+     * first check whether anything is registered.
+     */
+    [[nodiscard]] virtual Result
+        unregister(std::string_view owner) = 0;
+
+    IPayloadRegistry(const IPayloadRegistry &)            = delete;
+    IPayloadRegistry &operator=(const IPayloadRegistry &) = delete;
+    IPayloadRegistry(IPayloadRegistry &&)                 = delete;
+    IPayloadRegistry &operator=(IPayloadRegistry &&)      = delete;
+
+  protected:
+    IPayloadRegistry() = default;
+};
+
+} // namespace vigine::payload

--- a/include/vigine/payload/payloadrange.h
+++ b/include/vigine/payload/payloadrange.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <cstdint>
+
+namespace vigine::payload
+{
+/**
+ * @brief Reserved payload-id range constants.
+ *
+ * The 32-bit @c PayloadTypeId space is split into two halves:
+ *
+ *   - `[0 .. 0xFFFF]` — engine-bundled. Pre-registered at registry
+ *     construction; owned by the engine. This half is further carved
+ *     into four sub-ranges so that different engine concerns do not
+ *     collide with each other:
+ *       * Control    `[0x0000 .. 0x00FF]` — low-volume engine control
+ *                       payloads (lifecycle, shutdown, tick).
+ *       * System     `[0x0100 .. 0x0FFF]` — core engine subsystems
+ *                       (graph, threading, ECS, state machine,
+ *                       task flow).
+ *       * SystemExt  `[0x1000 .. 0x7FFF]` — extension subsystems
+ *                       shipped with the engine but not part of the
+ *                       core surface.
+ *       * Reserved   `[0x8000 .. 0xFFFF]` — reserved for future engine
+ *                       use. Application code must not register into
+ *                       this range.
+ *
+ *   - `[0x10000 .. 0xFFFFFFFF]` — user-registered. Available for
+ *     application-defined payload types. Every registration in this
+ *     half is performed at runtime through
+ *     @ref IPayloadRegistry::registerRange.
+ *
+ * The `0x8000..0xFFFF` range and the `0x10000` boundary are deliberately
+ * disjoint: identifiers in `[0x10000 ..)` are legal user territory; the
+ * small gap between the Reserved end and the User begin exists only
+ * because the constants split naturally at the 16-bit boundary.
+ */
+
+inline constexpr std::uint32_t kControlBegin   = 0x0000u;
+inline constexpr std::uint32_t kControlEnd     = 0x00FFu;
+
+inline constexpr std::uint32_t kSystemBegin    = 0x0100u;
+inline constexpr std::uint32_t kSystemEnd      = 0x0FFFu;
+
+inline constexpr std::uint32_t kSystemExtBegin = 0x1000u;
+inline constexpr std::uint32_t kSystemExtEnd   = 0x7FFFu;
+
+inline constexpr std::uint32_t kReservedBegin  = 0x8000u;
+inline constexpr std::uint32_t kReservedEnd    = 0xFFFFu;
+
+inline constexpr std::uint32_t kUserBegin      = 0x10000u;
+
+/**
+ * @brief Stable owner label used for every engine-bundled range
+ *        pre-registered at registry construction. Application code can
+ *        inspect the owner string returned by
+ *        @ref IPayloadRegistry::resolve to tell engine-owned identifiers
+ *        apart from user-owned ones.
+ */
+inline constexpr const char *kEngineOwner = "vigine.core";
+
+} // namespace vigine::payload

--- a/include/vigine/payload/payloadtypeid.h
+++ b/include/vigine/payload/payloadtypeid.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <cstdint>
+
+namespace vigine::payload
+{
+/**
+ * @brief Opaque identifier for a payload type carried through the engine.
+ *
+ * @ref PayloadTypeId is a thin value type wrapping a @c std::uint32_t. The
+ * wrapper exists so that the public surface never passes a bare integer
+ * that could be confused with an entity id, a node id, or any other
+ * numeric identifier. The underlying @c value field is accessible for
+ * hashing, logging, and static-cast discipline at integration points.
+ *
+ * Ranges carved out of the 32-bit space are declared in
+ * @ref payloadrange.h. Concrete identifiers are issued by the engine and
+ * by application code and registered with @ref IPayloadRegistry before
+ * first use.
+ *
+ * The type is a plain aggregate: trivially copyable, comparable, and
+ * usable as a key in ordered and hash-based associative containers.
+ */
+struct PayloadTypeId
+{
+    std::uint32_t value{0};
+
+    [[nodiscard]] friend constexpr bool operator==(PayloadTypeId lhs,
+                                                   PayloadTypeId rhs) noexcept
+    {
+        return lhs.value == rhs.value;
+    }
+
+    [[nodiscard]] friend constexpr bool operator!=(PayloadTypeId lhs,
+                                                   PayloadTypeId rhs) noexcept
+    {
+        return lhs.value != rhs.value;
+    }
+
+    [[nodiscard]] friend constexpr bool operator<(PayloadTypeId lhs,
+                                                  PayloadTypeId rhs) noexcept
+    {
+        return lhs.value < rhs.value;
+    }
+};
+
+} // namespace vigine::payload

--- a/include/vigine/result.h
+++ b/include/vigine/result.h
@@ -13,7 +13,12 @@ class Result
     enum class Code
     {
         Success,
-        Error
+        Error,
+        // Appended for the payload-id registry (R.1.3.1). Append-only:
+        // existing values above keep their numeric positions so that
+        // callers that persist or serialise Result codes are unaffected.
+        DuplicatePayloadId,
+        OutOfRange
     };
 
     Result();

--- a/src/payload/abstractpayloadregistry.cpp
+++ b/src/payload/abstractpayloadregistry.cpp
@@ -1,0 +1,172 @@
+#include "payload/abstractpayloadregistry.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <shared_mutex>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include "vigine/payload/payloadrange.h"
+#include "vigine/payload/payloadtypeid.h"
+#include "vigine/result.h"
+
+namespace vigine::payload
+{
+namespace
+{
+// Returns true when the range `[aMin, aMax]` overlaps with `[bMin, bMax]`
+// assuming both are non-empty and inclusive on both ends.
+[[nodiscard]] bool rangesOverlap(std::uint32_t aMin,
+                                 std::uint32_t aMax,
+                                 std::uint32_t bMin,
+                                 std::uint32_t bMax) noexcept
+{
+    return aMin <= bMax && bMin <= aMax;
+}
+
+// Returns true when the range `[min, max]` sits entirely inside the
+// engine-bundled half (`[0, kReservedEnd]`).
+[[nodiscard]] bool isEntirelyEngineHalf(std::uint32_t min,
+                                        std::uint32_t max) noexcept
+{
+    return max <= kReservedEnd;
+}
+
+// Returns true when the range `[min, max]` sits entirely inside the
+// user-registered half (`[kUserBegin, ..)`).
+[[nodiscard]] bool isEntirelyUserHalf(std::uint32_t min,
+                                      std::uint32_t max) noexcept
+{
+    return min >= kUserBegin;
+}
+
+} // namespace
+
+AbstractPayloadRegistry::AbstractPayloadRegistry() = default;
+
+AbstractPayloadRegistry::~AbstractPayloadRegistry() = default;
+
+void AbstractPayloadRegistry::bootstrapEngineRanges()
+{
+    // Runs on the constructing thread before the instance is handed
+    // out, so no locking is needed. The helper still goes through
+    // registerRangeLocked so every invariant check lives in one place.
+    static_cast<void>(registerRangeLocked(kControlBegin, kControlEnd, kEngineOwner));
+    static_cast<void>(registerRangeLocked(kSystemBegin, kSystemEnd, kEngineOwner));
+    static_cast<void>(registerRangeLocked(kSystemExtBegin, kSystemExtEnd, kEngineOwner));
+    static_cast<void>(registerRangeLocked(kReservedBegin, kReservedEnd, kEngineOwner));
+}
+
+Result AbstractPayloadRegistry::registerRange(PayloadTypeId    min,
+                                              PayloadTypeId    max,
+                                              std::string_view owner)
+{
+    std::unique_lock<std::shared_mutex> lock(_mutex);
+    return registerRangeLocked(min.value, max.value, owner);
+}
+
+Result AbstractPayloadRegistry::registerRangeLocked(std::uint32_t    min,
+                                                    std::uint32_t    max,
+                                                    std::string_view owner)
+{
+    if (owner.empty())
+    {
+        return Result{Result::Code::OutOfRange, "empty owner string"};
+    }
+    if (min > max)
+    {
+        return Result{Result::Code::OutOfRange, "inverted range (min > max)"};
+    }
+    // Reject ranges that span the reserved/user gap or that bridge the
+    // engine-bundled half and the user-registered half. A valid range is
+    // either entirely in the engine half or entirely in the user half.
+    const bool engineSide = isEntirelyEngineHalf(min, max);
+    const bool userSide   = isEntirelyUserHalf(min, max);
+    if (!engineSide && !userSide)
+    {
+        return Result{Result::Code::OutOfRange,
+                      "range crosses the engine/user boundary"};
+    }
+
+    if (overlapsAnyLocked(min, max))
+    {
+        return Result{Result::Code::DuplicatePayloadId,
+                      "range overlaps an already-registered range"};
+    }
+
+    RangeEntry entry;
+    entry.min   = min;
+    entry.max   = max;
+    entry.owner = std::string{owner};
+    _ranges.push_back(std::move(entry));
+    return Result{};
+}
+
+std::optional<std::string>
+    AbstractPayloadRegistry::resolve(PayloadTypeId id) const
+{
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    const RangeEntry *entry = findContainingLocked(id.value);
+    if (entry == nullptr)
+    {
+        return std::nullopt;
+    }
+    return entry->owner;
+}
+
+bool AbstractPayloadRegistry::isRegistered(PayloadTypeId id) const noexcept
+{
+    try
+    {
+        std::shared_lock<std::shared_mutex> lock(_mutex);
+        return findContainingLocked(id.value) != nullptr;
+    }
+    catch (...)
+    {
+        // Honouring the noexcept surface on the pure-virtual: a failed
+        // shared-lock acquisition translates to a conservative "not
+        // registered" answer rather than a crash.
+        return false;
+    }
+}
+
+Result AbstractPayloadRegistry::unregister(std::string_view owner)
+{
+    std::unique_lock<std::shared_mutex> lock(_mutex);
+    _ranges.erase(
+        std::remove_if(_ranges.begin(), _ranges.end(),
+                       [&](const RangeEntry &entry) { return entry.owner == owner; }),
+        _ranges.end());
+    return Result{};
+}
+
+bool AbstractPayloadRegistry::overlapsAnyLocked(std::uint32_t min,
+                                                std::uint32_t max) const noexcept
+{
+    for (const RangeEntry &entry : _ranges)
+    {
+        if (rangesOverlap(entry.min, entry.max, min, max))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+const AbstractPayloadRegistry::RangeEntry *
+    AbstractPayloadRegistry::findContainingLocked(std::uint32_t value) const noexcept
+{
+    for (const RangeEntry &entry : _ranges)
+    {
+        if (entry.min <= value && value <= entry.max)
+        {
+            return &entry;
+        }
+    }
+    return nullptr;
+}
+
+} // namespace vigine::payload

--- a/src/payload/abstractpayloadregistry.h
+++ b/src/payload/abstractpayloadregistry.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <shared_mutex>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "vigine/payload/ipayloadregistry.h"
+#include "vigine/payload/payloadtypeid.h"
+#include "vigine/result.h"
+
+namespace vigine::payload
+{
+/**
+ * @brief Concrete stateful base for every in-process @ref IPayloadRegistry.
+ *
+ * @ref AbstractPayloadRegistry carries the shared state every concrete
+ * payload registry needs: the reader-writer mutex, the range table, and
+ * the overlap-detection helpers. It implements the full
+ * @ref IPayloadRegistry surface so that every concrete subclass
+ * (currently @c DefaultPayloadRegistry) only has to choose its storage
+ * representation — the lookup and validation logic is identical across
+ * implementations and lives here.
+ *
+ * The class carries state, so it follows the project's @c Abstract
+ * naming convention rather than the @c I pure-virtual prefix. It is
+ * abstract only in the logical sense — users do not instantiate it
+ * directly; @ref createPayloadRegistry returns a @c final subclass that
+ * closes the inheritance chain.
+ *
+ * Thread-safety: every mutating entry point takes an exclusive lock on
+ * an internal @c std::shared_mutex; every read-only entry point takes
+ * a shared lock. Concurrent @c resolve / @c isRegistered calls do not
+ * block each other.
+ */
+class AbstractPayloadRegistry : public IPayloadRegistry
+{
+  public:
+    ~AbstractPayloadRegistry() override;
+
+    [[nodiscard]] Result
+        registerRange(PayloadTypeId    min,
+                      PayloadTypeId    max,
+                      std::string_view owner) override;
+
+    [[nodiscard]] std::optional<std::string>
+        resolve(PayloadTypeId id) const override;
+
+    [[nodiscard]] bool
+        isRegistered(PayloadTypeId id) const noexcept override;
+
+    [[nodiscard]] Result
+        unregister(std::string_view owner) override;
+
+  protected:
+    AbstractPayloadRegistry();
+
+    /**
+     * @brief Pre-registers the four engine-bundled ranges under the
+     *        `vigine.core` owner.
+     *
+     * Invoked by the constructor of the concrete subclass so that the
+     * vtable is fully formed by the time the initial registrations run.
+     * Because the call happens on the constructing thread before the
+     * instance is handed out, no locking is required.
+     */
+    void bootstrapEngineRanges();
+
+  private:
+    struct RangeEntry
+    {
+        std::uint32_t min{0};
+        std::uint32_t max{0};
+        std::string   owner;
+    };
+
+    // Internal registration helper that assumes the exclusive lock is
+    // already held. Used both by @ref registerRange and by
+    // @ref bootstrapEngineRanges (the bootstrap path is single-threaded
+    // but funnelling through one insertion routine keeps the invariants
+    // in exactly one place).
+    [[nodiscard]] Result registerRangeLocked(std::uint32_t    min,
+                                             std::uint32_t    max,
+                                             std::string_view owner);
+
+    [[nodiscard]] bool overlapsAnyLocked(std::uint32_t min,
+                                         std::uint32_t max) const noexcept;
+
+    [[nodiscard]] const RangeEntry *
+        findContainingLocked(std::uint32_t value) const noexcept;
+
+    mutable std::shared_mutex _mutex;
+    std::vector<RangeEntry>   _ranges;
+};
+
+} // namespace vigine::payload

--- a/src/payload/defaultpayloadregistry.cpp
+++ b/src/payload/defaultpayloadregistry.cpp
@@ -1,0 +1,10 @@
+#include "payload/defaultpayloadregistry.h"
+
+namespace vigine::payload
+{
+DefaultPayloadRegistry::DefaultPayloadRegistry()
+{
+    bootstrapEngineRanges();
+}
+
+} // namespace vigine::payload

--- a/src/payload/defaultpayloadregistry.h
+++ b/src/payload/defaultpayloadregistry.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "payload/abstractpayloadregistry.h"
+
+namespace vigine::payload
+{
+/**
+ * @brief Default concrete implementation of @ref IPayloadRegistry.
+ *
+ * Closes the inheritance chain on @ref AbstractPayloadRegistry and
+ * contributes no additional storage or behaviour of its own; every
+ * mechanic lives on the base. The @c final keyword prevents further
+ * subclassing so that @ref createPayloadRegistry has one well-defined
+ * concrete return type.
+ *
+ * The constructor calls @ref AbstractPayloadRegistry::bootstrapEngineRanges
+ * so that the four engine-bundled ranges are pre-registered by the time
+ * the instance is returned to the caller.
+ */
+class DefaultPayloadRegistry final : public AbstractPayloadRegistry
+{
+  public:
+    DefaultPayloadRegistry();
+    ~DefaultPayloadRegistry() override = default;
+};
+
+} // namespace vigine::payload

--- a/src/payload/factory.cpp
+++ b/src/payload/factory.cpp
@@ -1,0 +1,19 @@
+#include "vigine/payload/factory.h"
+
+#include <memory>
+
+#include "payload/defaultpayloadregistry.h"
+
+namespace vigine::payload
+{
+// Factory returns a unique_ptr because the payload registry is a
+// singular owner inside the engine construction chain. Callers that
+// need shared ownership can lift the returned pointer into a shared_ptr
+// at the call site.
+
+std::unique_ptr<IPayloadRegistry> createPayloadRegistry()
+{
+    return std::make_unique<DefaultPayloadRegistry>();
+}
+
+} // namespace vigine::payload

--- a/src/result.cpp
+++ b/src/result.cpp
@@ -26,7 +26,12 @@ bool Result::isSuccess() const { return _code == Code::Success; }
 
 Result::Code Result::code() const { return _code; }
 
-bool Result::isError() const { return _code == Code::Error; }
+// Any non-Success code is treated as an error, so that codes appended
+// after the initial `Success` / `Error` pair (e.g. DuplicatePayloadId,
+// OutOfRange introduced with the payload-id registry) are reported as
+// errors by isError() without requiring every caller to know the full
+// code list.
+bool Result::isError() const { return _code != Code::Success; }
 
 const std::string &Result::message() const { return _message; }
 } // namespace vigine

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -102,3 +102,38 @@ gtest_discover_tests(${GRAPH_CONTRACT_TARGET}
     DISCOVERY_MODE PRE_TEST
 )
 
+# ====================== Payload Registry Smoke Target =======================
+# Smoke coverage for IPayloadRegistry: factory ownership, engine
+# bootstrap, happy-path user registration, overlap and out-of-range
+# rejection, unregister, and a concurrent register/resolve case that
+# the thread sanitiser verifies under -fsanitize=thread.
+set(PAYLOAD_SMOKE_TARGET payload-smoke)
+
+add_executable(${PAYLOAD_SMOKE_TARGET}
+    payload/smoke_test.cpp
+)
+
+target_include_directories(${PAYLOAD_SMOKE_TARGET}
+    PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(${PAYLOAD_SMOKE_TARGET}
+    PRIVATE
+    gtest
+    gtest_main
+    vigine
+    ${GLM_LIBRARIES}
+)
+
+set_target_properties(${PAYLOAD_SMOKE_TARGET} PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
+gtest_discover_tests(${PAYLOAD_SMOKE_TARGET}
+    PROPERTIES LABELS "payload-registry-smoke"
+    DISCOVERY_TIMEOUT 60
+    DISCOVERY_MODE PRE_TEST
+)
+

--- a/test/payload/smoke_test.cpp
+++ b/test/payload/smoke_test.cpp
@@ -1,0 +1,193 @@
+#include "vigine/payload/factory.h"
+#include "vigine/payload/ipayloadregistry.h"
+#include "vigine/payload/payloadrange.h"
+#include "vigine/payload/payloadtypeid.h"
+#include "vigine/result.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <memory>
+#include <optional>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace vigine;
+using namespace vigine::payload;
+
+TEST(DefaultPayloadRegistrySmoke, FactoryReturnsUniquePtr)
+{
+    std::unique_ptr<IPayloadRegistry> registry = createPayloadRegistry();
+    ASSERT_NE(registry, nullptr);
+}
+
+TEST(DefaultPayloadRegistrySmoke, EngineRangesPreRegisteredAtBootstrap)
+{
+    std::unique_ptr<IPayloadRegistry> registry = createPayloadRegistry();
+
+    EXPECT_TRUE(registry->isRegistered(PayloadTypeId{kControlBegin}));
+    EXPECT_TRUE(registry->isRegistered(PayloadTypeId{kControlEnd}));
+    EXPECT_TRUE(registry->isRegistered(PayloadTypeId{kSystemBegin}));
+    EXPECT_TRUE(registry->isRegistered(PayloadTypeId{kSystemEnd}));
+    EXPECT_TRUE(registry->isRegistered(PayloadTypeId{kSystemExtBegin}));
+    EXPECT_TRUE(registry->isRegistered(PayloadTypeId{kSystemExtEnd}));
+    EXPECT_TRUE(registry->isRegistered(PayloadTypeId{kReservedBegin}));
+    EXPECT_TRUE(registry->isRegistered(PayloadTypeId{kReservedEnd}));
+
+    // Identifiers above the Reserved end but below kUserBegin fall in
+    // the gap and must stay unregistered.
+    EXPECT_FALSE(registry->isRegistered(PayloadTypeId{kUserBegin}));
+
+    const auto owner = registry->resolve(PayloadTypeId{kControlBegin});
+    ASSERT_TRUE(owner.has_value());
+    EXPECT_EQ(*owner, std::string{kEngineOwner});
+}
+
+TEST(DefaultPayloadRegistrySmoke, HappyPathUserRegistration)
+{
+    std::unique_ptr<IPayloadRegistry> registry = createPayloadRegistry();
+
+    const Result r = registry->registerRange(PayloadTypeId{0x20000u},
+                                             PayloadTypeId{0x200FFu},
+                                             "app.game");
+    EXPECT_TRUE(r.isSuccess());
+    EXPECT_TRUE(registry->isRegistered(PayloadTypeId{0x20000u}));
+    EXPECT_TRUE(registry->isRegistered(PayloadTypeId{0x200FFu}));
+
+    const auto owner = registry->resolve(PayloadTypeId{0x20050u});
+    ASSERT_TRUE(owner.has_value());
+    EXPECT_EQ(*owner, "app.game");
+}
+
+TEST(DefaultPayloadRegistrySmoke, DuplicateRangeRejected)
+{
+    std::unique_ptr<IPayloadRegistry> registry = createPayloadRegistry();
+
+    const Result first = registry->registerRange(PayloadTypeId{0x30000u},
+                                                 PayloadTypeId{0x300FFu},
+                                                 "app.a");
+    ASSERT_TRUE(first.isSuccess());
+
+    const Result collide = registry->registerRange(PayloadTypeId{0x30080u},
+                                                   PayloadTypeId{0x301FFu},
+                                                   "app.b");
+    EXPECT_TRUE(collide.isError());
+    EXPECT_EQ(collide.code(), Result::Code::DuplicatePayloadId);
+}
+
+TEST(DefaultPayloadRegistrySmoke, EngineRangesRejectReRegistration)
+{
+    std::unique_ptr<IPayloadRegistry> registry = createPayloadRegistry();
+
+    const Result r = registry->registerRange(PayloadTypeId{kSystemBegin},
+                                             PayloadTypeId{kSystemEnd},
+                                             "app.evil");
+    EXPECT_TRUE(r.isError());
+    EXPECT_EQ(r.code(), Result::Code::DuplicatePayloadId);
+}
+
+TEST(DefaultPayloadRegistrySmoke, OutOfRangeRejectedForCrossingBoundary)
+{
+    std::unique_ptr<IPayloadRegistry> registry = createPayloadRegistry();
+
+    // Spans the engine / user boundary.
+    const Result r = registry->registerRange(PayloadTypeId{0xFF00u},
+                                             PayloadTypeId{0x20000u},
+                                             "app.boundary");
+    EXPECT_TRUE(r.isError());
+    EXPECT_EQ(r.code(), Result::Code::OutOfRange);
+}
+
+TEST(DefaultPayloadRegistrySmoke, OutOfRangeRejectedForInvertedRange)
+{
+    std::unique_ptr<IPayloadRegistry> registry = createPayloadRegistry();
+
+    const Result r = registry->registerRange(PayloadTypeId{0x30010u},
+                                             PayloadTypeId{0x30000u},
+                                             "app.inverted");
+    EXPECT_TRUE(r.isError());
+    EXPECT_EQ(r.code(), Result::Code::OutOfRange);
+}
+
+TEST(DefaultPayloadRegistrySmoke, UnregisterFreesRangeForReuse)
+{
+    std::unique_ptr<IPayloadRegistry> registry = createPayloadRegistry();
+
+    ASSERT_TRUE(registry
+                    ->registerRange(PayloadTypeId{0x40000u},
+                                    PayloadTypeId{0x400FFu},
+                                    "app.transient")
+                    .isSuccess());
+    ASSERT_TRUE(registry->isRegistered(PayloadTypeId{0x40050u}));
+
+    ASSERT_TRUE(registry->unregister("app.transient").isSuccess());
+    EXPECT_FALSE(registry->isRegistered(PayloadTypeId{0x40050u}));
+
+    // Reuse the now-free range under a different owner.
+    const Result reuse = registry->registerRange(PayloadTypeId{0x40000u},
+                                                 PayloadTypeId{0x400FFu},
+                                                 "app.other");
+    EXPECT_TRUE(reuse.isSuccess());
+}
+
+TEST(DefaultPayloadRegistrySmoke, ConcurrentRegisterAndResolveAreTsanClean)
+{
+    std::unique_ptr<IPayloadRegistry> registry = createPayloadRegistry();
+
+    constexpr int kWriters    = 4;
+    constexpr int kReaders    = 4;
+    constexpr int kPerWriter  = 32;
+    std::atomic<bool> startFlag{false};
+    std::atomic<int>  registered{0};
+
+    std::vector<std::thread> workers;
+    workers.reserve(kWriters + kReaders);
+
+    for (int w = 0; w < kWriters; ++w)
+    {
+        workers.emplace_back([&, w]() {
+            while (!startFlag.load(std::memory_order_acquire))
+            {
+                std::this_thread::yield();
+            }
+            const std::uint32_t base = 0x50000u + static_cast<std::uint32_t>(w) * 0x10000u;
+            for (int i = 0; i < kPerWriter; ++i)
+            {
+                const std::uint32_t lo = base + static_cast<std::uint32_t>(i) * 0x10u;
+                const std::uint32_t hi = lo + 0x0Fu;
+                if (registry
+                        ->registerRange(PayloadTypeId{lo},
+                                        PayloadTypeId{hi},
+                                        "app.concurrent")
+                        .isSuccess())
+                {
+                    registered.fetch_add(1, std::memory_order_relaxed);
+                }
+            }
+        });
+    }
+
+    for (int r = 0; r < kReaders; ++r)
+    {
+        workers.emplace_back([&]() {
+            while (!startFlag.load(std::memory_order_acquire))
+            {
+                std::this_thread::yield();
+            }
+            for (std::uint32_t probe = 0x50000u; probe < 0x90000u; probe += 0x80u)
+            {
+                static_cast<void>(registry->isRegistered(PayloadTypeId{probe}));
+                static_cast<void>(registry->resolve(PayloadTypeId{probe}));
+            }
+        });
+    }
+
+    startFlag.store(true, std::memory_order_release);
+    for (std::thread &t : workers)
+    {
+        t.join();
+    }
+
+    EXPECT_EQ(registered.load(std::memory_order_relaxed), kWriters * kPerWriter);
+}


### PR DESCRIPTION
## Summary

Introduces the payload-type-id governance substrate so every future
facade and wrapper can allocate collision-free identifiers. The
subsystem is orthogonal: it does not depend on graph, messaging, ECS,
or any service, and nothing under `src/payload/` includes those
headers.

## Public surface

- `include/vigine/payload/payloadtypeid.h` — POD wrapper around
  `std::uint32_t` with equality and ordering operators.
- `include/vigine/payload/payloadrange.h` — reserved-range constants:
  `Control [0x0000..0x00FF]`, `System [0x0100..0x0FFF]`,
  `SystemExt [0x1000..0x7FFF]`, `Reserved [0x8000..0xFFFF]`,
  `User [0x10000 ..)`. Engine-bundled ranges are pre-registered under
  the `vigine.core` owner string.
- `include/vigine/payload/ipayloadregistry.h` — pure-virtual surface:
  `registerRange`, `resolve`, `isRegistered`, `unregister`.
- `include/vigine/payload/factory.h` — `createPayloadRegistry()`
  returns `std::unique_ptr<IPayloadRegistry>`.

## Implementation

- `AbstractPayloadRegistry` holds the range table behind a
  `std::shared_mutex`; reads take a shared lock, mutations take an
  exclusive lock.
- `DefaultPayloadRegistry` is a `final` subclass that bootstraps the
  four engine-bundled ranges at construction.
- Overlap detection is inclusive on both ends.
- Ranges that cross the engine/user boundary or that are inverted
  are rejected with `Result::Code::OutOfRange`.
- `unregister(owner)` removes every range owned by the argument, so
  dynamic-unload paths can reuse the freed space.

## Result::Code

Two codes appended at the end of the enum:
`DuplicatePayloadId`, `OutOfRange`. Existing `Success` / `Error`
positions are unchanged so serialised values stay stable. `isError()`
now reports any non-Success code (was `code() == Error`), so a caller
that only checks `isError()` sees the new codes without needing to
know the full list.

## Tests

`test/payload/smoke_test.cpp` — 9 cases under ctest label
`payload-registry-smoke`: factory ownership, engine-range bootstrap,
happy-path user registration, duplicate rejection (user vs user and
user vs engine), out-of-range boundary crossing, inverted-range
rejection, unregister-then-reuse, and a concurrent
register/resolve/isRegistered stress case suitable for TSAN.

## Build

- `cmake --build build --target vigine --config Debug` — clean.
- `cmake --build build --target vigine --config Release` — clean.
- `cmake --build build --target payload-smoke --config Debug` — 9/9
  tests pass.
- `cmake --build build --target graph-contract --config Debug` —
  78/78 tests pass (no regression from the `isError()` widening).

Closes #91
