### PR TITLE
build: CMake 3.25 + C++23 + Vulkan 1.3 baseline, three-OS CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,38 @@ jobs:
 
       - name: Run test_check_naming_convention
         run: pytest test/scripts/test_check_naming_convention.py -q
+
+  # Three-OS build matrix. Every cell runs a Debug and a Release build
+  # under the project baseline (CMake 3.25, C++23, Vulkan 1.3). vcpkg
+  # caches are keyed per-OS and per vcpkg.json hash so a lockfile bump
+  # invalidates only the affected slice.
+  #
+  # ASAN / UBSAN / TSAN jobs to be added in the sanitizer-matrix change.
+  build:
+    name: Build ${{ matrix.os }} ${{ matrix.config }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-2022, ubuntu-22.04, macos-13]
+        config: [Debug, Release]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Cache vcpkg
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ github.workspace }}/vcpkg
+            ${{ github.workspace }}/build/vcpkg_installed
+          key: vcpkg-${{ matrix.os }}-${{ hashFiles('vcpkg.json') }}
+          restore-keys: |
+            vcpkg-${{ matrix.os }}-
+
+      - name: Configure
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ matrix.config }}
+
+      - name: Build
+        run: cmake --build build --config ${{ matrix.config }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.25)
 
 set(PROJECT_NAME vigine)
 
@@ -10,17 +10,35 @@ project(${PROJECT_NAME})
 set(VIGINE_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR} CACHE INTERNAL "Vigine root directory")
 
 #
-# Set C++23 standard
+# Set C++23 standard. CMAKE_CXX_EXTENSIONS OFF keeps the build portable
+# across MSVC, libc++ / clang, and libstdc++ / gcc -- GNU extensions
+# silently change semantics (e.g. VLAs, __restrict) that are not part
+# of ISO C++.
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
+set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# Load the central compile-options helper. The helper is scoped to the
+# vigine library target (not directory-wide) so bundled third-party
+# sources like FreeType do not inherit /W4 / -Wpedantic.
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/VigineCompileOptions.cmake)
 
 if(MSVC)
     add_compile_options(/FS /utf-8)
 endif()
 
 if(WIN32)
-    add_compile_definitions(VK_USE_PLATFORM_WIN32_KHR)
+    # Windows 10+ baseline. Pins every Win32 API surface the build
+    # consumes to the Windows 10 (NTDDI_WIN10_VB) feature set; an older
+    # API accidentally used elsewhere would fail to compile here.
+    add_compile_definitions(
+        VK_USE_PLATFORM_WIN32_KHR
+        _WIN32_WINNT=0x0A00
+        NTDDI_VERSION=0x0A000000
+        WIN32_LEAN_AND_MEAN
+        NOMINMAX
+    )
 endif()
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -56,7 +74,18 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/external/freetype EXCLUDE_FROM_ALL)
 
 # Find and include glm
 find_package(GLM REQUIRED)
-find_package(Vulkan REQUIRED)
+# Vulkan 1.3 is the baseline. Try 1.3 first; if the build host only has
+# 1.2, downgrade with a visible WARNING so the mismatch is audible in
+# configure logs. CI jobs pin SDK 1.3.
+find_package(Vulkan 1.3 QUIET)
+if(Vulkan_FOUND)
+    find_package(Vulkan 1.3 REQUIRED)
+else()
+    message(WARNING
+        "Vulkan 1.3 SDK not found; falling back to Vulkan >= 1.2. "
+        "CI jobs require 1.3 -- install VulkanSDK 1.3+ for a parity build.")
+    find_package(Vulkan 1.2 REQUIRED)
+endif()
 find_package(VulkanHpp REQUIRED)
 
 # std::thread / std::mutex need the Threads package (Threads::Threads)
@@ -354,6 +383,12 @@ add_library(${PROJECT_NAME}
     include/vigine/base/macros.h
     include/vigine/base/info.h
 )
