### PR TITLE
feat(threading): add sync primitives (IMutex + ISemaphore + IBarrier + IMessageChannel)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,6 +161,10 @@ set(HEADER
     ${INCLUDE_DIR}/vigine/threading/threadmanagerconfig.h
     ${INCLUDE_DIR}/vigine/threading/irunnable.h
     ${INCLUDE_DIR}/vigine/threading/itaskhandle.h
+    ${INCLUDE_DIR}/vigine/threading/imutex.h
+    ${INCLUDE_DIR}/vigine/threading/isemaphore.h
+    ${INCLUDE_DIR}/vigine/threading/ibarrier.h
+    ${INCLUDE_DIR}/vigine/threading/imessagechannel.h
     ${INCLUDE_DIR}/vigine/threading/ithreadmanager.h
     ${INCLUDE_DIR}/vigine/threading/abstractthreadmanager.h
     ${INCLUDE_DIR}/vigine/threading/defaultthreadmanager.h
@@ -212,6 +216,15 @@ set(SOURCES
     ${SRC_DIR}/graph/factory.cpp
     ${SRC_DIR}/threading/abstractthreadmanager.cpp
     ${SRC_DIR}/threading/defaultthreadmanager.cpp
+    ${SRC_DIR}/threading/defaultmutex.h
+    ${SRC_DIR}/threading/defaultmutex.cpp
+    ${SRC_DIR}/threading/defaultsemaphore.h
+    ${SRC_DIR}/threading/defaultsemaphore.cpp
+    ${SRC_DIR}/threading/defaultbarrier.h
+    ${SRC_DIR}/threading/defaultbarrier.cpp
+    ${SRC_DIR}/threading/defaultmessagechannel.h
+    ${SRC_DIR}/threading/defaultmessagechannel.cpp
+    ${SRC_DIR}/threading/defaultthreadmanager_factories.cpp
     ${SRC_DIR}/threading/factory.cpp
     ${SRC_DIR}/payload/abstractpayloadregistry.h
     ${SRC_DIR}/payload/abstractpayloadregistry.cpp

--- a/include/vigine/threading/abstractthreadmanager.h
+++ b/include/vigine/threading/abstractthreadmanager.h
@@ -11,6 +11,10 @@
 #include <vector>
 
 #include "vigine/result.h"
+#include "vigine/threading/ibarrier.h"
+#include "vigine/threading/imessagechannel.h"
+#include "vigine/threading/imutex.h"
+#include "vigine/threading/isemaphore.h"
 #include "vigine/threading/ithreadmanager.h"
 #include "vigine/threading/namedthreadid.h"
 #include "vigine/threading/threadmanagerconfig.h"
@@ -57,6 +61,47 @@ class AbstractThreadManager : public IThreadManager
     [[nodiscard]] std::size_t poolSize() const noexcept override;
     [[nodiscard]] std::size_t dedicatedThreadCount() const noexcept override;
     [[nodiscard]] std::size_t namedThreadCount() const noexcept override;
+
+    // ------ IThreadManager: sync primitive factories (shared impl) ------
+
+    /**
+     * @brief Default @ref IMutex factory returning a @c std::mutex
+     *        wrapper.
+     *
+     * Derived classes override only when they need a different concrete
+     * mutex (for example a sanitiser-instrumented one).
+     */
+    [[nodiscard]] std::unique_ptr<IMutex> createMutex() override;
+
+    /**
+     * @brief Default @ref ISemaphore factory returning a counter built
+     *        on @c std::mutex + @c std::condition_variable.
+     */
+    [[nodiscard]] std::unique_ptr<ISemaphore>
+        createSemaphore(std::size_t initialCount) override;
+
+    /**
+     * @brief Default @ref IBarrier factory returning a cv-based
+     *        reusable barrier.
+     *
+     * A dedicated cv-based implementation (not @c std::barrier) is used
+     * for ABI stability across compilers and to keep the fallback code
+     * path singular — every supported toolchain hits exactly one
+     * implementation.
+     */
+    [[nodiscard]] std::unique_ptr<IBarrier>
+        createBarrier(std::size_t parties) override;
+
+    /**
+     * @brief Default @ref IMessageChannel factory returning a bounded
+     *        FIFO queue.
+     *
+     * The queue uses @c std::mutex plus two @c std::condition_variable
+     * instances (not-full / not-empty) to keep producer and consumer
+     * wake-ups independent.
+     */
+    [[nodiscard]] std::unique_ptr<IMessageChannel>
+        createMessageChannel(std::size_t capacity) override;
 
   protected:
     explicit AbstractThreadManager(ThreadManagerConfig config) noexcept;

--- a/include/vigine/threading/ibarrier.h
+++ b/include/vigine/threading/ibarrier.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <chrono>
+#include <cstddef>
+
+#include "vigine/result.h"
+
+namespace vigine::threading
+{
+/**
+ * @brief Pure-virtual reusable barrier produced by
+ *        @ref IThreadManager::createBarrier.
+ *
+ * @ref IBarrier implements a standard @c N-party rendezvous. Each party
+ * calls @ref arriveAndWait; the call blocks until exactly @c N parties
+ * have arrived, then all @c N calls return together and the barrier
+ * resets for the next phase. A party that does not want to participate
+ * in the next phase calls @ref arriveAndDrop, which counts the current
+ * arrival and reduces the party count by one for every subsequent phase.
+ *
+ * The party count is supplied at construction through the factory on
+ * @ref IThreadManager. A barrier with @c N=1 is legal and lets
+ * @ref arriveAndWait return immediately without blocking — useful as a
+ * no-op in code that only sometimes needs synchronisation.
+ *
+ * Ownership and lifetime: the barrier is owned by the caller via
+ * @c std::unique_ptr. Destroying the barrier while a party is blocked
+ * on @ref arriveAndWait is a programming error.
+ *
+ * Thread-safety: every entry point is safe to call from any thread.
+ */
+class IBarrier
+{
+  public:
+    virtual ~IBarrier() = default;
+
+    /**
+     * @brief Arrives at the barrier and blocks until the last party
+     *        arrives, then all blocked parties return together.
+     *
+     * Blocks up to @p timeout. Returns a successful @ref Result when
+     * the phase completed. Returns an error @ref Result when @p timeout
+     * elapses before the last party arrived; the barrier is left in a
+     * consistent state and the caller is considered to have withdrawn
+     * from the current phase.
+     */
+    [[nodiscard]] virtual Result
+        arriveAndWait(std::chrono::milliseconds timeout = std::chrono::milliseconds::max()) = 0;
+
+    /**
+     * @brief Arrives at the barrier and withdraws from all future
+     *        phases.
+     *
+     * Counts as one arrival for the current phase without blocking
+     * waiters that have not yet arrived. The party count for every
+     * subsequent phase decreases by one. Calling @ref arriveAndDrop
+     * more times than the construction-time party count is a programming
+     * error and leaves the barrier in an undefined state.
+     */
+    virtual void arriveAndDrop() = 0;
+
+    /**
+     * @brief Snapshot of the remaining party count for the current
+     *        phase.
+     *
+     * Primarily for diagnostics and smoke tests. Callers must not race
+     * on this value — by the time it returns, another party may have
+     * arrived or dropped.
+     */
+    [[nodiscard]] virtual std::size_t pendingParties() const = 0;
+
+    IBarrier(const IBarrier &)            = delete;
+    IBarrier &operator=(const IBarrier &) = delete;
+    IBarrier(IBarrier &&)                 = delete;
+    IBarrier &operator=(IBarrier &&)      = delete;
+
+  protected:
+    IBarrier() = default;
+};
+
+} // namespace vigine::threading

--- a/include/vigine/threading/imessagechannel.h
+++ b/include/vigine/threading/imessagechannel.h
@@ -1,0 +1,176 @@
+#pragma once
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+#include "vigine/payload/payloadtypeid.h"
+#include "vigine/result.h"
+
+namespace vigine::threading
+{
+/**
+ * @brief Owning wrapper around one payload byte buffer carried through
+ *        @ref IMessageChannel.
+ *
+ * @ref Message is a deliberately narrow value type. It pairs a
+ * @ref vigine::payload::PayloadTypeId (the key subscribers look up to
+ * decide how to decode the bytes) with a heap buffer and a byte count.
+ * The buffer is owned through a @c std::unique_ptr so that @ref Message
+ * is move-only and does not leak when callers discard it mid-transfer.
+ *
+ * The type is intentionally non-templated. A templated channel would
+ * violate INV-1 (no templates in public threading headers); a typed
+ * wrapper-over-bytes keeps the ABI stable and lets subscribers cast by
+ * payload id at the decode site.
+ *
+ * Typical producer pattern:
+ * @code
+ *   auto buffer = std::make_unique<std::byte[]>(payload.size());
+ *   std::memcpy(buffer.get(), payload.data(), payload.size());
+ *   Message msg{PayloadTypeId{kMyPayloadId}, std::move(buffer), payload.size()};
+ *   channel->send(std::move(msg), std::chrono::milliseconds::max());
+ * @endcode
+ */
+struct Message
+{
+    /// Payload-registry key the receiver uses to decode @ref bytes.
+    vigine::payload::PayloadTypeId typeId{};
+
+    /// Owned byte buffer carrying the serialised payload (may be null
+    /// when @ref sizeBytes is zero).
+    std::unique_ptr<std::byte[]> bytes;
+
+    /// Number of valid bytes in @ref bytes.
+    std::size_t sizeBytes{0};
+
+    Message()                                 = default;
+    Message(vigine::payload::PayloadTypeId id,
+            std::unique_ptr<std::byte[]>   buffer,
+            std::size_t                    size) noexcept
+        : typeId{id}, bytes{std::move(buffer)}, sizeBytes{size}
+    {
+    }
+
+    Message(const Message &)            = delete;
+    Message &operator=(const Message &) = delete;
+    Message(Message &&) noexcept            = default;
+    Message &operator=(Message &&) noexcept = default;
+};
+
+/**
+ * @brief Pure-virtual bounded FIFO channel produced by
+ *        @ref IThreadManager::createMessageChannel.
+ *
+ * @ref IMessageChannel is the engine's cross-thread message pipe. A
+ * fixed capacity is supplied at construction through the factory on
+ * @ref IThreadManager. Producers call @ref send (blocking until space
+ * is available) or @ref trySend (non-blocking). Consumers call
+ * @ref receive (blocking) or @ref tryReceive. @ref close flips the
+ * channel into a drained state: waiting senders and receivers wake up
+ * with an error @ref Result, further sends fail, and further receives
+ * succeed only as long as the channel still has queued messages.
+ *
+ * Ownership and lifetime: the channel is owned by the caller via
+ * @c std::unique_ptr. Messages move through the channel — each
+ * @ref send transfers ownership of the message into the channel and
+ * each @ref receive transfers it back out. Destroying a channel that
+ * still holds messages discards them silently; in practice callers
+ * should @ref close first so waiters wake up deterministically.
+ *
+ * Thread-safety: every entry point is safe to call from any thread.
+ * Implementations use two condition variables (one for "not full", one
+ * for "not empty") to keep producer and consumer wake-ups independent.
+ */
+class IMessageChannel
+{
+  public:
+    virtual ~IMessageChannel() = default;
+
+    /**
+     * @brief Sends a message, blocking up to @p timeout when the channel
+     *        is full.
+     *
+     * Transfers ownership of @p message into the channel on success.
+     * Returns a successful @ref Result when the message was queued.
+     * Returns an error @ref Result when @p timeout elapses before space
+     * becomes available, or when the channel is closed. On failure the
+     * caller retains ownership through @p message (the implementation
+     * leaves the buffer intact on the caller side).
+     */
+    [[nodiscard]] virtual Result send(Message message, std::chrono::milliseconds timeout = std::chrono::milliseconds::max()) = 0;
+
+    /**
+     * @brief Attempts to send a message without blocking.
+     *
+     * Returns @c true and transfers ownership of @p message into the
+     * channel when space is immediately available. Returns @c false
+     * without transferring ownership when the channel is full or
+     * closed.
+     */
+    [[nodiscard]] virtual bool trySend(Message &message) = 0;
+
+    /**
+     * @brief Receives a message, blocking up to @p timeout when the
+     *        channel is empty.
+     *
+     * On success @p out receives ownership of the dequeued message and
+     * the returned @ref Result is successful. On timeout or close with
+     * no queued messages the returned @ref Result is an error and
+     * @p out is left default-constructed.
+     */
+    [[nodiscard]] virtual Result receive(Message &out, std::chrono::milliseconds timeout = std::chrono::milliseconds::max()) = 0;
+
+    /**
+     * @brief Attempts to receive a message without blocking.
+     *
+     * Returns @c true and transfers ownership into @p out when a message
+     * is immediately available. Returns @c false without mutating
+     * @p out when the channel is empty (whether or not it is closed).
+     */
+    [[nodiscard]] virtual bool tryReceive(Message &out) = 0;
+
+    /**
+     * @brief Closes the channel.
+     *
+     * Idempotent: the second and subsequent calls are no-ops. After
+     * close, @ref send and @ref trySend fail immediately; @ref receive
+     * and @ref tryReceive continue to drain any queued messages and
+     * fail only once the channel is both closed and empty. Threads
+     * blocked in @ref send or @ref receive wake up with an error
+     * @ref Result.
+     */
+    virtual void close() = 0;
+
+    /**
+     * @brief Reports whether @ref close has been called.
+     *
+     * Diagnostic accessor. The value may change between the call and
+     * the next operation on the channel.
+     */
+    [[nodiscard]] virtual bool isClosed() const = 0;
+
+    /**
+     * @brief Number of messages currently queued in the channel.
+     *
+     * Diagnostic accessor. The value may change between the call and
+     * the next operation on the channel.
+     */
+    [[nodiscard]] virtual std::size_t size() const = 0;
+
+    /**
+     * @brief Fixed capacity of the channel, supplied at construction.
+     */
+    [[nodiscard]] virtual std::size_t capacity() const = 0;
+
+    IMessageChannel(const IMessageChannel &)            = delete;
+    IMessageChannel &operator=(const IMessageChannel &) = delete;
+    IMessageChannel(IMessageChannel &&)                 = delete;
+    IMessageChannel &operator=(IMessageChannel &&)      = delete;
+
+  protected:
+    IMessageChannel() = default;
+};
+
+} // namespace vigine::threading

--- a/include/vigine/threading/imutex.h
+++ b/include/vigine/threading/imutex.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <chrono>
+
+#include "vigine/result.h"
+
+namespace vigine::threading
+{
+/**
+ * @brief Pure-virtual engine-level mutual-exclusion primitive.
+ *
+ * @ref IMutex is the narrowest lock surface the engine offers. Callers
+ * obtain an instance from @ref IThreadManager::createMutex, hand the
+ * returned @c std::unique_ptr ownership around, and call @ref lock /
+ * @ref tryLock / @ref unlock on it exactly as they would a
+ * @c std::mutex. The concrete implementation is hidden behind the
+ * interface so that later leaves may swap @c std::mutex for a sanitiser-
+ * friendly instrumented mutex or for an @c std::timed_mutex on platforms
+ * that give tighter guarantees, without touching call sites.
+ *
+ * Ownership and lifetime: every mutex is owned by the caller via
+ * @c std::unique_ptr. The manager that produced the mutex does not
+ * retain a back-reference, so destroying the mutex after the manager has
+ * been shut down is safe. Destroying a mutex while another thread holds
+ * it is a programming error and is not tested for here — callers are
+ * expected to release their locks before drop.
+ *
+ * Thread-safety: every entry point is safe to call from any thread at
+ * any time. The locking protocol matches the C++ standard: a thread
+ * that holds the lock must release it before another thread can
+ * acquire it.
+ */
+class IMutex
+{
+  public:
+    virtual ~IMutex() = default;
+
+    /**
+     * @brief Acquires the mutex, blocking up to @p timeout.
+     *
+     * Returns a successful @ref Result when the lock was acquired.
+     * Returns an error @ref Result when @p timeout elapses before the
+     * lock was acquired. The default timeout of
+     * @c std::chrono::milliseconds::max asks the implementation to block
+     * indefinitely, matching @c std::mutex::lock semantics.
+     */
+    [[nodiscard]] virtual Result
+        lock(std::chrono::milliseconds timeout = std::chrono::milliseconds::max()) = 0;
+
+    /**
+     * @brief Attempts to acquire the mutex without blocking.
+     *
+     * Returns @c true when the lock was acquired on the calling thread
+     * and @c false when the mutex is already held by another thread or
+     * was already held by the caller. Implementations must match the
+     * non-blocking contract — a caller that needs a timed wait should
+     * use @ref lock with a non-default @p timeout.
+     */
+    [[nodiscard]] virtual bool tryLock() = 0;
+
+    /**
+     * @brief Releases the mutex.
+     *
+     * The caller must currently hold the lock. Unlocking a mutex the
+     * caller does not hold is undefined per the C++ standard; concrete
+     * implementations may or may not detect the misuse.
+     */
+    virtual void unlock() = 0;
+
+    IMutex(const IMutex &)            = delete;
+    IMutex &operator=(const IMutex &) = delete;
+    IMutex(IMutex &&)                 = delete;
+    IMutex &operator=(IMutex &&)      = delete;
+
+  protected:
+    IMutex() = default;
+};
+
+} // namespace vigine::threading

--- a/include/vigine/threading/isemaphore.h
+++ b/include/vigine/threading/isemaphore.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <chrono>
+#include <cstddef>
+
+#include "vigine/result.h"
+
+namespace vigine::threading
+{
+/**
+ * @brief Pure-virtual counting semaphore produced by
+ *        @ref IThreadManager::createSemaphore.
+ *
+ * @ref ISemaphore implements the canonical counting-semaphore protocol:
+ * an internal non-negative counter with @ref acquire decrementing (blocks
+ * while the counter is zero) and @ref release incrementing. The initial
+ * counter value is supplied at construction time through the factory on
+ * @ref IThreadManager and cannot be changed afterwards — callers that
+ * need a different starting value create a second semaphore.
+ *
+ * Ownership and lifetime: the semaphore is owned by the caller via
+ * @c std::unique_ptr. Destroying the semaphore while another thread
+ * blocks on @ref acquire is a programming error.
+ *
+ * Thread-safety: every entry point is safe to call from any thread.
+ * @ref release wakes exactly one pending @ref acquire at a time;
+ * implementations are free to pick any waiter (FIFO is not required by
+ * this contract).
+ */
+class ISemaphore
+{
+  public:
+    virtual ~ISemaphore() = default;
+
+    /**
+     * @brief Waits until the counter is positive, then decrements it.
+     *
+     * Blocks up to @p timeout. Returns a successful @ref Result when a
+     * permit was acquired. Returns an error @ref Result when @p timeout
+     * elapses first. The default timeout of
+     * @c std::chrono::milliseconds::max asks the implementation to block
+     * indefinitely.
+     */
+    [[nodiscard]] virtual Result
+        acquire(std::chrono::milliseconds timeout = std::chrono::milliseconds::max()) = 0;
+
+    /**
+     * @brief Attempts to decrement the counter without blocking.
+     *
+     * Returns @c true when a permit was acquired and @c false when the
+     * counter was already zero. The call never blocks; callers that want
+     * a timed wait should use @ref acquire with a non-default @p timeout.
+     */
+    [[nodiscard]] virtual bool tryAcquire() = 0;
+
+    /**
+     * @brief Increments the counter by one and wakes one waiter.
+     *
+     * The call never blocks. Implementations that bound the counter (to
+     * model a binary semaphore or to cap outstanding resources) may
+     * saturate at the bound; the default implementation does not cap.
+     */
+    virtual void release() = 0;
+
+    /**
+     * @brief Snapshot of the current counter value.
+     *
+     * Primarily for diagnostics and smoke tests. Callers must not race
+     * on this value — by the time it returns, another thread may have
+     * changed it.
+     */
+    [[nodiscard]] virtual std::size_t count() const = 0;
+
+    ISemaphore(const ISemaphore &)            = delete;
+    ISemaphore &operator=(const ISemaphore &) = delete;
+    ISemaphore(ISemaphore &&)                 = delete;
+    ISemaphore &operator=(ISemaphore &&)      = delete;
+
+  protected:
+    ISemaphore() = default;
+};
+
+} // namespace vigine::threading

--- a/include/vigine/threading/ithreadmanager.h
+++ b/include/vigine/threading/ithreadmanager.h
@@ -5,7 +5,11 @@
 #include <string_view>
 
 #include "vigine/result.h"
+#include "vigine/threading/ibarrier.h"
+#include "vigine/threading/imessagechannel.h"
+#include "vigine/threading/imutex.h"
 #include "vigine/threading/irunnable.h"
+#include "vigine/threading/isemaphore.h"
 #include "vigine/threading/itaskhandle.h"
 #include "vigine/threading/namedthreadid.h"
 #include "vigine/threading/threadaffinity.h"
@@ -134,6 +138,53 @@ class IThreadManager
      *        registered.
      */
     [[nodiscard]] virtual std::size_t namedThreadCount() const noexcept = 0;
+
+    // ------ Sync primitive factories ------
+
+    /**
+     * @brief Produces a new @ref IMutex owned by the caller.
+     *
+     * Every returned mutex is a fresh primitive with no shared state.
+     * The manager does not track the mutex after the call returns —
+     * lifetime is governed purely by the caller's
+     * @c std::unique_ptr.
+     */
+    [[nodiscard]] virtual std::unique_ptr<IMutex> createMutex() = 0;
+
+    /**
+     * @brief Produces a new counting @ref ISemaphore with initial
+     *        counter @p initialCount.
+     *
+     * @p initialCount is the starting value of the internal counter.
+     * A value of @c 0 means the first @ref ISemaphore::acquire call
+     * blocks until a matching @ref ISemaphore::release runs on another
+     * thread.
+     */
+    [[nodiscard]] virtual std::unique_ptr<ISemaphore>
+        createSemaphore(std::size_t initialCount) = 0;
+
+    /**
+     * @brief Produces a new reusable @ref IBarrier expecting @p parties
+     *        arrivals per phase.
+     *
+     * @p parties must be at least @c 1. A value of @c 0 is a
+     * programming error; implementations treat it as @c 1 (a no-op
+     * barrier) so that call sites do not crash on degenerate input.
+     */
+    [[nodiscard]] virtual std::unique_ptr<IBarrier>
+        createBarrier(std::size_t parties) = 0;
+
+    /**
+     * @brief Produces a new bounded @ref IMessageChannel of capacity
+     *        @p capacity.
+     *
+     * @p capacity is the maximum number of queued messages before a
+     * producer blocks on @ref IMessageChannel::send. A value of @c 0
+     * is a programming error; implementations treat it as @c 1 so that
+     * the channel can still carry at least one message in transit.
+     */
+    [[nodiscard]] virtual std::unique_ptr<IMessageChannel>
+        createMessageChannel(std::size_t capacity) = 0;
 
     // ------ Lifecycle ------
 

--- a/src/threading/defaultbarrier.cpp
+++ b/src/threading/defaultbarrier.cpp
@@ -1,0 +1,99 @@
+#include "defaultbarrier.h"
+
+#include <chrono>
+#include <cstdint>
+#include <mutex>
+
+namespace vigine::threading
+{
+namespace
+{
+// Clamp the constructor party count so that parties == 0 degenerates
+// into a trivial one-party barrier rather than an arithmetic trap.
+[[nodiscard]] std::size_t clampParties(std::size_t parties) noexcept
+{
+    return parties == 0 ? std::size_t{1} : parties;
+}
+} // namespace
+
+DefaultBarrier::DefaultBarrier(std::size_t parties) noexcept
+    : _parties{clampParties(parties)},
+      _pending{clampParties(parties)},
+      _generation{0}
+{
+}
+
+DefaultBarrier::~DefaultBarrier() = default;
+
+Result DefaultBarrier::arriveAndWait(std::chrono::milliseconds timeout)
+{
+    std::unique_lock<std::mutex> lock(_mutex);
+    const std::uint64_t          myGeneration = _generation;
+    if (_pending == 0)
+    {
+        // Degenerate "no parties expected" barrier (for instance after
+        // arriveAndDrop drained every party). Treat the call as a no-op
+        // success — the barrier has nothing to wait for.
+        return Result{Result::Code::Success};
+    }
+
+    --_pending;
+    if (_pending == 0)
+    {
+        // Last arrival — advance the generation, reset the pending
+        // count, and wake every waiter that captured the previous
+        // generation.
+        _pending = _parties;
+        ++_generation;
+        _cv.notify_all();
+        return Result{Result::Code::Success};
+    }
+
+    if (timeout == std::chrono::milliseconds::max())
+    {
+        _cv.wait(lock, [&] { return _generation != myGeneration; });
+        return Result{Result::Code::Success};
+    }
+
+    if (!_cv.wait_for(lock, timeout, [&] { return _generation != myGeneration; }))
+    {
+        // Timed out before the phase completed. Restore the pending
+        // count so the caller's earlier arrival does not count against
+        // future phases.
+        ++_pending;
+        return Result{Result::Code::Error, "threading: barrier arrive_and_wait timeout"};
+    }
+    return Result{Result::Code::Success};
+}
+
+void DefaultBarrier::arriveAndDrop()
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+    // Drop the party count for future phases.
+    if (_parties > 0)
+    {
+        --_parties;
+    }
+
+    if (_pending == 0)
+    {
+        return;
+    }
+
+    --_pending;
+    if (_pending == 0)
+    {
+        // Dropping the last outstanding arrival completes the phase.
+        _pending = _parties;
+        ++_generation;
+        _cv.notify_all();
+    }
+}
+
+std::size_t DefaultBarrier::pendingParties() const
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+    return _pending;
+}
+
+} // namespace vigine::threading

