### PR TITLE
feat(messaging): ship control block + weak token + IMessageTarget + engine cleanup hooks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,15 @@ set(HEADER
     ${INCLUDE_DIR}/vigine/payload/ipayloadregistry.h
     ${INCLUDE_DIR}/vigine/payload/factory.h
     ${INCLUDE_DIR}/vigine/messaging/kind.h
+    ${INCLUDE_DIR}/vigine/messaging/connectionid.h
+    ${INCLUDE_DIR}/vigine/messaging/targetkind.h
+    ${INCLUDE_DIR}/vigine/messaging/iconnectiontoken.h
+    ${INCLUDE_DIR}/vigine/messaging/ibuscontrolblock.h
+    ${INCLUDE_DIR}/vigine/messaging/connectiontoken.h
+    ${INCLUDE_DIR}/vigine/messaging/abstractmessagetarget.h
+    ${INCLUDE_DIR}/vigine/statemachine/istatemachine.h
+    ${INCLUDE_DIR}/vigine/context/icontext.h
+    ${INCLUDE_DIR}/vigine/ecs/ientitymanager.h
     ${INCLUDE_DIR}/vigine/ecs/kind.h
     ${INCLUDE_DIR}/vigine/fsm/kind.h
     ${INCLUDE_DIR}/vigine/taskflow/kind.h
@@ -218,6 +227,12 @@ set(SOURCES
     ${SRC_DIR}/payload/defaultpayloadregistry.h
     ${SRC_DIR}/payload/defaultpayloadregistry.cpp
     ${SRC_DIR}/payload/factory.cpp
+    ${SRC_DIR}/messaging/abstractmessagetarget.cpp
+    ${SRC_DIR}/messaging/connectiontoken.cpp
+    ${SRC_DIR}/messaging/ibuscontrolblock_default.h
+    ${SRC_DIR}/messaging/ibuscontrolblock_default.cpp
+    ${SRC_DIR}/messaging/cleanup.h
+    ${SRC_DIR}/messaging/cleanup.cpp
 )
 
 # Add platform-specific surface factory

--- a/example/postgresql/main.cpp
+++ b/example/postgresql/main.cpp
@@ -52,7 +52,12 @@ std::unique_ptr<TaskFlow> createCloseTaskFlow() { return std::make_unique<TaskFl
 int main()
 {
     Engine engine;
-    StateMachine *stMachine = engine.state();
+    // Engine::state() now returns IStateMachine&; the concrete
+    // StateMachine is still the only implementation shipped with the
+    // engine, so downcast back to it for the rich state-machine API.
+    // Later leaves move the addState/addTransition surface onto the
+    // interface itself; the cast is temporary scaffolding.
+    StateMachine *stMachine = static_cast<StateMachine *>(&engine.state());
 
     auto initState          = std::make_unique<InitState>();
     auto workState          = std::make_unique<WorkState>();

--- a/example/window/main.cpp
+++ b/example/window/main.cpp
@@ -82,7 +82,11 @@ std::unique_ptr<TaskFlow> createCloseTaskFlow() { return std::make_unique<TaskFl
 int main()
 {
     Engine engine;
-    StateMachine *stMachine = engine.state();
+    // Engine::state() now returns IStateMachine&; downcast back to the
+    // concrete StateMachine for the rich state-machine API. The cast
+    // is temporary scaffolding that will disappear once addState /
+    // addTransition move onto the interface in a later leaf.
+    StateMachine *stMachine = static_cast<StateMachine *>(&engine.state());
 
     MouseEventSignalBinder mouseSignalBinder;
     KeyEventSignalBinder keySignalBinder;

--- a/include/vigine/context.h
+++ b/include/vigine/context.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "vigine/context/icontext.h"
 #include "vigine/ecs/abstractsystem.h"
 #include <vigine/abstractservice.h>
 
@@ -17,7 +18,7 @@ class EntityManager;
 using ServiceInstancesContainer = std::vector<std::pair<const Name, AbstractServiceUPtr>>;
 using SystemInstancesContainer  = std::vector<std::pair<const SystemId, AbstractSystemUPtr>>;
 
-class Context
+class Context : public IContext
 {
   public:
     AbstractService *service(const ServiceId id, const Name name, const Property property);

--- a/include/vigine/context/icontext.h
+++ b/include/vigine/context/icontext.h
@@ -1,0 +1,33 @@
+#pragma once
+
+namespace vigine
+{
+/**
+ * @brief Pure-virtual forward-declared stub for the engine context.
+ *
+ * @ref IContext is a minimal stub whose only contract is a virtual
+ * destructor. It exists so that @ref Engine::context can return a
+ * reference to a pure-virtual interface without requiring the context
+ * domain (service container, system registry, binding host) to be
+ * finalised in this leaf. The finalised surface lands in a later leaf
+ * that refactors @c Context onto this interface.
+ *
+ * Ownership: the stub is never instantiated directly. Concrete
+ * @c Context objects derive from it and are owned by the @ref Engine as
+ * @c std::unique_ptr.
+ */
+class IContext
+{
+  public:
+    virtual ~IContext() = default;
+
+    IContext(const IContext &)            = delete;
+    IContext &operator=(const IContext &) = delete;
+    IContext(IContext &&)                 = delete;
+    IContext &operator=(IContext &&)      = delete;
+
+  protected:
+    IContext() = default;
+};
+
+} // namespace vigine

--- a/include/vigine/ecs/entitymanager.h
+++ b/include/vigine/ecs/entitymanager.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "vigine/ecs/ientitymanager.h"
+
 #include <map>
 #include <memory>
 #include <string>
@@ -12,7 +14,7 @@ class Entity;
 
 using EntityUPtr = std::unique_ptr<Entity>;
 
-class EntityManager
+class EntityManager : public IEntityManager
 {
   public:
     ~EntityManager();

--- a/include/vigine/ecs/ientitymanager.h
+++ b/include/vigine/ecs/ientitymanager.h
@@ -1,0 +1,34 @@
+#pragma once
+
+namespace vigine
+{
+/**
+ * @brief Pure-virtual forward-declared stub for the entity-manager
+ *        surface.
+ *
+ * @ref IEntityManager is a minimal stub whose only contract is a
+ * virtual destructor. It exists so that @ref Engine::entityManager can
+ * return a reference to a pure-virtual interface without requiring the
+ * ECS domain to be finalised in this leaf. The finalised surface --
+ * entity creation, removal, alias lookup -- lands in a later leaf that
+ * refactors @c EntityManager onto this interface.
+ *
+ * Ownership: the stub is never instantiated directly. Concrete
+ * @c EntityManager objects derive from it and are owned by the
+ * @ref Engine as @c std::unique_ptr.
+ */
+class IEntityManager
+{
+  public:
+    virtual ~IEntityManager() = default;
+
+    IEntityManager(const IEntityManager &)            = delete;
+    IEntityManager &operator=(const IEntityManager &) = delete;
+    IEntityManager(IEntityManager &&)                 = delete;
+    IEntityManager &operator=(IEntityManager &&)      = delete;
+
+  protected:
+    IEntityManager() = default;
+};
+
+} // namespace vigine

--- a/include/vigine/messaging/abstractmessagetarget.h
+++ b/include/vigine/messaging/abstractmessagetarget.h
@@ -1,0 +1,131 @@
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include "vigine/messaging/targetkind.h"
+
+namespace vigine::messaging
+{
+class IConnectionToken;
+class IMessage;
+
+/**
+ * @brief Stateful abstract base for every object that receives messages
+ *        from an @ref IMessageBus.
+ *
+ * @ref AbstractMessageTarget carries the one piece of state every
+ * subscriber needs: a mutex-guarded vector of the tokens that keep its
+ * bus subscriptions alive. Concrete subscribers (states, task flows,
+ * tasks, topic nodes, channel nodes, actor nodes, application targets)
+ * derive from this base, override the three pure-virtual hooks, and
+ * rely on the base class's RAII to unregister every subscription when
+ * the target is destroyed.
+ *
+ * The class carries state, so it follows the project's @c Abstract
+ * naming convention rather than the @c I pure-virtual prefix. The
+ * @c _connections vector is the RAII anchor that makes this base more
+ * than a pure interface: every concrete target inherits the same
+ * lifetime plumbing without having to duplicate it.
+ *
+ * Ownership: the vector owns the @ref IConnectionToken handles. Tokens
+ * are produced by the bus during registration and handed over via
+ * @ref acceptConnection; their destructors run when the vector clears
+ * (either on target destruction or on a selective erase driven by the
+ * target's owner). The bus keeps only a raw, non-owning pointer to the
+ * target in its registry, which is why the target's address must be
+ * stable while any connection is live.
+ *
+ * Move semantics: moving a registered target would leave a dangling
+ * pointer inside every bus that tracks it. The move constructor and
+ * move-assignment operator therefore assert that the source holds no
+ * connections. Callers that need to relocate a target should either do
+ * so before registration or destroy all tokens first (see
+ * @ref canMove).
+ *
+ * Thread-safety: @ref acceptConnection takes an exclusive lock on an
+ * internal mutex so that multiple buses can register the same target
+ * concurrently. The lock is NOT held during @ref onMessage dispatch;
+ * the bus is responsible for sequencing dispatch against the target's
+ * own concurrency model.
+ *
+ * Reentrancy: implementations MUST NOT destroy the target or any of its
+ * tokens from inside @ref onMessage. Doing so makes the
+ * @ref ConnectionToken destructor wait for itself, which deadlocks.
+ */
+class AbstractMessageTarget
+{
+  public:
+    virtual ~AbstractMessageTarget() = default;
+
+    /**
+     * @brief Returns the closed-enum tag describing this target's kind.
+     *
+     * Used by the bus to dispatch on delivery policy without a
+     * @c dynamic_cast. The value is stable for the lifetime of the
+     * target.
+     */
+    [[nodiscard]] virtual TargetKind targetKind() const noexcept = 0;
+
+    /**
+     * @brief Delivers @p message to the target.
+     *
+     * Called from the bus's dispatch path. Implementations must run to
+     * completion without destroying the target or any of its
+     * @ref IConnectionToken handles; see the class-level reentrancy
+     * note.
+     */
+    virtual void onMessage(const IMessage &message) = 0;
+
+    /**
+     * @brief Takes ownership of @p token and appends it to the
+     *        target's connection list.
+     *
+     * Called by the bus at the end of a successful registration. The
+     * call is serialised against other @ref acceptConnection calls on
+     * the same target by @c _connectionsMutex, so a target can be
+     * registered on multiple buses concurrently without risk of a
+     * @c std::vector resize-race.
+     */
+    void acceptConnection(std::unique_ptr<IConnectionToken> token);
+
+    /**
+     * @brief Returns @c true when the target holds no active
+     *        connections and can safely be moved.
+     *
+     * The snapshot reads the vector size without the mutex; callers
+     * that race with a concurrent @ref acceptConnection should not rely
+     * on the value for correctness.
+     */
+    [[nodiscard]] bool canMove() const noexcept;
+
+    AbstractMessageTarget(const AbstractMessageTarget &)            = delete;
+    AbstractMessageTarget &operator=(const AbstractMessageTarget &) = delete;
+
+    /**
+     * @brief Moves connections from @p other into @c *this.
+     *
+     * @p other MUST be unregistered (@ref canMove @c true). The
+     * constructor asserts on a registered source in debug builds; in
+     * release builds the assert is compiled out and the move proceeds
+     * unsafely -- callers are responsible for the precondition.
+     */
+    AbstractMessageTarget(AbstractMessageTarget &&other) noexcept;
+
+    /**
+     * @brief Move-assigns from @p other.
+     *
+     * Both operands MUST be unregistered; see @ref canMove.
+     */
+    AbstractMessageTarget &operator=(AbstractMessageTarget &&other) noexcept;
+
+  protected:
+    AbstractMessageTarget() = default;
+
+  private:
+    std::vector<std::unique_ptr<IConnectionToken>> _connections;
+    mutable std::mutex                             _connectionsMutex;
+};
+
+} // namespace vigine::messaging

--- a/include/vigine/messaging/connectionid.h
+++ b/include/vigine/messaging/connectionid.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <cstdint>
+
+namespace vigine::messaging
+{
+/**
+ * @brief Generational identifier for a single bus-side connection slot.
+ *
+ * @ref ConnectionId is a POD value type. The @c index field addresses a
+ * slot in an @ref IBusControlBlock registry; the @c generation field is
+ * incremented whenever that slot is recycled. A connection id whose
+ * @c generation is zero is the default-constructed sentinel and reports
+ * @ref valid as @c false so that call sites can detect uninitialised
+ * handles without reaching into the slot table.
+ *
+ * The pair is small (8 bytes), trivially copyable, and safe to pass by
+ * value across thread boundaries. Control-block implementations issue
+ * ids starting at @c generation == 1; zero is reserved for the sentinel.
+ */
+struct ConnectionId
+{
+    std::uint32_t index{0};
+    std::uint32_t generation{0};
+
+    /**
+     * @brief Returns @c true when the id addresses a live slot.
+     *
+     * The sentinel (@c generation == 0) is not valid. A non-zero
+     * generation is accepted as valid even when the matching slot has
+     * since been recycled; stale-slot detection is the control block's
+     * responsibility and happens at lookup time.
+     */
+    [[nodiscard]] constexpr bool valid() const noexcept { return generation != 0; }
+
+    [[nodiscard]] friend constexpr bool operator==(ConnectionId lhs,
+                                                   ConnectionId rhs) noexcept
+    {
+        return lhs.index == rhs.index && lhs.generation == rhs.generation;
+    }
+
+    [[nodiscard]] friend constexpr bool operator!=(ConnectionId lhs,
+                                                   ConnectionId rhs) noexcept
+    {
+        return !(lhs == rhs);
+    }
+};
+
+} // namespace vigine::messaging

--- a/include/vigine/messaging/connectiontoken.h
+++ b/include/vigine/messaging/connectiontoken.h
@@ -1,0 +1,118 @@
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+
+#include "vigine/messaging/connectionid.h"
+#include "vigine/messaging/iconnectiontoken.h"
+
+namespace vigine::messaging
+{
+class IBusControlBlock;
+
+/**
+ * @brief Concrete RAII token bound to a single bus-side connection slot.
+ *
+ * @ref ConnectionToken is the only shipped implementation of
+ * @ref IConnectionToken. It carries a @c std::weak_ptr to the bus's
+ * @ref IBusControlBlock so that it tolerates the bus being destroyed
+ * first, plus the @ref ConnectionId that addresses its slot inside that
+ * block. The destructor enforces the strong-unsubscribe barrier: the
+ * slot is unregistered from the bus, and the destructor then waits until
+ * every in-flight @c onMessage call that targets this token has
+ * returned. That wait-until-drained step is what keeps the subscriber's
+ * lifetime strictly longer than any dispatch that could still be running
+ * against it.
+ *
+ * A token is non-copyable and non-movable: the RAII contract ties one
+ * token to one slot for its entire lifetime. The @c _inFlight counter
+ * and condition variable are private plumbing driven by the bus during
+ * dispatch; callers never touch them directly.
+ *
+ * Thread-safety: construction, @ref active, and destruction are safe to
+ * call from any thread. The destructor is permitted to block until
+ * in-flight dispatches on this slot complete, which is the whole point
+ * of the strong-unsubscribe guarantee.
+ *
+ * Reentrancy: a target's @c onMessage implementation must not destroy
+ * the token (or the enclosing target) while the call is in flight.
+ * Doing so would make the destructor wait for itself -- a self-deadlock.
+ * Implementations document this as a hard precondition; runtime
+ * detection is out of scope for this leaf.
+ */
+class ConnectionToken final : public IConnectionToken
+{
+  public:
+    /**
+     * @brief Builds a token bound to the slot addressed by @p id inside
+     *        the control block reachable through @p control.
+     *
+     * The @c std::weak_ptr lets the token tolerate the bus being
+     * destroyed before the target. @p id is stored as-is; invalid ids
+     * (generation zero) produce a token whose @ref active always
+     * reports @c false.
+     */
+    ConnectionToken(std::weak_ptr<IBusControlBlock> control, ConnectionId id) noexcept;
+
+    /**
+     * @brief Unregisters the slot (if the bus is still alive) and then
+     *        waits for every in-flight dispatch on this slot to drain.
+     *
+     * See the class-level note on reentrancy: destroying a token from
+     * inside its own dispatch causes a self-deadlock.
+     */
+    ~ConnectionToken() override;
+
+    /**
+     * @brief Returns @c true when both the control block is reachable
+     *        and @ref IBusControlBlock::isAlive reports @c true.
+     *
+     * Cheap: one @c weak_ptr::lock plus one atomic load. The return
+     * value is a momentary snapshot; callers racing with
+     * @ref IBusControlBlock::markDead may observe the bus transitioning
+     * to dead between the @c active check and a subsequent dispatch.
+     */
+    [[nodiscard]] bool active() const noexcept override;
+
+    /**
+     * @brief Returns the connection id addressing this token's slot.
+     *
+     * Stable for the lifetime of the token. Safe to call concurrently
+     * with any other member function.
+     */
+    [[nodiscard]] ConnectionId id() const noexcept { return _id; }
+
+    /**
+     * @brief Records that a dispatch targeting this slot is about to
+     *        start. Called by the bus on the dispatch hot path.
+     *
+     * The paired @ref endDispatch must run on exactly one thread per
+     * @ref beginDispatch. Both are wait-free.
+     */
+    void beginDispatch() noexcept;
+
+    /**
+     * @brief Records that the matching dispatch has returned.
+     *
+     * When the in-flight counter transitions from @c 1 to @c 0, the
+     * destructor waiter (if any) is notified.
+     */
+    void endDispatch() noexcept;
+
+    ConnectionToken(const ConnectionToken &)            = delete;
+    ConnectionToken &operator=(const ConnectionToken &) = delete;
+    ConnectionToken(ConnectionToken &&)                 = delete;
+    ConnectionToken &operator=(ConnectionToken &&)      = delete;
+
+  private:
+    std::weak_ptr<IBusControlBlock> _control;
+    ConnectionId                    _id;
+    std::atomic<std::uint32_t>      _inFlight{0};
+    mutable std::mutex              _waitMutex;
+    std::condition_variable_any     _waitCv;
+};
+
+} // namespace vigine::messaging

--- a/include/vigine/messaging/ibuscontrolblock.h
+++ b/include/vigine/messaging/ibuscontrolblock.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include "vigine/messaging/connectionid.h"
+
+namespace vigine::messaging
+{
+class AbstractMessageTarget;
+
+/**
+ * @brief Pure-virtual shared-heap state owned jointly by a message bus
+ *        and the connection tokens it hands out.
+ *
+ * @ref IBusControlBlock is the safety anchor that removes the
+ * destruction-ordering hazard between an @ref IMessageBus and its
+ * subscribers. The bus holds a @c std::shared_ptr to the control block
+ * and every token holds a @c std::weak_ptr to the same block. When the
+ * bus dies first, its destructor calls @ref markDead so that every still-
+ * held token becomes a safe no-op on destruction; when a target dies
+ * first, the token's destructor calls @ref unregisterTarget so that the
+ * bus's registry never sees a dangling target pointer.
+ *
+ * Ownership and lifetime:
+ *   - The control block outlives the bus exactly long enough for any
+ *     remaining weak tokens to be destroyed cleanly. It is always
+ *     allocated on the heap and only reached through a shared/weak
+ *     pointer pair.
+ *   - @ref allocateSlot records a raw, non-owning pointer to the target.
+ *     The caller (the bus) must guarantee that the target outlives the
+ *     corresponding token or that the token's destructor runs before the
+ *     target is freed -- which is the invariant provided by
+ *     @ref AbstractMessageTarget owning its tokens.
+ *
+ * Thread-safety: every entry point is safe to call from any thread.
+ * Implementations typically protect the registry with a
+ * @c std::shared_mutex and the alive flag with a @c std::atomic.
+ */
+class IBusControlBlock
+{
+  public:
+    virtual ~IBusControlBlock() = default;
+
+    /**
+     * @brief Returns @c true when the bus is still alive.
+     *
+     * Reads must be cheap and wait-free. Implementations typically back
+     * this with a @c std::atomic<bool> loaded with acquire ordering.
+     */
+    [[nodiscard]] virtual bool isAlive() const noexcept = 0;
+
+    /**
+     * @brief Marks the bus as dead.
+     *
+     * Called from the bus destructor. Idempotent: a second call is a
+     * no-op. After @ref markDead returns, every future call to
+     * @ref isAlive reports @c false and every future call to
+     * @ref unregisterTarget is a no-op, regardless of the connection id.
+     */
+    virtual void markDead() noexcept = 0;
+
+    /**
+     * @brief Allocates a new registry slot for @p target and returns its
+     *        generational id.
+     *
+     * The returned @ref ConnectionId always has a non-zero @c generation
+     * when allocation succeeded. When the bus is already dead or when
+     * the registry is exhausted, implementations return a default-
+     * constructed sentinel (@c generation == 0) so that call sites can
+     * detect the failure without needing a separate @ref Result.
+     *
+     * Passing @c nullptr is a programming error; implementations return
+     * the sentinel id and do not insert anything into the registry.
+     */
+    [[nodiscard]] virtual ConnectionId
+        allocateSlot(AbstractMessageTarget *target) = 0;
+
+    /**
+     * @brief Removes the registry entry addressed by @p id.
+     *
+     * Idempotent: unregistering a stale id or an id from a dead bus is a
+     * no-op. After this call returns, no future dispatch on this bus
+     * reaches the slot addressed by @p id; in-flight dispatches on that
+     * slot are serialised separately by the token (see
+     * @ref ConnectionToken).
+     */
+    virtual void unregisterTarget(ConnectionId id) noexcept = 0;
+
+    IBusControlBlock(const IBusControlBlock &)            = delete;
+    IBusControlBlock &operator=(const IBusControlBlock &) = delete;
+    IBusControlBlock(IBusControlBlock &&)                 = delete;
+    IBusControlBlock &operator=(IBusControlBlock &&)      = delete;
+
+  protected:
+    IBusControlBlock() = default;
+};
+
+} // namespace vigine::messaging

--- a/include/vigine/messaging/iconnectiontoken.h
+++ b/include/vigine/messaging/iconnectiontoken.h
@@ -1,0 +1,49 @@
+#pragma once
+
+namespace vigine::messaging
+{
+/**
+ * @brief Pure-virtual handle to a single subscription slot on an
+ *        @ref IBusControlBlock.
+ *
+ * @ref IConnectionToken is the subscriber-facing surface returned by an
+ * @ref IBusControlBlock after @ref IBusControlBlock::allocateSlot. Its
+ * only semantic contract is that @ref active reports whether the backing
+ * bus and slot are still live; the concrete RAII token
+ * (@ref ConnectionToken) adds destructor-driven unregistration, weak
+ * tracking of the control block, and a strong-unsubscribe barrier.
+ *
+ * Ownership: tokens are owned by their target (typically by
+ * @ref AbstractMessageTarget holding them in its @c _connections vector).
+ * The bus never owns the token; its only reference is through the
+ * registry slot, which becomes inert once the token's destructor runs.
+ *
+ * Thread-safety: @ref active is safe to call from any thread at any
+ * time. Implementations must keep the call wait-free on the fast path.
+ */
+class IConnectionToken
+{
+  public:
+    virtual ~IConnectionToken() = default;
+
+    /**
+     * @brief Returns @c true when the subscription slot is still live.
+     *
+     * A token becomes inactive when the underlying bus is marked dead
+     * (either through @ref IBusControlBlock::markDead or the bus being
+     * destroyed) or when the token's slot has been explicitly
+     * unregistered. Once @ref active returns @c false, it never returns
+     * @c true again.
+     */
+    [[nodiscard]] virtual bool active() const noexcept = 0;
+
+    IConnectionToken(const IConnectionToken &)            = delete;
+    IConnectionToken &operator=(const IConnectionToken &) = delete;
+    IConnectionToken(IConnectionToken &&)                 = delete;
+    IConnectionToken &operator=(IConnectionToken &&)      = delete;
+
+  protected:
+    IConnectionToken() = default;
+};
+
+} // namespace vigine::messaging

--- a/include/vigine/messaging/targetkind.h
+++ b/include/vigine/messaging/targetkind.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <cstdint>
+
+namespace vigine::messaging
+{
+/**
+ * @brief Closed enumeration of the kinds of message targets the engine
+ *        routes messages to.
+ *
+ * Every concrete @ref AbstractMessageTarget reports one of these seven
+ * tags so that the bus can disambiguate delivery policy without paying
+ * for a @c dynamic_cast on the hot path. The enumeration is intentionally
+ * closed: adding a new value is a breaking API change and requires
+ * architect approval.
+ *
+ * Values:
+ *   - @c State       -- a state in the state machine.
+ *   - @c TaskFlow    -- a task-flow wrapper node.
+ *   - @c Task        -- a concrete task scheduled inside a task flow.
+ *   - @c TopicNode   -- a subscription target on a topic-shaped channel.
+ *   - @c ChannelNode -- a generic channel-node subscriber.
+ *   - @c ActorNode   -- an actor-shaped target with its own mailbox.
+ *   - @c User        -- any target supplied by application code.
+ */
+enum class TargetKind : std::uint8_t
+{
+    State       = 1,
+    TaskFlow    = 2,
+    Task        = 3,
+    TopicNode   = 4,
+    ChannelNode = 5,
+    ActorNode   = 6,
+    User        = 7,
+};
+
+} // namespace vigine::messaging

--- a/include/vigine/result.h
+++ b/include/vigine/result.h
@@ -18,7 +18,18 @@ class Result
         // existing values above keep their numeric positions so that
         // callers that persist or serialise Result codes are unaffected.
         DuplicatePayloadId,
-        OutOfRange
+        OutOfRange,
+        // Appended for the messaging control-block additions (R.3.1.1).
+        // Append-only; existing numeric values above are frozen.
+        // SubscriptionExpired   -- reported when a caller hands the bus a
+        //                          connection id whose slot has been
+        //                          released (target-first destruction or
+        //                          an explicit unregister).
+        // InvalidMessageTarget  -- reported when the target pointer is
+        //                          null or the registered target has
+        //                          already been torn down.
+        SubscriptionExpired,
+        InvalidMessageTarget
     };
 
     Result();

--- a/include/vigine/statemachine.h
+++ b/include/vigine/statemachine.h
@@ -2,6 +2,7 @@
 
 #include "abstractstate.h"
 #include "result.h"
+#include "statemachine/istatemachine.h"
 
 #include <memory>
 #include <unordered_map>
@@ -11,7 +12,7 @@ namespace vigine
 {
 class Engine;
 
-class StateMachine
+class StateMachine : public IStateMachine
 {
     using StateUPtr           = std::unique_ptr<AbstractState>;
     using StateContainer      = std::vector<StateUPtr>;

--- a/include/vigine/statemachine/istatemachine.h
+++ b/include/vigine/statemachine/istatemachine.h
@@ -1,0 +1,34 @@
+#pragma once
+
+namespace vigine
+{
+/**
+ * @brief Pure-virtual forward-declared stub for the state-machine surface.
+ *
+ * @ref IStateMachine is a minimal stub whose only contract is a virtual
+ * destructor. It exists so that @ref Engine::state can return a
+ * reference to a pure-virtual interface without requiring the
+ * state-machine domain to be finalised in this leaf. The finalised
+ * surface -- transitions, state lookup, tick semantics, and so on --
+ * lands in a later leaf that refactors @c StateMachine onto this
+ * interface.
+ *
+ * Ownership: this type is never instantiated directly. Concrete
+ * @c StateMachine objects derive from it and are owned by the
+ * @ref Engine as @c std::unique_ptr.
+ */
+class IStateMachine
+{
+  public:
+    virtual ~IStateMachine() = default;
+
+    IStateMachine(const IStateMachine &)            = delete;
+    IStateMachine &operator=(const IStateMachine &) = delete;
+    IStateMachine(IStateMachine &&)                 = delete;
+    IStateMachine &operator=(IStateMachine &&)      = delete;
+
+  protected:
+    IStateMachine() = default;
+};
+
+} // namespace vigine

--- a/include/vigine/vigine.h
+++ b/include/vigine/vigine.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 namespace vigine
 {
@@ -8,19 +9,56 @@ namespace vigine
 class StateMachine;
 class Context;
 class EntityManager;
+class IStateMachine;
+class IContext;
+class IEntityManager;
 
+namespace threading
+{
+class IThreadManager;
+} // namespace threading
+
+namespace messaging
+{
+class IMessageBus;
+} // namespace messaging
+
+/**
+ * @brief Top-level engine object.
+ *
+ * The public accessors return references to pure-virtual interfaces so
+ * that the engine's ownership model (private @c std::unique_ptr) stays
+ * decoupled from the surface callers see. The core domain objects
+ * (state machine, context, entity manager) keep their unique-ownership
+ * shape; only the accessors now return @c IStateMachine / @c IContext /
+ * @c IEntityManager references. Messaging and threading fields are
+ * forward-declared and lazily constructed by later leaves
+ * (plan_09 and onward); they are default-null in this leaf.
+ */
 class Engine
 {
   public:
     Engine();
     ~Engine();
+
     void run();
-    StateMachine *state();
-    Context *context();
+
+    [[nodiscard]] IStateMachine& state() const;
+    [[nodiscard]] IContext& context() const;
+    [[nodiscard]] IEntityManager& entityManager() const;
 
   private:
-    std::unique_ptr<StateMachine> _stateMachine;
-    std::unique_ptr<Context> _context;
+    // Messaging / threading substrate -- introduced here, left null.
+    // Their concrete wiring lands in later leaves (plan_09 for the
+    // message bus core, plan_23 for the final construction order).
+    std::unique_ptr<threading::IThreadManager>            _threadManager;
+    std::shared_ptr<messaging::IMessageBus>               _systemBus;
+    std::vector<std::shared_ptr<messaging::IMessageBus>>  _userBuses;
+
+    // Core engine state -- unique ownership preserved.
+    std::unique_ptr<StateMachine>  _stateMachine;
+    std::unique_ptr<Context>       _context;
     std::unique_ptr<EntityManager> _entityManager;
 };
+
 } // namespace vigine

--- a/src/messaging/abstractmessagetarget.cpp
+++ b/src/messaging/abstractmessagetarget.cpp
@@ -1,0 +1,51 @@
+#include "vigine/messaging/abstractmessagetarget.h"
+
+#include <cassert>
+#include <utility>
+
+#include "vigine/messaging/iconnectiontoken.h"
+
+namespace vigine::messaging
+{
+
+void AbstractMessageTarget::acceptConnection(std::unique_ptr<IConnectionToken> token)
+{
+    std::lock_guard<std::mutex> lock{_connectionsMutex};
+    _connections.push_back(std::move(token));
+}
+
+bool AbstractMessageTarget::canMove() const noexcept
+{
+    // Deliberately unsynchronised: the check is advisory only; callers
+    // that race with a concurrent acceptConnection cannot rely on the
+    // answer for correctness. The move constructor / move assignment
+    // below asserts on the same predicate under a lock.
+    return _connections.empty();
+}
+
+AbstractMessageTarget::AbstractMessageTarget(AbstractMessageTarget &&other) noexcept
+{
+    std::lock_guard<std::mutex> lock{other._connectionsMutex};
+    assert(other._connections.empty()
+           && "AbstractMessageTarget move: source is still registered");
+    _connections = std::move(other._connections);
+}
+
+AbstractMessageTarget &
+AbstractMessageTarget::operator=(AbstractMessageTarget &&other) noexcept
+{
+    if (this == &other)
+    {
+        return *this;
+    }
+    std::scoped_lock<std::mutex, std::mutex> lock{_connectionsMutex,
+                                                  other._connectionsMutex};
+    assert(_connections.empty()
+           && "AbstractMessageTarget move-assign: destination is still registered");
+    assert(other._connections.empty()
+           && "AbstractMessageTarget move-assign: source is still registered");
+    _connections = std::move(other._connections);
+    return *this;
+}
+
+} // namespace vigine::messaging

--- a/src/messaging/cleanup.cpp
+++ b/src/messaging/cleanup.cpp
@@ -1,0 +1,16 @@
+#include "messaging/cleanup.h"
+
+namespace vigine::messaging
+{
+
+void MessagingCleanup::flipDead(
+    const std::shared_ptr<IBusControlBlock> &block) noexcept
+{
+    if (!block)
+    {
+        return;
+    }
+    block->markDead();
+}
+
+} // namespace vigine::messaging

--- a/src/messaging/cleanup.h
+++ b/src/messaging/cleanup.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <memory>
+
+#include "vigine/messaging/ibuscontrolblock.h"
+
+namespace vigine::messaging
+{
+/**
+ * @brief Drains a bus's pending connections at engine-shutdown time.
+ *
+ * Exposes a small helper the Engine can call on shutdown to flip an
+ * @ref IBusControlBlock into the dead state before any remaining
+ * @ref ConnectionToken destructors run. Declared as a standalone
+ * helper because the Engine assembly leaf (context_aggregator,
+ * plan_23) is the site that wires the exact dtor order; until that
+ * lands, facade and bus ownership is introduced in later leaves and
+ * this helper is available for them to call.
+ *
+ * Thread-safety: @ref flipDead is safe to call from any thread.
+ * Idempotent: a second call on the same block is a no-op.
+ */
+class MessagingCleanup
+{
+  public:
+    /**
+     * @brief Flips @p block into the dead state.
+     *
+     * Null @p block is tolerated so callers can pass a bus-owned
+     * @c std::shared_ptr without a pre-check. After this call every
+     * live @ref ConnectionToken observing @p block reports
+     * @ref IConnectionToken::active as @c false.
+     */
+    static void flipDead(const std::shared_ptr<IBusControlBlock> &block) noexcept;
+
+    MessagingCleanup()                                     = delete;
+    MessagingCleanup(const MessagingCleanup &)             = delete;
+    MessagingCleanup &operator=(const MessagingCleanup &)  = delete;
+    MessagingCleanup(MessagingCleanup &&)                  = delete;
+    MessagingCleanup &operator=(MessagingCleanup &&)       = delete;
+};
+
+} // namespace vigine::messaging

--- a/src/messaging/connectiontoken.cpp
+++ b/src/messaging/connectiontoken.cpp
@@ -1,0 +1,58 @@
+#include "vigine/messaging/connectiontoken.h"
+
+#include <utility>
+
+#include "vigine/messaging/ibuscontrolblock.h"
+
+namespace vigine::messaging
+{
+
+ConnectionToken::ConnectionToken(std::weak_ptr<IBusControlBlock> control,
+                                 ConnectionId                   id) noexcept
+    : _control{std::move(control)}, _id{id}
+{
+}
+
+ConnectionToken::~ConnectionToken()
+{
+    // First, prevent new dispatches on this slot. If the bus is still
+    // alive we ask it to drop our registry entry; if it died first, the
+    // weak lock fails and we fall through to the drain wait.
+    if (auto ctrl = _control.lock())
+    {
+        ctrl->unregisterTarget(_id);
+    }
+
+    // Strong-unsubscribe barrier: wait until every dispatch that
+    // observed the slot (before unregisterTarget took effect) has
+    // finished calling AbstractMessageTarget::onMessage. The bus is
+    // responsible for incrementing _inFlight before the call and
+    // decrementing it after the call; endDispatch signals the cv on
+    // the 1 -> 0 transition.
+    std::unique_lock<std::mutex> lock{_waitMutex};
+    _waitCv.wait(lock, [this] {
+        return _inFlight.load(std::memory_order_acquire) == 0;
+    });
+}
+
+bool ConnectionToken::active() const noexcept
+{
+    auto ctrl = _control.lock();
+    return static_cast<bool>(ctrl) && ctrl->isAlive();
+}
+
+void ConnectionToken::beginDispatch() noexcept
+{
+    _inFlight.fetch_add(1, std::memory_order_acq_rel);
+}
+
+void ConnectionToken::endDispatch() noexcept
+{
+    if (_inFlight.fetch_sub(1, std::memory_order_acq_rel) == 1)
+    {
+        std::lock_guard<std::mutex> lock{_waitMutex};
+        _waitCv.notify_all();
+    }
+}
+
+} // namespace vigine::messaging

--- a/src/messaging/ibuscontrolblock_default.cpp
+++ b/src/messaging/ibuscontrolblock_default.cpp
@@ -1,0 +1,109 @@
+#include "messaging/ibuscontrolblock_default.h"
+
+#include <mutex>
+
+namespace vigine::messaging
+{
+
+DefaultBusControlBlock::DefaultBusControlBlock() noexcept = default;
+
+DefaultBusControlBlock::~DefaultBusControlBlock()
+{
+    // markDead is idempotent; running it from the destructor makes sure
+    // that any token that outlives this block but observes the weak_ptr
+    // lock() before the shared count drops to zero still sees the bus
+    // as dead and skips its unregister call.
+    markDead();
+}
+
+bool DefaultBusControlBlock::isAlive() const noexcept
+{
+    return _alive.load(std::memory_order_acquire);
+}
+
+void DefaultBusControlBlock::markDead() noexcept
+{
+    _alive.store(false, std::memory_order_release);
+}
+
+ConnectionId
+DefaultBusControlBlock::allocateSlot(AbstractMessageTarget *target)
+{
+    if (target == nullptr)
+    {
+        return ConnectionId{};
+    }
+    if (!_alive.load(std::memory_order_acquire))
+    {
+        return ConnectionId{};
+    }
+
+    std::unique_lock<std::shared_mutex> lock{_registryMutex};
+
+    // Re-check under the lock: another thread may have raced ahead and
+    // called markDead between the fast-path read and the lock.
+    if (!_alive.load(std::memory_order_acquire))
+    {
+        return ConnectionId{};
+    }
+
+    const std::uint32_t index      = _nextIndex++;
+    const std::uint32_t generation = _nextGeneration++;
+    _registry.emplace(index, Slot{target, generation});
+
+    return ConnectionId{index, generation};
+}
+
+void DefaultBusControlBlock::unregisterTarget(ConnectionId id) noexcept
+{
+    if (!id.valid())
+    {
+        return;
+    }
+    if (!_alive.load(std::memory_order_acquire))
+    {
+        // Fast-path after markDead: drop the lock acquisition entirely
+        // and let the destructor reclaim the registry en masse.
+        return;
+    }
+
+    std::unique_lock<std::shared_mutex> lock{_registryMutex};
+    auto it = _registry.find(id.index);
+    if (it == _registry.end())
+    {
+        return;
+    }
+    if (it->second.generation != id.generation)
+    {
+        // The slot was already recycled under a newer generation; the
+        // caller's id is stale and must not touch the live slot.
+        return;
+    }
+    _registry.erase(it);
+}
+
+AbstractMessageTarget *
+DefaultBusControlBlock::lookup(ConnectionId id) const noexcept
+{
+    if (!id.valid())
+    {
+        return nullptr;
+    }
+    if (!_alive.load(std::memory_order_acquire))
+    {
+        return nullptr;
+    }
+    std::shared_lock<std::shared_mutex> lock{_registryMutex};
+    auto it = _registry.find(id.index);
+    if (it == _registry.end())
+    {
+        return nullptr;
+    }
+    if (it->second.generation != id.generation)
+    {
+        return nullptr;
+    }
+    return it->second.target;
+}
+
+} // namespace vigine::messaging

--- a/src/messaging/ibuscontrolblock_default.h
+++ b/src/messaging/ibuscontrolblock_default.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <shared_mutex>
+#include <unordered_map>
+
+#include "vigine/messaging/connectionid.h"
+#include "vigine/messaging/ibuscontrolblock.h"
+
+namespace vigine::messaging
+{
+class AbstractMessageTarget;
+
+/**
+ * @brief Reference implementation of @ref IBusControlBlock used by the
+ *        default message bus.
+ *
+ * The class owns the atomic alive flag, the generational slot
+ * generator, and the target registry. Mutating entry points take an
+ * exclusive lock on an internal @c std::shared_mutex; the alive check
+ * is wait-free through a @c std::atomic<bool> loaded with acquire
+ * ordering. The registry keeps raw, non-owning pointers to
+ * @ref AbstractMessageTarget objects; lifetime safety is provided by
+ * @ref ConnectionToken running the corresponding @ref unregisterTarget
+ * before the target is destroyed.
+ *
+ * The class is sized for a single bus instance. It lives under @c src
+ * because it is a concrete implementation detail; the public surface
+ * for callers is @ref IBusControlBlock.
+ */
+class DefaultBusControlBlock final : public IBusControlBlock
+{
+  public:
+    DefaultBusControlBlock() noexcept;
+    ~DefaultBusControlBlock() override;
+
+    [[nodiscard]] bool isAlive() const noexcept override;
+    void               markDead() noexcept override;
+
+    [[nodiscard]] ConnectionId
+        allocateSlot(AbstractMessageTarget *target) override;
+    void unregisterTarget(ConnectionId id) noexcept override;
+
+    /**
+     * @brief Returns the live target pointer behind @p id, or
+     *        @c nullptr when the slot is stale, recycled, or the bus
+     *        is dead.
+     *
+     * Exposed on the concrete type so that the bus's dispatch path can
+     * look up the target without reaching into the registry map
+     * directly. The returned pointer is valid only as long as the
+     * matching @ref ConnectionToken is alive; the bus holds a
+     * @c shared_lock while dereferencing it.
+     */
+    [[nodiscard]] AbstractMessageTarget *lookup(ConnectionId id) const noexcept;
+
+  private:
+    struct Slot
+    {
+        AbstractMessageTarget *target{nullptr};
+        std::uint32_t          generation{0};
+    };
+
+    mutable std::shared_mutex                     _registryMutex;
+    std::unordered_map<std::uint32_t, Slot>       _registry;
+    std::uint32_t                                 _nextIndex{1};
+    std::uint32_t                                 _nextGeneration{1};
+    std::atomic<bool>                             _alive{true};
+};
+
+} // namespace vigine::messaging

--- a/src/vigine.cpp
+++ b/src/vigine.cpp
@@ -3,8 +3,7 @@
 #include "vigine/context.h"
 #include "vigine/ecs/entitymanager.h"
 #include "vigine/statemachine.h"
-
-#include <iostream>
+#include "vigine/threading/ithreadmanager.h"
 
 namespace vigine
 {
@@ -16,7 +15,7 @@ Engine::Engine()
     _stateMachine.reset(new StateMachine(_context.get()));
 }
 
-Engine::~Engine() {}
+Engine::~Engine() = default;
 
 void Engine::run()
 {
@@ -24,10 +23,10 @@ void Engine::run()
         _stateMachine->runCurrentState();
 }
 
-StateMachine *Engine::state() { return _stateMachine.get(); }
+IStateMachine &Engine::state() const { return *_stateMachine; }
 
-Context *Engine::context() { return _context.get(); }
+IContext &Engine::context() const { return *_context; }
 
-void exampleFunction() {}
+IEntityManager &Engine::entityManager() const { return *_entityManager; }
 
 } // namespace vigine

--- a/test/architecture/EngineTest.cpp
+++ b/test/architecture/EngineTest.cpp
@@ -26,7 +26,9 @@ TEST(EngineTest, constructor_empty)
 TEST(EngineTest, state)
 {
     auto engine = std::make_unique<Engine>();
-    ASSERT_NE(engine->state(), nullptr);
+    // Engine::state() returns IStateMachine& -- a reference, so the
+    // address is always non-null by construction.
+    ASSERT_NE(&engine->state(), nullptr);
 }
 
 TEST(EngineTest, run_without_states)
@@ -37,8 +39,10 @@ TEST(EngineTest, run_without_states)
 
 TEST(EngineTest, state_management)
 {
-    auto engine       = std::make_unique<Engine>();
-    auto stateMachine = engine->state();
+    auto engine = std::make_unique<Engine>();
+    // Downcast back to the concrete StateMachine for the rich state
+    // API; later leaves move that API onto IStateMachine itself.
+    auto *stateMachine = static_cast<StateMachine *>(&engine->state());
     ASSERT_NE(stateMachine, nullptr);
 
     // Test state machine functionality through engine

--- a/test/architecture/StateMachineTest.cpp
+++ b/test/architecture/StateMachineTest.cpp
@@ -146,7 +146,7 @@ TEST(StateMachineTest, method_destructor)
 TEST(StateMachineTest, addState)
 {
     vigine::Engine eng;
-    auto stateMachine          = eng.state();
+    auto *stateMachine         = static_cast<StateMachine *>(&eng.state());
     auto someState             = std::make_unique<SomeState>();
     SomeState *rawPtrSomeState = someState.get();
 
@@ -158,7 +158,9 @@ TEST(StateMachineTest, addState)
 TEST(StateMachineTest, addTransition)
 {
     vigine::Engine eng;
-    auto stateMachine = eng.state();
+    // Engine::state() returns IStateMachine& after R.3.1.1; the rich
+    // StateMachine surface lands on the interface in a later leaf.
+    auto *stateMachine = static_cast<StateMachine *>(&eng.state());
 
     // Add states
     auto state1            = std::make_unique<SomeState>();
@@ -187,7 +189,9 @@ TEST(StateMachineTest, addTransition)
 TEST(StateMachineTest, hasStatesToRun)
 {
     vigine::Engine eng;
-    auto stateMachine = eng.state();
+    // Engine::state() returns IStateMachine& after R.3.1.1; the rich
+    // StateMachine surface lands on the interface in a later leaf.
+    auto *stateMachine = static_cast<StateMachine *>(&eng.state());
 
     // Check without state
     ASSERT_FALSE(stateMachine->hasStatesToRun());
@@ -205,7 +209,9 @@ TEST(StateMachineTest, hasStatesToRun)
 TEST(StateMachineTest, runCurrentState_without_transition)
 {
     vigine::Engine eng;
-    auto stateMachine = eng.state();
+    // Engine::state() returns IStateMachine& after R.3.1.1; the rich
+    // StateMachine surface lands on the interface in a later leaf.
+    auto *stateMachine = static_cast<StateMachine *>(&eng.state());
 
     // Add state
     auto state    = std::make_unique<SomeState>();
@@ -223,7 +229,9 @@ TEST(StateMachineTest, runCurrentState_without_transition)
 TEST(StateMachineTest, changeStateTo)
 {
     vigine::Engine eng;
-    auto stateMachine = eng.state();
+    // Engine::state() returns IStateMachine& after R.3.1.1; the rich
+    // StateMachine surface lands on the interface in a later leaf.
+    auto *stateMachine = static_cast<StateMachine *>(&eng.state());
 
     // Add states
     auto state1    = std::make_unique<SomeState>();
@@ -246,7 +254,9 @@ TEST(StateMachineTest, changeStateTo)
 TEST(StateMachineTest, currentState)
 {
     vigine::Engine eng;
-    auto stateMachine = eng.state();
+    // Engine::state() returns IStateMachine& after R.3.1.1; the rich
+    // StateMachine surface lands on the interface in a later leaf.
+    auto *stateMachine = static_cast<StateMachine *>(&eng.state());
 
     // Initially should be nullptr
     ASSERT_EQ(nullptr, stateMachine->currentState());


### PR DESCRIPTION
Ships the messaging control plane.

- `IConnectionToken` / `ConnectionToken` -- subscriber-side RAII handle. Token holds a `weak_ptr` to the bus's `IBusControlBlock` plus a generational `ConnectionId`; destructor unregisters the slot and then blocks on an `atomic<uint32_t>` counter until every in-flight dispatch on this slot has drained (strong-unsubscribe barrier).
- `IBusControlBlock` / `DefaultBusControlBlock` -- shared-heap anchor the bus hands out. Default impl uses an `atomic<bool>` alive flag and a `shared_mutex`-guarded slot map with generational ids.
- `AbstractMessageTarget` -- stateful abstract base every subscriber derives from. Private `vector<unique_ptr<IConnectionToken>>` plus mutex; `acceptConnection` is the only mutator the bus touches. Move asserts the source is unregistered.
- `MessagingCleanup` under `src/messaging/` -- standalone helper that flips an `IBusControlBlock` into the dead state. A later context-aggregator leaf wires it into the engine shutdown sequence; destruction order stays untouched here.
- `Engine` accessors return `IStateMachine& / IContext& / IEntityManager&`; ownership stays `unique_ptr`. Three minimal forward-declared pure-virtual stubs ship alongside so the accessor bodies compile; the stubs get their finalised surface in later leaves. `IThreadManager` + `shared_ptr<IMessageBus>` fields are added ahead of wiring.
- `Result::Code::SubscriptionExpired` + `Result::Code::InvalidMessageTarget` appended (numeric values of existing codes unchanged).

Example mains and two tests use a `static_cast<StateMachine*>(&engine.state())` bridge where the rich state-machine surface is still needed; the cast disappears once a later leaf lifts that surface onto `IStateMachine`.

`cmake --build build --target vigine` -- clean on Debug and Release. The unrelated `TaskFlowTest.cpp` error (`TaskFlow::addTransition` no longer exists) reproduces on unmodified `main` and is pre-existing.

Closes #97