+
+# Apply the warning / strict-mode compile options to the vigine target.
+# Scoped via target_compile_options inside the helper so FreeType and
+# other vendored dependencies are not affected.
+vigine_apply_compile_options(${PROJECT_NAME})
+
 # Include directories
 target_include_directories(${PROJECT_NAME}
     PUBLIC

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,7 +2,7 @@
     "version": 6,
     "cmakeMinimumRequired": {
         "major": 3,
-        "minor": 21,
+        "minor": 25,
         "patch": 0
     },
     "configurePresets": [

--- a/cmake/VigineCompileOptions.cmake
+++ b/cmake/VigineCompileOptions.cmake
@@ -1,0 +1,33 @@
+# VigineCompileOptions.cmake
+#
+# Central compile-option helper. Provides vigine_apply_compile_options()
+# which applies the warning / strict-mode flag set that the vigine
+# library (and only vigine, never its vendored dependencies) compiles
+# under. Bundled third-party sources like FreeType must NOT inherit the
+# stricter warning set or the log would drown in unrelated noise.
+#
+# Baseline:
+#   * MSVC / clang-cl : /W4 /permissive- /Zc:__cplusplus
+#   * GCC / Clang     : -Wall -Wextra -Wpedantic
+#   * C++ standard    : c++23, no GNU extensions (set at root via
+#                       CMAKE_CXX_EXTENSIONS OFF)
+#
+# /WX / -Werror is deliberately absent -- pre-existing warnings in
+# ecs/render/meshcomponent.h are not fixed here. The CI matrix
+# surfaces new warnings; a follow-up change will flip the switch once
+# the render headers are clean.
+
+function(vigine_apply_compile_options target)
+    if(MSVC)
+        # /Zc:__cplusplus lets feature-test macros report the real
+        # standard (MSVC otherwise reports 199711L for any -std setting).
+        # /permissive- disables MSVC-specific language extensions;
+        # paired with CMAKE_CXX_EXTENSIONS OFF it keeps the code ISO-C++
+        # portable.
+        target_compile_options(${target} PRIVATE /W4 /permissive- /Zc:__cplusplus)
+    else()
+        # GCC and Clang share the same flag spellings. -Wpedantic
+        # catches GNU extensions we'd otherwise miss on Linux / macOS.
+        target_compile_options(${target} PRIVATE -Wall -Wextra -Wpedantic)
+    endif()
+endfunction()

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,0 +1,88 @@
+# Building Vigine
+
+Vigine compiles under a single codified baseline: CMake 3.25, C++23
+(no GNU extensions), Windows 10+, Vulkan 1.3. The same CMake project
+drives Windows, Linux, and macOS builds. CI verifies every
+combination on every push.
+
+## Required toolchain
+
+| OS | Compiler | CMake | Vulkan SDK |
+|----|----------|-------|------------|
+| Windows 10+ | MSVC 2022 (17.5+) | 3.25 | 1.3 |
+| Ubuntu 22.04+ | g++-13 or clang-16 | 3.25 | 1.3 |
+| macOS 13+ | AppleClang 15+ (Xcode 15) | 3.25 | 1.3 |
+
+The CMake baseline is pinned by `cmake_minimum_required(VERSION 3.25)`
+at the top of the root `CMakeLists.txt`. The C++ standard is pinned by
+`CMAKE_CXX_STANDARD 23` together with `CMAKE_CXX_EXTENSIONS OFF`
+(no `-std=gnu++23`).
+
+## Windows baseline defines
+
+The root CMake adds these on every WIN32 build:
+
+```
+_WIN32_WINNT = 0x0A00          # Windows 10
+NTDDI_VERSION = 0x0A000000     # NTDDI_WIN10
+WIN32_LEAN_AND_MEAN            # trim <Windows.h>
+NOMINMAX                       # avoid min/max macro collisions
+VK_USE_PLATFORM_WIN32_KHR      # surface-factory selector
+```
+
+If a newer API surface is needed, bump `_WIN32_WINNT` and
+`NTDDI_VERSION` together; they are paired intentionally.
+
+## Warning level
+
+`cmake/VigineCompileOptions.cmake` applies per-toolchain warning
+flags to the `vigine` library target (scoped, so vendored FreeType
+does not inherit them):
+
+| Toolchain | Flags |
+|-----------|-------|
+| MSVC / clang-cl | `/W4 /permissive- /Zc:__cplusplus` |
+| GCC / Clang (any non-MSVC) | `-Wall -Wextra -Wpedantic` |
+
+`/WX` and `-Werror` are intentionally not enabled in this baseline; a
+follow-up change will flip them once the pre-existing render-header
+warnings are cleaned up.
+
+## Local build
+
+```bash
+cmake -S . -B build
+cmake --build build --config Debug
+cmake --build build --config Release
+```
+
+On Windows, CMake selects the Visual Studio 2022 generator
+automatically; pass `-G Ninja` if Ninja is installed and preferred.
+
+## CI matrix
+
+`.github/workflows/ci.yml` defines a three-OS build matrix:
+
+| Runner | Configs |
+|--------|---------|
+| `windows-2022` | Debug, Release |
+| `ubuntu-22.04` | Debug, Release |
+| `macos-13` | Debug, Release |
+
+Each cell caches vcpkg keyed on the OS and the SHA of `vcpkg.json`, so
+a lockfile bump invalidates only the affected slices. The Python
+static checkers (`check_graph_purity`, `check_naming_convention`,
+their pytest suites) continue to run on `ubuntu-latest` only.
+
+## Vulkan 1.3 fallback
+
+The root CMake tries `find_package(Vulkan 1.3 REQUIRED)`. If only
+Vulkan 1.2 is present on a build host, configuration emits a visible
+`WARNING` and falls back to 1.2 so local development is not blocked
+on every engineer's laptop. CI runners always pin 1.3.
+
+## Sanitizers
+
+Sanitizer builds (ASAN / UBSAN / TSAN) are not part of this baseline.
+They ship in a later change under a dedicated sanitizer-matrix job
+that extends the CI matrix above.


### PR DESCRIPTION
## Summary

Locks the build baseline for the Vigine engine:

- **CMake 3.25** minimum (was 3.10); enables modern feature set across all sub-directories.
- **C++23** with `CMAKE_CXX_EXTENSIONS OFF` so MSVC / libc++ / libstdc++ stay in ISO-mode.
- **Windows 10+** pinned via `_WIN32_WINNT=0x0A00` and `NTDDI_VERSION=0x0A000000` (plus `WIN32_LEAN_AND_MEAN` and `NOMINMAX` to trim `<Windows.h>`).
- **Warning flags** in `cmake/VigineCompileOptions.cmake` — `/W4 /permissive- /Zc:__cplusplus` on MSVC, `-Wall -Wextra -Wpedantic` on GCC/Clang. Flags are scoped to the `vigine` library target so vendored FreeType does not inherit them. `/WX` / `-Werror` are intentionally off in this change.
- **Vulkan 1.3** pinned at `find_package`, with a visible downgrade warning to 1.2 for dev hosts that have not rolled to the 1.3 SDK.
- **Three-OS CI matrix** — `windows-2022`, `ubuntu-22.04`, `macos-13`, each Debug + Release. vcpkg cache keyed on OS + `vcpkg.json` hash. Python-checker jobs stay on `ubuntu-latest`.
- **`docs/build.md`** documents the toolchain, local build flow, and the CI matrix.
- **`CMakePresets.json`** `cmakeMinimumRequired` bumped to 3.25.

## Local verification

- Fresh configure: `cmake -S . -B build -DENABLE_POSTGRESQL=OFF -DENABLE_EXAMPLE=OFF` — OK.
- `cmake --build build --config Debug --target vigine` — OK.
- `cmake --build build --config Release --target vigine` — OK.
- Only warnings surfaced are pre-existing (`meshcomponent.h` C4267; two C4100s in `abstractpayloadregistry.cpp` that are now visible under `/W4`).

## Test plan

- [ ] CI matrix build cells go green on `windows-2022`, `ubuntu-22.04`, `macos-13` for both Debug and Release.
- [ ] `check_graph_purity`, `check_naming_convention`, and `unit-tests-scripts` jobs stay green on `ubuntu-latest`.
- [ ] vcpkg cache hit on a re-run of the same commit.

Closes #122