--- a/src/threading/defaultbarrier.h
+++ b/src/threading/defaultbarrier.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+
+#include "vigine/result.h"
+#include "vigine/threading/ibarrier.h"
+
+namespace vigine::threading
+{
+/**
+ * @brief Default @ref IBarrier implementation — a reusable generation-
+ *        based barrier on @c std::mutex + @c std::condition_variable.
+ *
+ * @c std::barrier (C++20) is intentionally avoided to keep the
+ * implementation's code path uniform across every supported toolchain
+ * and to avoid relying on library features that shipped at different
+ * times on different platforms. The generation counter protects
+ * against the classic reusable-barrier race — a late arriver from
+ * phase @c N cannot block waiters of phase @c N+1 because each
+ * @ref arriveAndWait captures the generation it entered on and waits
+ * only for that generation to advance.
+ *
+ * State is strictly private (INV — strict encapsulation).
+ */
+class DefaultBarrier final : public IBarrier
+{
+  public:
+    explicit DefaultBarrier(std::size_t parties) noexcept;
+    ~DefaultBarrier() override;
+
+    [[nodiscard]] Result
+        arriveAndWait(std::chrono::milliseconds timeout) override;
+
+    void arriveAndDrop() override;
+
+    [[nodiscard]] std::size_t pendingParties() const override;
+
+  private:
+    mutable std::mutex      _mutex;
+    std::condition_variable _cv;
+    // Party count for every future phase; decreases with arriveAndDrop.
+    std::size_t             _parties;
+    // Number of arrivals outstanding for the current phase.
+    std::size_t             _pending;
+    // Generation counter — every time the phase completes it
+    // increments, and every waiter compares against the snapshot it
+    // captured on entry.
+    std::uint64_t           _generation;
+};
+
+} // namespace vigine::threading

--- a/src/threading/defaultmessagechannel.cpp
+++ b/src/threading/defaultmessagechannel.cpp
@@ -1,0 +1,147 @@
+#include "defaultmessagechannel.h"
+
+#include <chrono>
+#include <mutex>
+#include <utility>
+
+namespace vigine::threading
+{
+namespace
+{
+// Clamp capacity: 0 degenerates into a 1-slot channel so call sites do
+// not deadlock or miscompute full/empty state.
+[[nodiscard]] std::size_t clampCapacity(std::size_t capacity) noexcept
+{
+    return capacity == 0 ? std::size_t{1} : capacity;
+}
+} // namespace
+
+DefaultMessageChannel::DefaultMessageChannel(std::size_t capacity) noexcept
+    : _capacity{clampCapacity(capacity)}, _closed{false}
+{
+}
+
+DefaultMessageChannel::~DefaultMessageChannel()
+{
+    // Deterministic shutdown: wake every waiter and drain. Destroying
+    // a channel with pending senders/receivers is a caller error, but
+    // calling close here makes the dtor safe rather than blocking on a
+    // condition variable.
+    close();
+}
+
+Result DefaultMessageChannel::send(Message message, std::chrono::milliseconds timeout)
+{
+    std::unique_lock<std::mutex> lock(_mutex);
+    const auto predicate = [this] { return _queue.size() < _capacity || _closed; };
+
+    if (timeout == std::chrono::milliseconds::max())
+    {
+        _notFull.wait(lock, predicate);
+    }
+    else if (!_notFull.wait_for(lock, timeout, predicate))
+    {
+        return Result{Result::Code::Error, "threading: channel send timeout"};
+    }
+
+    if (_closed)
+    {
+        return Result{Result::Code::Error, "threading: channel closed"};
+    }
+
+    _queue.push_back(std::move(message));
+    lock.unlock();
+    _notEmpty.notify_one();
+    return Result{Result::Code::Success};
+}
+
+bool DefaultMessageChannel::trySend(Message &message)
+{
+    std::unique_lock<std::mutex> lock(_mutex);
+    if (_closed || _queue.size() >= _capacity)
+    {
+        return false;
+    }
+    _queue.push_back(std::move(message));
+    lock.unlock();
+    _notEmpty.notify_one();
+    return true;
+}
+
+Result DefaultMessageChannel::receive(Message &out, std::chrono::milliseconds timeout)
+{
+    std::unique_lock<std::mutex> lock(_mutex);
+    const auto predicate = [this] { return !_queue.empty() || _closed; };
+
+    if (timeout == std::chrono::milliseconds::max())
+    {
+        _notEmpty.wait(lock, predicate);
+    }
+    else if (!_notEmpty.wait_for(lock, timeout, predicate))
+    {
+        return Result{Result::Code::Error, "threading: channel receive timeout"};
+    }
+
+    if (_queue.empty())
+    {
+        // Closed and empty — final-drain path.
+        return Result{Result::Code::Error, "threading: channel closed"};
+    }
+
+    out = std::move(_queue.front());
+    _queue.pop_front();
+    lock.unlock();
+    _notFull.notify_one();
+    return Result{Result::Code::Success};
+}
+
+bool DefaultMessageChannel::tryReceive(Message &out)
+{
+    std::unique_lock<std::mutex> lock(_mutex);
+    if (_queue.empty())
+    {
+        return false;
+    }
+    out = std::move(_queue.front());
+    _queue.pop_front();
+    lock.unlock();
+    _notFull.notify_one();
+    return true;
+}
+
+void DefaultMessageChannel::close()
+{
+    {
+        std::lock_guard<std::mutex> lock(_mutex);
+        if (_closed)
+        {
+            return;
+        }
+        _closed = true;
+    }
+    // Wake every waiter so they re-evaluate the closed flag and exit
+    // with an error Result (for senders) or drain-then-error (for
+    // receivers).
+    _notFull.notify_all();
+    _notEmpty.notify_all();
+}
+
+bool DefaultMessageChannel::isClosed() const
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+    return _closed;
+}
+
+std::size_t DefaultMessageChannel::size() const
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+    return _queue.size();
+}
+
+std::size_t DefaultMessageChannel::capacity() const
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+    return _capacity;
+}
+
+} // namespace vigine::threading

--- a/src/threading/defaultmessagechannel.h
+++ b/src/threading/defaultmessagechannel.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <deque>
+#include <mutex>
+
+#include "vigine/result.h"
+#include "vigine/threading/imessagechannel.h"
+
+namespace vigine::threading
+{
+/**
+ * @brief Default @ref IMessageChannel implementation — a bounded FIFO
+ *        queue on @c std::mutex + two @c std::condition_variable
+ *        instances (not-full, not-empty).
+ *
+ * Separate condition variables for the two waiter populations avoid the
+ * classic "notify_all wakes a producer to find nothing changed" problem
+ * of single-cv implementations: a @ref send increment wakes exactly
+ * receivers, and a @ref receive decrement wakes exactly producers.
+ *
+ * @ref close flips an internal flag and broadcasts on both condition
+ * variables so every blocked waiter re-evaluates its predicate. After
+ * close, producers always fail fast; receivers continue draining until
+ * the queue is empty and then fail fast too. The destructor calls
+ * @ref close internally so outstanding waiters never hang on dtor.
+ *
+ * State is strictly private (INV — strict encapsulation).
+ */
+class DefaultMessageChannel final : public IMessageChannel
+{
+  public:
+    explicit DefaultMessageChannel(std::size_t capacity) noexcept;
+    ~DefaultMessageChannel() override;
+
+    [[nodiscard]] Result
+        send(Message message, std::chrono::milliseconds timeout) override;
+
+    [[nodiscard]] bool trySend(Message &message) override;
+
+    [[nodiscard]] Result
+        receive(Message &out, std::chrono::milliseconds timeout) override;
+
+    [[nodiscard]] bool tryReceive(Message &out) override;
+
+    void close() override;
+
+    [[nodiscard]] bool isClosed() const override;
+
+    [[nodiscard]] std::size_t size() const override;
+
+    [[nodiscard]] std::size_t capacity() const override;
+
+  private:
+    mutable std::mutex      _mutex;
+    std::condition_variable _notFull;
+    std::condition_variable _notEmpty;
+    std::deque<Message>     _queue;
+    std::size_t             _capacity;
+    bool                    _closed;
+};
+
+} // namespace vigine::threading

--- a/src/threading/defaultmutex.cpp
+++ b/src/threading/defaultmutex.cpp
@@ -1,0 +1,40 @@
+#include "defaultmutex.h"
+
+#include <chrono>
+
+namespace vigine::threading
+{
+DefaultMutex::DefaultMutex() noexcept = default;
+
+DefaultMutex::~DefaultMutex() = default;
+
+Result DefaultMutex::lock(std::chrono::milliseconds timeout)
+{
+    // std::chrono::milliseconds::max() is the "block forever" sentinel;
+    // forwarding that to try_lock_for would overflow the internal
+    // timeout computation on some implementations. The infinite branch
+    // delegates to std::timed_mutex::lock which blocks until acquired.
+    if (timeout == std::chrono::milliseconds::max())
+    {
+        _mutex.lock();
+        return Result{Result::Code::Success};
+    }
+
+    if (_mutex.try_lock_for(timeout))
+    {
+        return Result{Result::Code::Success};
+    }
+    return Result{Result::Code::Error, "threading: mutex lock timeout"};
+}
+
+bool DefaultMutex::tryLock()
+{
+    return _mutex.try_lock();
+}
+
+void DefaultMutex::unlock()
+{
+    _mutex.unlock();
+}
+
+} // namespace vigine::threading

--- a/src/threading/defaultmutex.h
+++ b/src/threading/defaultmutex.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <chrono>
+#include <mutex>
+
+#include "vigine/result.h"
+#include "vigine/threading/imutex.h"
+
+namespace vigine::threading
+{
+/**
+ * @brief Default @ref IMutex implementation over @c std::timed_mutex.
+ *
+ * The timed variant of the standard mutex is used so that every
+ * timeout branch on @ref IMutex::lock maps to a single primitive. For
+ * infinite timeouts @ref lock forwards to @c std::timed_mutex::lock;
+ * for finite timeouts it forwards to @c try_lock_for. @ref tryLock
+ * forwards to @c try_lock. @ref unlock forwards to @c unlock.
+ *
+ * State is strictly private (INV — strict encapsulation). The class is
+ * declared @c final — it is the single engine-shipped concrete mutex,
+ * and subclassing would bypass the pure-virtual contract.
+ */
+class DefaultMutex final : public IMutex
+{
+  public:
+    DefaultMutex() noexcept;
+    ~DefaultMutex() override;
+
+    [[nodiscard]] Result
+        lock(std::chrono::milliseconds timeout) override;
+
+    [[nodiscard]] bool tryLock() override;
+
+    void unlock() override;
+
+  private:
+    std::timed_mutex _mutex;
+};
+
+} // namespace vigine::threading

--- a/src/threading/defaultsemaphore.cpp
+++ b/src/threading/defaultsemaphore.cpp
@@ -1,0 +1,59 @@
+#include "defaultsemaphore.h"
+
+#include <chrono>
+#include <mutex>
+
+namespace vigine::threading
+{
+DefaultSemaphore::DefaultSemaphore(std::size_t initialCount) noexcept
+    : _count{initialCount}
+{
+}
+
+DefaultSemaphore::~DefaultSemaphore() = default;
+
+Result DefaultSemaphore::acquire(std::chrono::milliseconds timeout)
+{
+    std::unique_lock<std::mutex> lock(_mutex);
+    if (timeout == std::chrono::milliseconds::max())
+    {
+        _cv.wait(lock, [this] { return _count > 0; });
+        --_count;
+        return Result{Result::Code::Success};
+    }
+
+    if (!_cv.wait_for(lock, timeout, [this] { return _count > 0; }))
+    {
+        return Result{Result::Code::Error, "threading: semaphore acquire timeout"};
+    }
+    --_count;
+    return Result{Result::Code::Success};
+}
+
+bool DefaultSemaphore::tryAcquire()
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+    if (_count == 0)
+    {
+        return false;
+    }
+    --_count;
+    return true;
+}
+
+void DefaultSemaphore::release()
+{
+    {
+        std::lock_guard<std::mutex> lock(_mutex);
+        ++_count;
+    }
+    _cv.notify_one();
+}
+
+std::size_t DefaultSemaphore::count() const
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+    return _count;
+}
+
+} // namespace vigine::threading

--- a/src/threading/defaultsemaphore.h
+++ b/src/threading/defaultsemaphore.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <mutex>
+
+#include "vigine/result.h"
+#include "vigine/threading/isemaphore.h"
+
+namespace vigine::threading
+{
+/**
+ * @brief Default @ref ISemaphore implementation built on
+ *        @c std::mutex + @c std::condition_variable.
+ *
+ * The implementation deliberately avoids @c std::counting_semaphore so
+ * that the same code path runs on every supported toolchain. The
+ * internal counter is guarded by a @c std::mutex; @ref acquire waits on
+ * a single @c std::condition_variable for a positive counter, and
+ * @ref release notifies one waiter per increment.
+ *
+ * State is strictly private (INV — strict encapsulation).
+ */
+class DefaultSemaphore final : public ISemaphore
+{
+  public:
+    explicit DefaultSemaphore(std::size_t initialCount) noexcept;
+    ~DefaultSemaphore() override;
+
+    [[nodiscard]] Result
+        acquire(std::chrono::milliseconds timeout) override;
+
+    [[nodiscard]] bool tryAcquire() override;
+
+    void release() override;
+
+    [[nodiscard]] std::size_t count() const override;
+
+  private:
+    mutable std::mutex      _mutex;
+    std::condition_variable _cv;
+    std::size_t             _count;
+};
+
+} // namespace vigine::threading

--- a/src/threading/defaultthreadmanager_factories.cpp
+++ b/src/threading/defaultthreadmanager_factories.cpp
@@ -1,0 +1,47 @@
+// Factory bodies for sync-primitive creators on AbstractThreadManager.
+//
+// The definitions live in a dedicated TU rather than inside
+// abstractthreadmanager.cpp so that extending the primitive catalogue
+// in a later leaf does not force a recompile of the registry/lifecycle
+// bookkeeping code. DefaultThreadManager inherits these definitions
+// unchanged — it does not override any of them.
+
+#include <cstddef>
+#include <memory>
+
+#include "defaultbarrier.h"
+#include "defaultmessagechannel.h"
+#include "defaultmutex.h"
+#include "defaultsemaphore.h"
+#include "vigine/threading/abstractthreadmanager.h"
+#include "vigine/threading/ibarrier.h"
+#include "vigine/threading/imessagechannel.h"
+#include "vigine/threading/imutex.h"
+#include "vigine/threading/isemaphore.h"
+
+namespace vigine::threading
+{
+std::unique_ptr<IMutex> AbstractThreadManager::createMutex()
+{
+    return std::make_unique<DefaultMutex>();
+}
+
+std::unique_ptr<ISemaphore>
+AbstractThreadManager::createSemaphore(std::size_t initialCount)
+{
+    return std::make_unique<DefaultSemaphore>(initialCount);
+}
+
+std::unique_ptr<IBarrier>
+AbstractThreadManager::createBarrier(std::size_t parties)
+{
+    return std::make_unique<DefaultBarrier>(parties);
+}
+
+std::unique_ptr<IMessageChannel>
+AbstractThreadManager::createMessageChannel(std::size_t capacity)
+{
+    return std::make_unique<DefaultMessageChannel>(capacity);
+}
+
+} // namespace vigine::threading


### PR DESCRIPTION
Ships the four engine-level synchronisation primitives plus the factory
methods that produce them on `IThreadManager`.

## Surface

- `include/vigine/threading/imutex.h` — pure-virtual `IMutex` (lock with timeout, tryLock, unlock).
- `include/vigine/threading/isemaphore.h` — pure-virtual counting `ISemaphore` (acquire/tryAcquire/release/count).
- `include/vigine/threading/ibarrier.h` — pure-virtual reusable `IBarrier` (arriveAndWait/arriveAndDrop/pendingParties).
- `include/vigine/threading/imessagechannel.h` — pure-virtual bounded FIFO `IMessageChannel` (send/trySend/receive/tryReceive/close). Carries a non-template `Message` value type keyed on `PayloadTypeId`.
- `IThreadManager` gains four factory methods returning `std::unique_ptr` per primitive.

## Implementation

- `DefaultMutex` — `std::timed_mutex` wrapper; timeout=max maps to blocking `lock()`.
- `DefaultSemaphore` — counter + `std::mutex` + single `std::condition_variable`.
- `DefaultBarrier` — generation-based reusable barrier over `std::mutex` + `std::condition_variable`; `arriveAndDrop` shrinks parties for future phases.
- `DefaultMessageChannel` — bounded `std::deque` queue guarded by one `std::mutex` plus two `std::condition_variable` instances (not-full / not-empty); `close()` broadcasts on both; destructor calls `close()` to avoid dtor hangs.
- Factory bodies live in `src/threading/defaultthreadmanager_factories.cpp`, inherited unchanged by `DefaultThreadManager`.
- No templates in public headers (INV-1). No graph includes under `src/threading/` (INV-9). All concrete-impl data members `private`. Every factory returns `std::unique_ptr` (FF-1).

## Build

- `cmake --build build --config Debug` — clean.
- `cmake --build build --config Release` — clean.
- `scripts/check_graph_purity.py` — 0 violations.
- `scripts/check_naming_convention.py` — unchanged pre-existing count (IPayloadRegistry + IThreadManager false positives from multi-line declarations on `main`; the new `IMessageChannel` header is clean).

Closes #94