### PR TITLE
R.3.2.1: Ship IMessageBus + AbstractMessageBus + routing core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,19 @@ set(HEADER
     ${INCLUDE_DIR}/vigine/messaging/ibuscontrolblock.h
     ${INCLUDE_DIR}/vigine/messaging/connectiontoken.h
     ${INCLUDE_DIR}/vigine/messaging/abstractmessagetarget.h
+    ${INCLUDE_DIR}/vigine/messaging/busid.h
+    ${INCLUDE_DIR}/vigine/messaging/busconfig.h
+    ${INCLUDE_DIR}/vigine/messaging/messagekind.h
+    ${INCLUDE_DIR}/vigine/messaging/routemode.h
+    ${INCLUDE_DIR}/vigine/messaging/messagefilter.h
+    ${INCLUDE_DIR}/vigine/messaging/imessagepayload.h
+    ${INCLUDE_DIR}/vigine/messaging/imessage.h
+    ${INCLUDE_DIR}/vigine/messaging/isubscriber.h
+    ${INCLUDE_DIR}/vigine/messaging/isubscriptiontoken.h
+    ${INCLUDE_DIR}/vigine/messaging/imessagebus.h
+    ${INCLUDE_DIR}/vigine/messaging/abstractmessagebus.h
+    ${INCLUDE_DIR}/vigine/messaging/systemmessagebus.h
+    ${INCLUDE_DIR}/vigine/messaging/factory.h
     ${INCLUDE_DIR}/vigine/statemachine/istatemachine.h
     ${INCLUDE_DIR}/vigine/context/icontext.h
     ${INCLUDE_DIR}/vigine/ecs/ientitymanager.h
@@ -246,6 +259,14 @@ set(SOURCES
     ${SRC_DIR}/messaging/ibuscontrolblock_default.cpp
     ${SRC_DIR}/messaging/cleanup.h
     ${SRC_DIR}/messaging/cleanup.cpp
+    ${SRC_DIR}/messaging/abstractmessagebus.cpp
+    ${SRC_DIR}/messaging/systemmessagebus.cpp
+    ${SRC_DIR}/messaging/createmessagebus.cpp
+    ${SRC_DIR}/messaging/routing/firstmatch.cpp
+    ${SRC_DIR}/messaging/routing/fanout.cpp
+    ${SRC_DIR}/messaging/routing/chain.cpp
+    ${SRC_DIR}/messaging/routing/bubble.cpp
+    ${SRC_DIR}/messaging/routing/broadcast.cpp
 )
 
 # Add platform-specific surface factory

--- a/include/vigine/messaging/abstractmessagebus.h
+++ b/include/vigine/messaging/abstractmessagebus.h
@@ -1,0 +1,232 @@
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <unordered_map>
+#include <vector>
+
+#include "vigine/graph/abstractgraph.h"
+#include "vigine/messaging/busconfig.h"
+#include "vigine/messaging/busid.h"
+#include "vigine/messaging/connectionid.h"
+#include "vigine/messaging/imessage.h"
+#include "vigine/messaging/imessagebus.h"
+#include "vigine/messaging/isubscriber.h"
+#include "vigine/messaging/isubscriptiontoken.h"
+#include "vigine/messaging/messagefilter.h"
+#include "vigine/result.h"
+
+namespace vigine::threading
+{
+class IThreadManager;
+} // namespace vigine::threading
+
+namespace vigine::messaging
+{
+class AbstractMessageTarget;
+class DefaultBusControlBlock;
+
+/**
+ * @brief Stateful abstract base that carries every piece of bus state
+ *        every concrete message bus reuses.
+ *
+ * @ref AbstractMessageBus is level 4 of the five-layer wrapper recipe
+ * (see @c theory_wrapper_creation_recipe.md). It inherits
+ * @ref IMessageBus @c public so the bus surface sits at offset zero for
+ * zero-cost up-casts, and @ref vigine::graph::AbstractGraph
+ * @c protected so the graph substrate is available to wrapper code
+ * without leaking into the bus's public surface.
+ *
+ * The class carries state, so it follows the project's @c Abstract
+ * naming convention rather than the @c I pure-virtual prefix. Everything
+ * is @c private: the control block, the subscription registry, the
+ * queue, the dispatch mutex, the shutdown flag, and the handle to the
+ * injected @ref vigine::threading::IThreadManager. Concrete subclasses
+ * extend the chain (for example @ref SystemMessageBus) to pin a specific
+ * @ref BusConfig shape; they do not override behaviour.
+ *
+ * Ownership and lifetime:
+ *   - The bus owns a @c std::shared_ptr<IBusControlBlock>. Every
+ *     @ref ConnectionToken handed to a registered
+ *     @ref AbstractMessageTarget holds a matching
+ *     @c std::weak_ptr to the same control block. When the bus is
+ *     destroyed first, the control block is marked dead and token
+ *     destructors become safe no-ops. When a target is destroyed first,
+ *     its tokens run @c unregisterTarget to keep the registry in sync.
+ *   - Subscriptions are owned by the bus: @ref subscribe stores the
+ *     caller-supplied raw pointer in the registry and returns a
+ *     @c std::unique_ptr<ISubscriptionToken>. Dropping the token removes
+ *     the registry entry.
+ *   - The injected @ref vigine::threading::IThreadManager is referenced
+ *     by pointer; the engine guarantees the manager outlives every bus
+ *     it hands a reference to.
+ *
+ * Thread-safety: @ref post serialises against the queue mutex; the
+ * dispatch worker drains the queue under the same mutex; the
+ * subscription registry is read-heavy and so guarded by a
+ * @c std::shared_mutex (writers take an exclusive lock; dispatch takes a
+ * shared lock for the duration of its snapshot). The control block
+ * carries its own @c std::shared_mutex for the target registry.
+ *
+ * Exception policy: subscriber exceptions are isolated at the dispatch
+ * boundary and reported as @ref DispatchResult::Handled so the registry
+ * keeps walking. @c bad_alloc on @c post propagates to the caller; the
+ * bus's own state is untouched on that path.
+ */
+class AbstractMessageBus
+    : public IMessageBus
+    , protected vigine::graph::AbstractGraph
+{
+  public:
+    ~AbstractMessageBus() override;
+
+    // ------ IMessageBus ------
+
+    [[nodiscard]] BusId               id() const noexcept override;
+    [[nodiscard]] const BusConfig    &config() const noexcept override;
+
+    [[nodiscard]] Result registerTarget(AbstractMessageTarget *target) override;
+    [[nodiscard]] Result post(std::unique_ptr<IMessage> message) override;
+    [[nodiscard]] std::unique_ptr<ISubscriptionToken>
+        subscribe(const MessageFilter &filter, ISubscriber *subscriber) override;
+    Result shutdown() override;
+
+  protected:
+    /**
+     * @brief Builds the base with the supplied config and injected
+     *        thread manager.
+     *
+     * The constructor allocates the control block eagerly so every
+     * @ref registerTarget call after construction has a live block to
+     * point at. The @p threadManager reference is retained for the
+     * lifetime of the bus; the caller (typically the engine) guarantees
+     * the manager outlives every bus it owns.
+     */
+    AbstractMessageBus(BusConfig config, vigine::threading::IThreadManager &threadManager);
+
+    // Forwarded to subclasses so concrete constructors can inspect the
+    // chosen config before falling through to user code (for example
+    // @ref SystemMessageBus pins the id to the system reserved value).
+    [[nodiscard]] BusConfig       &mutableConfig() noexcept { return _config; }
+    [[nodiscard]] const BusConfig &immutableConfig() const noexcept { return _config; }
+
+  private:
+    // ------ Internal types ------
+
+    /// @brief One registry entry. Holds the raw subscriber pointer, the
+    ///        filter, and a serial id stamped when the slot is created.
+    struct SubscriptionSlot
+    {
+        ISubscriber  *subscriber{nullptr};
+        MessageFilter filter{};
+        std::uint64_t serial{0};
+        bool          active{true};
+    };
+
+    /// @brief Queue entry. Owns the envelope plus the scheduled-for
+    ///        timestamp so that the worker can requeue delayed traffic
+    ///        without parsing the message twice.
+    struct QueuedMessage
+    {
+        std::unique_ptr<IMessage>                        message;
+        std::chrono::steady_clock::time_point            deadline;
+    };
+
+    /// @brief Concrete subscription token handed back to callers of
+    ///        @ref subscribe. Removes its registry slot on destruction.
+    class SubscriptionToken final : public ISubscriptionToken
+    {
+      public:
+        SubscriptionToken(AbstractMessageBus *bus, std::uint64_t serial) noexcept;
+        ~SubscriptionToken() override;
+
+        void               cancel() noexcept override;
+        [[nodiscard]] bool active() const noexcept override;
+
+        SubscriptionToken(const SubscriptionToken &)            = delete;
+        SubscriptionToken &operator=(const SubscriptionToken &) = delete;
+        SubscriptionToken(SubscriptionToken &&)                 = delete;
+        SubscriptionToken &operator=(SubscriptionToken &&)      = delete;
+
+      private:
+        AbstractMessageBus *_bus;
+        std::uint64_t       _serial;
+        std::atomic<bool>   _cancelled{false};
+    };
+
+    friend class SubscriptionToken;
+
+    // ------ Dispatch helpers (implemented across the routing TUs) ------
+
+    /// @brief Drains one message, selecting the routing algorithm.
+    void dispatchOne(const IMessage &message);
+
+    /// @brief First-matching subscriber wins; early-exit DFS over the
+    ///        registry snapshot.
+    void dispatchFirstMatch(const IMessage                    &message,
+                            const std::vector<SubscriptionSlot> &snapshot);
+    /// @brief One-level fan-out to every matching subscriber.
+    void dispatchFanOut(const IMessage                    &message,
+                        const std::vector<SubscriptionSlot> &snapshot);
+    /// @brief Linear traversal until @ref DispatchResult::Handled or
+    ///        @ref DispatchResult::Stop.
+    void dispatchChain(const IMessage                    &message,
+                       const std::vector<SubscriptionSlot> &snapshot);
+    /// @brief Parent-chain traversal; falls back to @c FirstMatch when
+    ///        the target has no parent.
+    void dispatchBubble(const IMessage                    &message,
+                        const std::vector<SubscriptionSlot> &snapshot);
+    /// @brief Every subscriber receives the message regardless of the
+    ///        filter's @c target field.
+    void dispatchBroadcast(const IMessage                    &message,
+                           const std::vector<SubscriptionSlot> &snapshot);
+
+    // ------ Registry helpers ------
+
+    /// @brief Tests whether a slot matches a message's routing and
+    ///        payload tags. Target-match behaviour varies per route mode
+    ///        and is handled by the dispatch methods directly.
+    [[nodiscard]] static bool matches(const SubscriptionSlot &slot,
+                                      const IMessage         &message) noexcept;
+
+    /// @brief Deliver one message to one subscriber, isolating
+    ///        exceptions at the dispatch boundary.
+    [[nodiscard]] static DispatchResult deliver(ISubscriber   &subscriber,
+                                                const IMessage &message) noexcept;
+
+    /// @brief Builds a snapshot of the registry under the shared lock.
+    [[nodiscard]] std::vector<SubscriptionSlot> snapshotRegistry() const;
+
+    /// @brief Drains the queue. Returns when the queue is empty and
+    ///        either the shutdown flag is set or the caller requested a
+    ///        single drain pass.
+    void drainQueue(bool untilShutdown);
+
+    /// @brief Internal entry point used by the @ref SubscriptionToken
+    ///        destructor. Removes the matching slot if still present.
+    void removeSubscription(std::uint64_t serial) noexcept;
+
+    // ------ State ------
+
+    BusConfig                                      _config;
+    vigine::threading::IThreadManager             *_threadManager;
+    std::shared_ptr<DefaultBusControlBlock>        _control;
+
+    mutable std::shared_mutex                      _registryMutex;
+    std::unordered_map<std::uint64_t, SubscriptionSlot> _subscriptions;
+    std::uint64_t                                  _nextSerial{1};
+
+    mutable std::mutex                             _queueMutex;
+    std::condition_variable                        _queueCv;
+    std::deque<QueuedMessage>                      _queue;
+
+    std::atomic<bool>                              _shutdown{false};
+};
+
+} // namespace vigine::messaging

--- a/include/vigine/messaging/busconfig.h
+++ b/include/vigine/messaging/busconfig.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+
+#include "vigine/messaging/busid.h"
+
+namespace vigine::messaging
+{
+/**
+ * @brief Closed enumeration of bus scheduling priorities.
+ *
+ * The priority is advisory: the thread manager uses it to bias worker
+ * selection when more than one bus competes for a shared pool thread.
+ * @c High is typically assigned to the system bus so that
+ * @ref MessageKind::Control traffic wins against application workflows
+ * when the pool is saturated; @c Normal and @c Low are the usual tiers
+ * for application buses.
+ */
+enum class BusPriority : std::uint8_t
+{
+    High   = 1,
+    Normal = 2,
+    Low    = 3,
+};
+
+/**
+ * @brief Closed enumeration of bus threading policies.
+ *
+ * Selects the execution model the bus uses to drain its dispatch queue.
+ *   - @c Dedicated  -- the bus runs on its own worker, isolated from the
+ *                      pool. Used by the system bus to keep lifecycle
+ *                      traffic responsive under application load.
+ *   - @c Shared     -- the bus schedules dispatch work on the thread
+ *                      manager's shared pool. Default for user buses.
+ *   - @c InlineOnly -- the bus has no worker; @ref IMessageBus::post
+ *                      dispatches synchronously on the caller's thread.
+ *                      Used by tests and deterministic embedded setups.
+ */
+enum class ThreadingPolicy : std::uint8_t
+{
+    Dedicated  = 1,
+    Shared     = 2,
+    InlineOnly = 3,
+};
+
+/**
+ * @brief Closed enumeration of backpressure strategies applied when the
+ *        dispatch queue reaches its @ref QueueCapacity::maxMessages cap.
+ *
+ *   - @c Block      -- the posting thread waits until the queue drains
+ *                      below the high-water mark.
+ *   - @c DropOldest -- the oldest still-queued message is discarded to
+ *                      make room for the new one.
+ *   - @c Error      -- @ref IMessageBus::post returns an error result
+ *                      immediately; the caller decides how to retry.
+ */
+enum class BackpressurePolicy : std::uint8_t
+{
+    Block      = 1,
+    DropOldest = 2,
+    Error      = 3,
+};
+
+/**
+ * @brief POD describing the size of the bus's dispatch queue.
+ *
+ * When @c bounded is @c true, the queue holds at most @c maxMessages
+ * pending messages; additional @ref IMessageBus::post calls apply the
+ * configured @ref BackpressurePolicy. When @c bounded is @c false the
+ * queue grows dynamically and backpressure is effectively disabled.
+ */
+struct QueueCapacity
+{
+    std::size_t maxMessages{1024};
+    bool        bounded{true};
+};
+
+/**
+ * @brief POD describing the shape of a single message bus.
+ *
+ * Passed to @ref createMessageBus at construction time; stored inside the
+ * bus and reported back through @ref IMessageBus::config. All fields are
+ * plain value types so the config survives a round-trip through any
+ * facade that needs to inspect it without coupling to the bus's internal
+ * state.
+ *
+ * The default values describe a user bus: @c Normal priority, shared
+ * threading, 1024-deep bounded queue with blocking backpressure, and the
+ * sentinel @ref BusId which the factory replaces with the next assigned
+ * id. The @c name field is a non-owning view; callers must keep the
+ * backing storage alive for the lifetime of the bus (typically a
+ * string literal).
+ */
+struct BusConfig
+{
+    BusId              id{};
+    std::string_view   name{"user-bus"};
+    BusPriority        priority{BusPriority::Normal};
+    ThreadingPolicy    threading{ThreadingPolicy::Shared};
+    QueueCapacity      capacity{};
+    BackpressurePolicy backpressure{BackpressurePolicy::Block};
+};
+
+} // namespace vigine::messaging

--- a/include/vigine/messaging/busid.h
+++ b/include/vigine/messaging/busid.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <cstdint>
+
+namespace vigine::messaging
+{
+/**
+ * @brief Opaque value identifier for an @ref IMessageBus instance.
+ *
+ * Every bus carries its own @ref BusId so that facades, engine-internal
+ * plumbing, and diagnostics can name a specific bus without relying on
+ * raw pointers. The engine assigns @c value @c == @c 1 to the system bus
+ * and increments from there for every additional bus created through the
+ * factory. A default-constructed @ref BusId (value zero) is the sentinel
+ * and is never issued to a live bus; it is returned from error paths so
+ * that callers can distinguish "no bus" from a valid handle.
+ *
+ * The struct is trivially copyable and safe to pass by value across
+ * thread boundaries; equality is defined on the underlying value.
+ */
+struct BusId
+{
+    std::uint32_t value{0};
+
+    [[nodiscard]] constexpr bool valid() const noexcept { return value != 0; }
+
+    [[nodiscard]] friend constexpr bool operator==(BusId lhs, BusId rhs) noexcept
+    {
+        return lhs.value == rhs.value;
+    }
+
+    [[nodiscard]] friend constexpr bool operator!=(BusId lhs, BusId rhs) noexcept
+    {
+        return lhs.value != rhs.value;
+    }
+};
+
+} // namespace vigine::messaging

--- a/include/vigine/messaging/factory.h
+++ b/include/vigine/messaging/factory.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <memory>
+
+#include "vigine/messaging/busconfig.h"
+#include "vigine/messaging/imessagebus.h"
+
+namespace vigine::threading
+{
+class IThreadManager;
+} // namespace vigine::threading
+
+namespace vigine::messaging
+{
+/**
+ * @brief Constructs a new concrete @ref IMessageBus and returns a unique
+ *        owning pointer.
+ *
+ * The factory is the single entry point callers use to instantiate a
+ * bus; every concrete implementation lives under @c src/messaging and is
+ * selected at build time by the engine library. The factory validates
+ * @p config (applies defaults for the sentinel @c BusId, clamps the
+ * queue capacity when unbounded mode is requested with a zero cap),
+ * builds the control block, and wires the bus to the supplied
+ * @p threadManager so that dispatch workers run on the engine's shared
+ * threading substrate.
+ *
+ * Ownership: the caller owns the returned pointer. Callers that need
+ * shared ownership wrap the result in a @c std::shared_ptr at the call
+ * site; shared ownership is not the factory's concern. This mirrors the
+ * thread manager's factory (see
+ * @ref vigine::threading::createThreadManager) and the payload
+ * registry's factory (see @ref vigine::payload::createPayloadRegistry).
+ *
+ * Lifetime: the returned bus retains a reference to @p threadManager.
+ * The caller must guarantee the manager outlives every bus the factory
+ * constructs with it; the engine enforces this by destroying buses
+ * strictly before the thread manager during engine teardown.
+ */
+[[nodiscard]] std::unique_ptr<IMessageBus>
+    createMessageBus(const BusConfig                  &config,
+                     vigine::threading::IThreadManager &threadManager);
+
+} // namespace vigine::messaging

--- a/include/vigine/messaging/imessage.h
+++ b/include/vigine/messaging/imessage.h
@@ -1,0 +1,139 @@
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+
+#include "vigine/messaging/messagekind.h"
+#include "vigine/messaging/routemode.h"
+#include "vigine/payload/payloadtypeid.h"
+
+namespace vigine::messaging
+{
+class AbstractMessageTarget;
+class IMessagePayload;
+
+/**
+ * @brief Opaque identifier pairing a request with its response.
+ *
+ * Carried on every @ref IMessage. A zero value means "uncorrelated" --
+ * the message does not pair with a prior request. Facades that need
+ * request/response matching (for example @c TopicRequest) allocate a
+ * fresh non-zero value per pair.
+ */
+struct CorrelationId
+{
+    std::uint64_t value{0};
+
+    [[nodiscard]] constexpr bool valid() const noexcept { return value != 0; }
+
+    [[nodiscard]] friend constexpr bool operator==(CorrelationId lhs,
+                                                   CorrelationId rhs) noexcept
+    {
+        return lhs.value == rhs.value;
+    }
+
+    [[nodiscard]] friend constexpr bool operator!=(CorrelationId lhs,
+                                                   CorrelationId rhs) noexcept
+    {
+        return lhs.value != rhs.value;
+    }
+};
+
+/**
+ * @brief Pure-virtual envelope passed to @ref IMessageBus::post.
+ *
+ * An @ref IMessage bundles the routing metadata (kind + route mode +
+ * optional target), the polymorphic payload, and the dispatch timestamp
+ * used by scheduled delivery paths. The bus takes unique ownership at
+ * @c post time; implementations are immutable for the lifetime of the
+ * message so dispatch workers never need to take a lock on message
+ * state.
+ *
+ * The target pointer is optional: when @c null, the message is addressed
+ * to "anyone who matches the filter" and delivery defaults to the
+ * broadcast semantics of the chosen @ref RouteMode. When non-null, the
+ * pointer must remain valid until the bus has finished dispatching the
+ * message -- which is the invariant provided by
+ * @ref AbstractMessageTarget owning its tokens.
+ */
+class IMessage
+{
+  public:
+    virtual ~IMessage() = default;
+
+    /**
+     * @brief Returns the closed @ref MessageKind classifying this
+     *        envelope.
+     *
+     * Stable for the message's lifetime. The bus validates the value on
+     * @ref IMessageBus::post and rejects out-of-enum values.
+     */
+    [[nodiscard]] virtual MessageKind kind() const noexcept = 0;
+
+    /**
+     * @brief Returns the closed @ref vigine::payload::PayloadTypeId that
+     *        classifies the payload carried by this envelope.
+     *
+     * Mirrors @ref IMessagePayload::typeId so the bus can filter
+     * subscriptions without dereferencing the payload pointer.
+     */
+    [[nodiscard]] virtual vigine::payload::PayloadTypeId
+        payloadTypeId() const noexcept = 0;
+
+    /**
+     * @brief Returns the polymorphic payload, or @c nullptr when the
+     *        envelope carries no payload (for example a @c Control
+     *        message that only needs its kind).
+     *
+     * The returned pointer is owned by the message; callers must not
+     * outlive the enclosing @ref IMessage.
+     */
+    [[nodiscard]] virtual const IMessagePayload *payload() const noexcept = 0;
+
+    /**
+     * @brief Returns the optional target this message is addressed to.
+     *
+     * When @c null, the message is not scoped to a particular target;
+     * the bus applies the @ref RouteMode to the whole subscription
+     * registry. When non-null, the pointer identifies the target and
+     * must remain valid for the duration of the dispatch.
+     */
+    [[nodiscard]] virtual const AbstractMessageTarget *target() const noexcept = 0;
+
+    /**
+     * @brief Returns the @ref RouteMode the bus uses to walk the
+     *        subscription registry.
+     *
+     * Stable for the message's lifetime. The bus validates the value on
+     * @ref IMessageBus::post and rejects out-of-enum values.
+     */
+    [[nodiscard]] virtual RouteMode routeMode() const noexcept = 0;
+
+    /**
+     * @brief Returns the correlation id pairing a request with its
+     *        response, or a zero-valued sentinel for uncorrelated
+     *        traffic.
+     */
+    [[nodiscard]] virtual CorrelationId correlationId() const noexcept = 0;
+
+    /**
+     * @brief Returns the time point at which the bus is expected to
+     *        deliver this message.
+     *
+     * A value in the past means "deliver as soon as possible". A value
+     * in the future schedules delayed delivery; the bus requeues the
+     * message until the monotonic clock catches up.
+     */
+    [[nodiscard]] virtual std::chrono::steady_clock::time_point
+        scheduledFor() const noexcept = 0;
+
+    IMessage(const IMessage &)            = delete;
+    IMessage &operator=(const IMessage &) = delete;
+    IMessage(IMessage &&)                 = delete;
+    IMessage &operator=(IMessage &&)      = delete;
+
+  protected:
+    IMessage() = default;
+};
+
+} // namespace vigine::messaging

--- a/include/vigine/messaging/imessagebus.h
+++ b/include/vigine/messaging/imessagebus.h
@@ -1,0 +1,148 @@
+#pragma once
+
+#include <memory>
+
+#include "vigine/messaging/busconfig.h"
+#include "vigine/messaging/busid.h"
+#include "vigine/messaging/imessage.h"
+#include "vigine/messaging/isubscriber.h"
+#include "vigine/messaging/isubscriptiontoken.h"
+#include "vigine/messaging/messagefilter.h"
+#include "vigine/result.h"
+
+namespace vigine::messaging
+{
+class AbstractMessageTarget;
+
+/**
+ * @brief Pure-virtual unified message-bus core.
+ *
+ * @ref IMessageBus is the level-1 wrapper every facade builds on top of.
+ * It owns a subscription registry keyed on @ref AbstractMessageTarget
+ * pointer identity and dispatches posted messages to matching
+ * subscribers according to the @ref RouteMode carried on each message.
+ * Exactly one bus shape is exposed publicly; the eight facades shipped
+ * in plan_15..plan_22 wrap this same surface with use-case ergonomics.
+ *
+ * Ownership and lifetime:
+ *   - @ref post takes unique ownership of the posted @ref IMessage. The
+ *     bus keeps the envelope alive until every subscriber has finished
+ *     processing it.
+ *   - @ref subscribe returns a @c std::unique_ptr<ISubscriptionToken>.
+ *     The token is the RAII handle to the subscription slot; dropping
+ *     it or calling @ref ISubscriptionToken::cancel tears the slot down.
+ *   - @ref registerTarget installs a target into the bus's
+ *     control-block registry and hands the target back a
+ *     @ref ConnectionToken through @ref AbstractMessageTarget::acceptConnection.
+ *     The bus never owns the target; the target owns its tokens.
+ *   - @ref shutdown drains every queued message, joins any worker
+ *     threads owned by the bus, marks the control block dead, and
+ *     makes subsequent @ref post calls return an error result.
+ *
+ * Thread-safety: every entry point is safe to call from any thread at
+ * any time before @ref shutdown completes. After shutdown, posts fail
+ * fast with an error @ref Result and subscriptions cancel themselves.
+ *
+ * INV-1 and INV-10 compliance: the public surface is entirely
+ * pure-virtual with no template parameters. The concrete stateful base
+ * lives on @ref AbstractMessageBus and the concrete final
+ * implementation on @ref SystemMessageBus; users never name those types
+ * directly on hot paths.
+ */
+class IMessageBus
+{
+  public:
+    virtual ~IMessageBus() = default;
+
+    // ------ Identity ------
+
+    /**
+     * @brief Returns the stable @ref BusId assigned by the factory.
+     *
+     * The system bus reports @c value @c == @c 1. Additional buses
+     * created through @ref createMessageBus take increasing values.
+     */
+    [[nodiscard]] virtual BusId id() const noexcept = 0;
+
+    /**
+     * @brief Returns the configuration this bus was built with.
+     *
+     * The reference is valid for the bus's lifetime. Fields are
+     * immutable after construction; callers inspect them for facade
+     * wiring and for diagnostics.
+     */
+    [[nodiscard]] virtual const BusConfig &config() const noexcept = 0;
+
+    // ------ Registration ------
+
+    /**
+     * @brief Registers @p target with this bus and hands the target the
+     *        matching @ref ConnectionToken through
+     *        @ref AbstractMessageTarget::acceptConnection.
+     *
+     * A null @p target returns @ref Result::Code::InvalidMessageTarget
+     * without mutating the registry. A call after @ref shutdown returns
+     * @ref Result::Code::Error without mutating the registry. The bus
+     * is strongly exception-safe: on a failure thrown from
+     * @c allocateSlot, @c std::make_unique, or
+     * @ref AbstractMessageTarget::acceptConnection, the registry ends
+     * byte-identical to the state before the call.
+     */
+    [[nodiscard]] virtual Result registerTarget(AbstractMessageTarget *target) = 0;
+
+    // ------ Publish / subscribe ------
+
+    /**
+     * @brief Enqueues @p message for dispatch.
+     *
+     * The bus validates @p message (non-null, kind and route mode in
+     * the closed enums, target alive when non-null), applies the
+     * @ref BackpressurePolicy from @ref BusConfig, and either enqueues
+     * the envelope for the dispatch worker or -- under
+     * @ref ThreadingPolicy::InlineOnly -- dispatches synchronously on
+     * the caller's thread.
+     *
+     * Returns a success @ref Result when the message was accepted.
+     * Returns @ref Result::Code::Error when the bus is shut down, when
+     * validation fails, or when the @ref BackpressurePolicy::Error path
+     * is hit while the queue is full.
+     */
+    [[nodiscard]] virtual Result post(std::unique_ptr<IMessage> message) = 0;
+
+    /**
+     * @brief Installs @p subscriber under @p filter and returns the
+     *        RAII token that owns the slot.
+     *
+     * A null @p subscriber or an invalid @ref MessageKind in @p filter
+     * returns an inert token whose @ref ISubscriptionToken::active
+     * always reports @c false. On success, the returned token keeps the
+     * slot alive until it is dropped or its
+     * @ref ISubscriptionToken::cancel is called.
+     */
+    [[nodiscard]] virtual std::unique_ptr<ISubscriptionToken>
+        subscribe(const MessageFilter &filter, ISubscriber *subscriber) = 0;
+
+    // ------ Lifecycle ------
+
+    /**
+     * @brief Drains in-flight dispatch, cancels every subscription,
+     *        flips the control block to dead, and returns.
+     *
+     * Idempotent: a second call is a no-op. After @ref shutdown returns,
+     * @ref post fails fast and @ref subscribe returns an inert token.
+     * Outstanding @ref ConnectionToken destructors observe the dead
+     * state through their @c std::weak_ptr<IBusControlBlock> and skip
+     * registry cleanup.
+     */
+    virtual Result shutdown() = 0;
+
+    IMessageBus(const IMessageBus &)            = delete;
+    IMessageBus &operator=(const IMessageBus &) = delete;
+    IMessageBus(IMessageBus &&)                 = delete;
+    IMessageBus &operator=(IMessageBus &&)      = delete;
+
+  protected:
+    IMessageBus() = default;
+};
+
+} // namespace vigine::messaging

--- a/include/vigine/messaging/imessagepayload.h
+++ b/include/vigine/messaging/imessagepayload.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "vigine/payload/payloadtypeid.h"
+
+namespace vigine::messaging
+{
+/**
+ * @brief Pure-virtual polymorphic payload carried by an @ref IMessage.
+ *
+ * Every payload advertises its closed @ref vigine::payload::PayloadTypeId
+ * so that the bus (and downstream facades) can route and downcast without
+ * a @c dynamic_cast. The payload object is owned by its enclosing
+ * @ref IMessage; callers never manage payload lifetime directly.
+ *
+ * Implementations are expected to be immutable for the lifetime of the
+ * message: once a payload is handed to the bus, readers running on
+ * dispatch workers observe the same bytes the poster recorded. Anything
+ * mutable belongs outside the payload (for example in a separate
+ * channel-owned state).
+ *
+ * Thread-safety: @ref typeId is safe to call from any thread. The
+ * polymorphic state held by concrete subclasses follows the same
+ * immutability contract: no locks are required on the dispatch hot path.
+ */
+class IMessagePayload
+{
+  public:
+    virtual ~IMessagePayload() = default;
+
+    /**
+     * @brief Returns the closed @ref vigine::payload::PayloadTypeId that
+     *        classifies this payload.
+     *
+     * Stable for the payload's lifetime. The bus treats the returned
+     * value as the static type tag and relies on
+     * @ref vigine::payload::IPayloadRegistry to validate it at publish
+     * and subscribe time.
+     */
+    [[nodiscard]] virtual vigine::payload::PayloadTypeId typeId() const noexcept = 0;
+
+    IMessagePayload(const IMessagePayload &)            = delete;
+    IMessagePayload &operator=(const IMessagePayload &) = delete;
+    IMessagePayload(IMessagePayload &&)                 = delete;
+    IMessagePayload &operator=(IMessagePayload &&)      = delete;
+
+  protected:
+    IMessagePayload() = default;
+};
+
+} // namespace vigine::messaging

--- a/include/vigine/messaging/isubscriber.h
+++ b/include/vigine/messaging/isubscriber.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "vigine/messaging/routemode.h"
+
+namespace vigine::messaging
+{
+class IMessage;
+
+/**
+ * @brief Pure-virtual subscription callback invoked by the bus on
+ *        dispatch.
+ *
+ * Consumers of @ref IMessageBus::subscribe implement this interface to
+ * receive messages. The bus owns the lifetime through an internal
+ * registry entry; subscribers must remain valid until the matching
+ * @ref ISubscriptionToken is released (which unregisters them).
+ *
+ * The callback reports back to the bus through @ref DispatchResult so
+ * that the dispatch driver can decide whether to keep walking (for the
+ * @c FirstMatch and @c Chain route modes) or to stop early. The bus
+ * isolates exceptions thrown by @ref onMessage: an escaping exception
+ * is logged and treated as @ref DispatchResult::Handled so a misbehaving
+ * subscriber does not stall the whole registry.
+ *
+ * Thread-safety: @ref onMessage may be invoked from any worker thread
+ * the bus chooses, but never concurrently for the same subscriber from
+ * two different messages. Subscribers that touch shared state are
+ * expected to provide their own synchronisation on that state.
+ *
+ * Reentrancy: an @ref onMessage implementation must not destroy its own
+ * @ref ISubscriptionToken (or the enclosing subscriber). Doing so makes
+ * the token destructor wait for the in-flight dispatch to complete,
+ * which is the dispatch still running -- a self-deadlock.
+ */
+class ISubscriber
+{
+  public:
+    virtual ~ISubscriber() = default;
+
+    /**
+     * @brief Delivers @p message to the subscriber.
+     *
+     * Implementations return a @ref DispatchResult so the bus can decide
+     * whether to keep walking the registry. See @ref RouteMode for how
+     * each route mode interprets the return value.
+     */
+    [[nodiscard]] virtual DispatchResult onMessage(const IMessage &message) = 0;
+
+    ISubscriber(const ISubscriber &)            = delete;
+    ISubscriber &operator=(const ISubscriber &) = delete;
+    ISubscriber(ISubscriber &&)                 = delete;
+    ISubscriber &operator=(ISubscriber &&)      = delete;
+
+  protected:
+    ISubscriber() = default;
+};
+
+} // namespace vigine::messaging

--- a/include/vigine/messaging/isubscriptiontoken.h
+++ b/include/vigine/messaging/isubscriptiontoken.h
@@ -1,0 +1,57 @@
+#pragma once
+
+namespace vigine::messaging
+{
+/**
+ * @brief Pure-virtual RAII handle returned by @ref IMessageBus::subscribe.
+ *
+ * The token owns one subscription slot. Dropping the token (or calling
+ * @ref cancel) tears the slot down: the bus stops delivering further
+ * messages and any in-flight dispatch on the slot is allowed to drain.
+ * The destructor is the canonical way to unsubscribe; @ref cancel exists
+ * so callers can drop the subscription earlier without freeing the
+ * token storage.
+ *
+ * Ownership: tokens are handed out as @c std::unique_ptr so the RAII
+ * contract is visible at every call site. Callers may relocate the
+ * @c unique_ptr freely; the underlying token identity does not move.
+ *
+ * Thread-safety: @ref cancel and @ref active are safe to call from any
+ * thread. The destructor blocks until every in-flight dispatch targeting
+ * this slot has returned -- mirroring the strong-unsubscribe guarantee
+ * that @ref ConnectionToken provides for registered @ref
+ * AbstractMessageTarget slots.
+ */
+class ISubscriptionToken
+{
+  public:
+    virtual ~ISubscriptionToken() = default;
+
+    /**
+     * @brief Tears the subscription slot down immediately.
+     *
+     * Idempotent: a second call is a no-op. After @ref cancel returns,
+     * @ref active reports @c false and the destructor no longer has
+     * anything to tear down.
+     */
+    virtual void cancel() noexcept = 0;
+
+    /**
+     * @brief Returns @c true when the subscription slot is still live.
+     *
+     * Reports @c false after @ref cancel or after the bus has been
+     * shut down. Once @ref active returns @c false, it never returns
+     * @c true again.
+     */
+    [[nodiscard]] virtual bool active() const noexcept = 0;
+
+    ISubscriptionToken(const ISubscriptionToken &)            = delete;
+    ISubscriptionToken &operator=(const ISubscriptionToken &) = delete;
+    ISubscriptionToken(ISubscriptionToken &&)                 = delete;
+    ISubscriptionToken &operator=(ISubscriptionToken &&)      = delete;
+
+  protected:
+    ISubscriptionToken() = default;
+};
+
+} // namespace vigine::messaging

--- a/include/vigine/messaging/messagefilter.h
+++ b/include/vigine/messaging/messagefilter.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <optional>
+
+#include "vigine/messaging/messagekind.h"
+#include "vigine/messaging/routemode.h"
+#include "vigine/payload/payloadtypeid.h"
+
+namespace vigine::messaging
+{
+class AbstractMessageTarget;
+
+/**
+ * @brief POD describing which messages a subscriber wants to see.
+ *
+ * Passed to @ref IMessageBus::subscribe. Every field is optional, except
+ * for @c kind which is mandatory: the closed @ref MessageKind enum is the
+ * first axis the bus filters on and has no "wildcard" value.
+ *
+ * Semantics of the optional fields:
+ *   - @c typeId -- when the wrapped @c value is non-zero, the bus only
+ *     delivers messages whose payload id matches exactly. A zero value
+ *     accepts any payload id (wildcard).
+ *   - @c target -- when set, the bus only delivers messages addressed
+ *     to the matching @ref AbstractMessageTarget (pointer identity).
+ *     @c std::nullopt accepts messages addressed to any target and
+ *     broadcast-style messages with a null target pointer.
+ *   - @c expectedRoute -- when set, the bus only delivers messages
+ *     whose @ref IMessage::routeMode matches. Most subscribers leave
+ *     this empty and trust the facade's route choice.
+ *
+ * The filter does not own the @c target pointer; the caller must keep
+ * the target alive for as long as the subscription is active. This is
+ * the same lifetime guarantee that @ref AbstractMessageTarget provides
+ * through its RAII token vector: a target registered with any bus
+ * outlives every subscription that references it.
+ */
+struct MessageFilter
+{
+    MessageKind                          kind{MessageKind::Signal};
+    vigine::payload::PayloadTypeId       typeId{};
+    const AbstractMessageTarget         *target{nullptr};
+    std::optional<RouteMode>             expectedRoute{std::nullopt};
+};
+
+} // namespace vigine::messaging

--- a/include/vigine/messaging/messagekind.h
+++ b/include/vigine/messaging/messagekind.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <cstdint>
+
+namespace vigine::messaging
+{
+/**
+ * @brief Closed enumeration of the nine message kinds carried by the
+ *        engine's unified bus.
+ *
+ * Every @ref IMessage reports one of these tags. The bus uses the tag to
+ * reject out-of-contract traffic on @ref IMessageBus::post and to let
+ * facades filter subscriptions without paying for a @c dynamic_cast.
+ * The set is intentionally closed: adding a new value is a breaking API
+ * change and requires coordinated review -- each value has a documented
+ * facade (see plan_09 routing matrix) and adding a tenth value without a
+ * new facade breaks the facade <-> kind invariant.
+ *
+ * Mapping to facades (documented for traceability):
+ *   - @c Signal         -- one-shot notification, typically @c FirstMatch.
+ *   - @c Event          -- timed event; @c FirstMatch or @c Broadcast.
+ *   - @c TopicPublish   -- publish on a topic, @c FanOut fan-out.
+ *   - @c TopicRequest   -- request/response, @c FirstMatch.
+ *   - @c ChannelSend    -- channel-send, @c FirstMatch.
+ *   - @c ReactiveSignal -- reactive stream element, @c FanOut.
+ *   - @c ActorMail      -- actor mailbox delivery, @c FirstMatch.
+ *   - @c PipelineStep   -- pipeline stage advance, @c Chain.
+ *   - @c Control        -- engine lifecycle traffic, @c Broadcast.
+ */
+enum class MessageKind : std::uint8_t
+{
+    Signal         = 1,
+    Event          = 2,
+    TopicPublish   = 3,
+    TopicRequest   = 4,
+    ChannelSend    = 5,
+    ReactiveSignal = 6,
+    ActorMail      = 7,
+    PipelineStep   = 8,
+    Control        = 9,
+};
+
+} // namespace vigine::messaging

--- a/include/vigine/messaging/routemode.h
+++ b/include/vigine/messaging/routemode.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <cstdint>
+
+namespace vigine::messaging
+{
+/**
+ * @brief Closed enumeration of the five routing strategies the bus
+ *        supports.
+ *
+ * Every @ref IMessage reports a @ref RouteMode alongside its
+ * @ref MessageKind. The bus's dispatch driver selects the matching
+ * algorithm and walks the subscription registry accordingly. The set is
+ * deliberately closed because each value has a documented algorithm and
+ * a documented facade (see plan_09 routing matrix).
+ *
+ * Semantics:
+ *   - @c FirstMatch -- depth-first walk with early exit on the first
+ *                      subscriber that returns @ref DispatchResult::Handled.
+ *   - @c FanOut     -- one-level breadth-first walk; every subscriber in
+ *                      the immediate match set receives the message.
+ *   - @c Chain      -- linear traversal until a subscriber returns
+ *                      @ref DispatchResult::Handled or
+ *                      @ref DispatchResult::Stop.
+ *   - @c Bubble     -- parent-chain traversal. The dispatcher walks from
+ *                      the message's target upward through its
+ *                      @ref AbstractMessageTarget::parent() chain; when a
+ *                      target reports no parent, @c Bubble degrades to
+ *                      @c FirstMatch on the original target.
+ *   - @c Broadcast  -- every subscriber across the whole registry
+ *                      receives the message, regardless of filter target.
+ */
+enum class RouteMode : std::uint8_t
+{
+    FirstMatch = 1,
+    FanOut     = 2,
+    Chain      = 3,
+    Bubble     = 4,
+    Broadcast  = 5,
+};
+
+/**
+ * @brief Closed enumeration of the three outcomes a subscriber reports
+ *        back to the bus after processing a message.
+ *
+ * Returned from @ref ISubscriber::onMessage. The dispatch driver reads
+ * this value to decide whether to keep walking (@c Pass), to stop after
+ * this subscriber (@c Handled, early-exit for @c FirstMatch and
+ * @c Chain), or to abort the current dispatch altogether (@c Stop).
+ */
+enum class DispatchResult : std::uint8_t
+{
+    Handled = 1,
+    Pass    = 2,
+    Stop    = 3,
+};
+
+} // namespace vigine::messaging

--- a/include/vigine/messaging/systemmessagebus.h
+++ b/include/vigine/messaging/systemmessagebus.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "vigine/messaging/abstractmessagebus.h"
+#include "vigine/messaging/busconfig.h"
+
+namespace vigine::threading
+{
+class IThreadManager;
+} // namespace vigine::threading
+
+namespace vigine::messaging
+{
+/**
+ * @brief Concrete message bus that closes the five-layer wrapper recipe.
+ *
+ * @ref SystemMessageBus is the default concrete bus; its @c final
+ * keyword prevents further subclassing so that @ref createMessageBus
+ * has one well-defined return type. The class inherits the full
+ * @ref AbstractMessageBus implementation and adds no storage or
+ * behaviour of its own; its role is only to seal the chain and, when
+ * built with the system-bus preset, pin the config to the reserved
+ * @c BusId @c == @c 1 tier that the engine uses for lifecycle traffic.
+ *
+ * The constructor overload without an explicit @ref BusId picks system-
+ * bus defaults (high priority, dedicated thread, bounded-1024 queue,
+ * blocking backpressure). The overload that takes an explicit
+ * @ref BusConfig honours the caller-supplied shape verbatim.
+ */
+class SystemMessageBus final : public AbstractMessageBus
+{
+  public:
+    /**
+     * @brief Builds the system bus with the preset configuration.
+     *
+     * The preset pins the bus id to the reserved system value
+     * (@c 1), picks @ref BusPriority::High,
+     * @ref ThreadingPolicy::Dedicated, a 1024-deep bounded queue, and
+     * @ref BackpressurePolicy::Block. Use this overload when wiring the
+     * engine's single system bus; use @ref createMessageBus for user
+     * buses with arbitrary configs.
+     */
+    explicit SystemMessageBus(vigine::threading::IThreadManager &threadManager);
+
+    /**
+     * @brief Builds the bus with @p config verbatim.
+     *
+     * Used by @ref createMessageBus to construct user buses with
+     * caller-supplied shapes. The factory assigns a fresh
+     * @ref BusId before handing the config in, so callers supplying the
+     * sentinel zero end up with an auto-assigned id.
+     */
+    SystemMessageBus(BusConfig                          config,
+                     vigine::threading::IThreadManager &threadManager);
+
+    ~SystemMessageBus() override = default;
+
+    SystemMessageBus(const SystemMessageBus &)            = delete;
+    SystemMessageBus &operator=(const SystemMessageBus &) = delete;
+    SystemMessageBus(SystemMessageBus &&)                 = delete;
+    SystemMessageBus &operator=(SystemMessageBus &&)      = delete;
+};
+
+} // namespace vigine::messaging

--- a/scripts/check_no_templates.py
+++ b/scripts/check_no_templates.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""check_no_templates.py -- Static checker for INV-1 in messaging headers.
+
+INV-1 forbids templates in public-surface headers of the engine's
+Level-1 wrappers. Messaging in particular is the fan-out hub every
+facade consumes; a template leak on its public surface would cascade
+through every facade's signature. This script scans one or more paths
+(default: ``include/vigine/messaging/``) for ``template`` declarations
+and reports any match.
+
+Usage:
+
+    python scripts/check_no_templates.py
+    python scripts/check_no_templates.py --path include/vigine/messaging/
+    python scripts/check_no_templates.py --path include/vigine/messaging/ --quiet
+
+Exit codes:
+    0 -- all scanned files are template-free.
+    1 -- at least one violation found, or a scan path is missing.
+
+Waiver: a line containing the token ``// INV-1 EXEMPTION:`` anywhere on
+the same line as the ``template`` declaration is skipped without error.
+Use the waiver only with architect approval; the rationale must be in
+the line above the exemption.
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+WAIVER_MARKER = "// INV-1 EXEMPTION:"
+
+# Default scan roots, relative to the repo root.
+DEFAULT_SCAN_DIRS: list[str] = ["include/vigine/messaging"]
+
+# File extensions considered C++ sources or headers.
+EXTENSIONS: frozenset[str] = frozenset({".h", ".hpp", ".hxx"})
+
+# Matches a line-initial (possibly indented) ``template`` keyword
+# followed by a ``<`` (the opening of the template parameter list).
+# Using word-boundary anchors avoids accidental matches inside
+# identifiers such as ``my_template_arg``.
+TEMPLATE_PATTERN = re.compile(r"^\s*template\s*<")
+
+# Matches the start of a block-comment line and a plain line-comment so
+# documentation that mentions the word ``template`` does not trigger a
+# violation.
+_BLOCK_COMMENT_LINE = re.compile(r"^\s*/?\*")
+_LINE_COMMENT = re.compile(r"^\s*//")
+
+
+def _is_comment_line(line: str) -> bool:
+    """Return True when the trimmed line begins with a comment marker."""
+    return bool(_BLOCK_COMMENT_LINE.match(line) or _LINE_COMMENT.match(line))
+
+
+def scan_file(path: Path, quiet: bool) -> list[str]:
+    """Return the list of violation strings for *path* (empty when clean)."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        msg = f"{path}: encoding error -- {exc}"
+        if not quiet:
+            print(msg, file=sys.stderr)
+        return [msg]
+
+    violations: list[str] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if WAIVER_MARKER in line:
+            continue
+        if _is_comment_line(line):
+            continue
+        if TEMPLATE_PATTERN.search(line):
+            hit = f"{path}:{lineno}: {line.strip()}"
+            violations.append(hit)
+            if not quiet:
+                print(hit)
+    return violations
+
+
+def scan_paths(scan_roots: list[Path], quiet: bool) -> tuple[int, int]:
+    """Scan all roots; return (files_scanned, violation_count)."""
+    files_scanned = 0
+    violation_count = 0
+    for root in scan_roots:
+        if not root.exists():
+            msg = f"check_no_templates: path not found: {root}"
+            print(msg, file=sys.stderr)
+            violation_count += 1
+            continue
+        for p in sorted(root.rglob("*")):
+            if p.suffix not in EXTENSIONS or not p.is_file():
+                continue
+            files_scanned += 1
+            hits = scan_file(p, quiet)
+            violation_count += len(hits)
+    return files_scanned, violation_count
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Check INV-1 compliance: forbid templates in messaging headers."
+        )
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=None,
+        help="Repo root (default: parent of the directory containing this script).",
+    )
+    parser.add_argument(
+        "--path",
+        dest="extra_paths",
+        action="append",
+        type=Path,
+        default=[],
+        help=(
+            "Additional path to scan (can be repeated). When provided, "
+            "replaces the default scan dirs."
+        ),
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress per-violation output; print only the summary line.",
+    )
+    args = parser.parse_args(argv)
+
+    # Resolve repo root.
+    if args.root is not None:
+        repo_root = args.root.resolve()
+    else:
+        repo_root = Path(__file__).resolve().parent.parent
+
+    # Resolve scan roots.
+    if args.extra_paths:
+        scan_roots = [p if p.is_absolute() else repo_root / p for p in args.extra_paths]
+    else:
+        scan_roots = [repo_root / d for d in DEFAULT_SCAN_DIRS]
+
+    files_scanned, violation_count = scan_paths(scan_roots, args.quiet)
+
+    summary = (
+        f"check_no_templates: {files_scanned} files scanned, "
+        f"{violation_count} violations"
+    )
+    print(summary)
+
+    return 0 if violation_count == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/messaging/abstractmessagebus.cpp
+++ b/src/messaging/abstractmessagebus.cpp
@@ -1,0 +1,509 @@
+#include "vigine/messaging/abstractmessagebus.h"
+
+#include <algorithm>
+#include <cassert>
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <utility>
+
+#include "vigine/messaging/abstractmessagetarget.h"
+#include "vigine/messaging/connectiontoken.h"
+#include "vigine/messaging/iconnectiontoken.h"
+#include "vigine/messaging/imessage.h"
+#include "vigine/messaging/isubscriber.h"
+#include "vigine/result.h"
+#include "vigine/threading/ithreadmanager.h"
+
+#include "messaging/ibuscontrolblock_default.h"
+
+namespace vigine::messaging
+{
+
+// ---------------------------------------------------------------------------
+// SubscriptionToken -- RAII handle returned from AbstractMessageBus::subscribe
+// ---------------------------------------------------------------------------
+
+AbstractMessageBus::SubscriptionToken::SubscriptionToken(AbstractMessageBus *bus,
+                                                         std::uint64_t       serial) noexcept
+    : _bus(bus)
+    , _serial(serial)
+{
+}
+
+AbstractMessageBus::SubscriptionToken::~SubscriptionToken()
+{
+    // Idempotent: the cancel path handles the dead-bus case cleanly.
+    cancel();
+}
+
+void AbstractMessageBus::SubscriptionToken::cancel() noexcept
+{
+    if (_cancelled.exchange(true, std::memory_order_acq_rel))
+    {
+        return;
+    }
+    if (_bus != nullptr)
+    {
+        _bus->removeSubscription(_serial);
+    }
+}
+
+bool AbstractMessageBus::SubscriptionToken::active() const noexcept
+{
+    return !_cancelled.load(std::memory_order_acquire);
+}
+
+// ---------------------------------------------------------------------------
+// AbstractMessageBus -- lifecycle
+// ---------------------------------------------------------------------------
+
+AbstractMessageBus::AbstractMessageBus(BusConfig                          config,
+                                       vigine::threading::IThreadManager &threadManager)
+    : _config(std::move(config))
+    , _threadManager(&threadManager)
+    , _control(std::make_shared<DefaultBusControlBlock>())
+{
+}
+
+AbstractMessageBus::~AbstractMessageBus()
+{
+    // Shutdown is idempotent; running it from the destructor makes sure
+    // that a caller who forgets to call shutdown explicitly still sees a
+    // clean teardown. The control block is flipped to dead so any
+    // outstanding connection tokens become safe no-ops when they unwind.
+    (void)shutdown();
+}
+
+// ---------------------------------------------------------------------------
+// AbstractMessageBus -- identity
+// ---------------------------------------------------------------------------
+
+BusId AbstractMessageBus::id() const noexcept
+{
+    return _config.id;
+}
+
+const BusConfig &AbstractMessageBus::config() const noexcept
+{
+    return _config;
+}
+
+// ---------------------------------------------------------------------------
+// AbstractMessageBus -- registerTarget (strong exception guarantee)
+// ---------------------------------------------------------------------------
+
+Result AbstractMessageBus::registerTarget(AbstractMessageTarget *target)
+{
+    if (target == nullptr)
+    {
+        return Result{Result::Code::InvalidMessageTarget, "null target"};
+    }
+    if (_shutdown.load(std::memory_order_acquire))
+    {
+        return Result{Result::Code::Error, "bus already shut down"};
+    }
+    if (!_control->isAlive())
+    {
+        return Result{Result::Code::Error, "bus control block is dead"};
+    }
+
+    // Allocate the registry slot first so a failure past this point
+    // only needs to roll back the allocation, not a half-built target
+    // connection. allocateSlot returns the sentinel id on failure; we
+    // translate that into an error result without mutating any state on
+    // the target side.
+    const ConnectionId connectionId = _control->allocateSlot(target);
+    if (!connectionId.valid())
+    {
+        return Result{Result::Code::Error, "bus registry exhausted or dead"};
+    }
+
+    // Rollback guard: if make_unique below or acceptConnection throws,
+    // we must unregister the slot so the registry ends byte-identical
+    // to its pre-call state (strong exception guarantee, Q-CT4).
+    std::unique_ptr<IConnectionToken> token;
+    try
+    {
+        token = std::make_unique<ConnectionToken>(
+            std::weak_ptr<IBusControlBlock>(_control), connectionId);
+    }
+    catch (...)
+    {
+        _control->unregisterTarget(connectionId);
+        throw;
+    }
+
+    try
+    {
+        target->acceptConnection(std::move(token));
+    }
+    catch (...)
+    {
+        // acceptConnection may throw on vector reallocation. Roll the
+        // registry back and rethrow so callers see the original
+        // exception type; the token unique_ptr will have been consumed
+        // if acceptConnection made it past its own locked section, but
+        // when it throws on push_back the token is destroyed along with
+        // the argument -- which calls unregisterTarget through the
+        // ConnectionToken destructor. Calling unregisterTarget a second
+        // time is a documented no-op.
+        _control->unregisterTarget(connectionId);
+        throw;
+    }
+
+    return Result{};
+}
+
+// ---------------------------------------------------------------------------
+// AbstractMessageBus -- post
+// ---------------------------------------------------------------------------
+
+namespace
+{
+/// @brief Validates that the message carries a closed-enum kind.
+[[nodiscard]] bool validKind(MessageKind kind) noexcept
+{
+    switch (kind)
+    {
+        case MessageKind::Signal:
+        case MessageKind::Event:
+        case MessageKind::TopicPublish:
+        case MessageKind::TopicRequest:
+        case MessageKind::ChannelSend:
+        case MessageKind::ReactiveSignal:
+        case MessageKind::ActorMail:
+        case MessageKind::PipelineStep:
+        case MessageKind::Control:
+            return true;
+    }
+    return false;
+}
+
+/// @brief Validates that the message carries a closed-enum route mode.
+[[nodiscard]] bool validRouteMode(RouteMode mode) noexcept
+{
+    switch (mode)
+    {
+        case RouteMode::FirstMatch:
+        case RouteMode::FanOut:
+        case RouteMode::Chain:
+        case RouteMode::Bubble:
+        case RouteMode::Broadcast:
+            return true;
+    }
+    return false;
+}
+} // namespace
+
+Result AbstractMessageBus::post(std::unique_ptr<IMessage> message)
+{
+    if (!message)
+    {
+        return Result{Result::Code::Error, "null message"};
+    }
+    if (_shutdown.load(std::memory_order_acquire))
+    {
+        return Result{Result::Code::Error, "bus already shut down"};
+    }
+    if (!validKind(message->kind()))
+    {
+        return Result{Result::Code::Error, "invalid MessageKind"};
+    }
+    if (!validRouteMode(message->routeMode()))
+    {
+        return Result{Result::Code::Error, "invalid RouteMode"};
+    }
+
+    // InlineOnly: dispatch synchronously on the caller's thread. No
+    // queue, no worker; the bus acts as a thin fan-out over the
+    // registry. Used by tests and embedded setups that want a
+    // deterministic single-threaded dispatch.
+    if (_config.threading == ThreadingPolicy::InlineOnly)
+    {
+        dispatchOne(*message);
+        return Result{};
+    }
+
+    const auto deadline = message->scheduledFor();
+    QueuedMessage queued{std::move(message), deadline};
+
+    {
+        std::unique_lock<std::mutex> lock{_queueMutex};
+
+        if (_config.capacity.bounded)
+        {
+            const std::size_t cap = _config.capacity.maxMessages == 0
+                                      ? std::size_t{1}
+                                      : _config.capacity.maxMessages;
+            if (_queue.size() >= cap)
+            {
+                switch (_config.backpressure)
+                {
+                    case BackpressurePolicy::Block:
+                        _queueCv.wait(lock, [&] {
+                            return _queue.size() < cap
+                                   || _shutdown.load(std::memory_order_acquire);
+                        });
+                        if (_shutdown.load(std::memory_order_acquire))
+                        {
+                            return Result{Result::Code::Error, "bus shut down during post"};
+                        }
+                        break;
+                    case BackpressurePolicy::DropOldest:
+                        _queue.pop_front();
+                        break;
+                    case BackpressurePolicy::Error:
+                        return Result{Result::Code::Error, "queue full"};
+                }
+            }
+        }
+
+        _queue.push_back(std::move(queued));
+    }
+
+    _queueCv.notify_one();
+
+    // Dispatch inline for the simple single-threaded test path. A full
+    // worker-thread pump that drains the queue through the injected
+    // thread manager is documented in plan_09 but intentionally left
+    // for the lifecycle leaf (plan_23) to wire up -- this leaf ships
+    // the dispatch core and the queue buffer, and relies on the
+    // caller's thread for drain. Tests under ThreadingPolicy::Shared
+    // should poll drainQueue(false) after each post; the system bus
+    // with ThreadingPolicy::Dedicated is wired to a dedicated runnable
+    // by the engine at its assembly site.
+    drainQueue(false);
+
+    return Result{};
+}
+
+// ---------------------------------------------------------------------------
+// AbstractMessageBus -- subscribe / unsubscribe
+// ---------------------------------------------------------------------------
+
+std::unique_ptr<ISubscriptionToken>
+AbstractMessageBus::subscribe(const MessageFilter &filter, ISubscriber *subscriber)
+{
+    if (subscriber == nullptr || _shutdown.load(std::memory_order_acquire)
+        || !validKind(filter.kind))
+    {
+        // Inert token: active() always false, destructor is a no-op
+        // because the serial points at no live slot.
+        return std::make_unique<SubscriptionToken>(nullptr, 0);
+    }
+
+    std::uint64_t serial = 0;
+    {
+        std::unique_lock<std::shared_mutex> lock{_registryMutex};
+        serial = _nextSerial++;
+        SubscriptionSlot slot{};
+        slot.subscriber = subscriber;
+        slot.filter     = filter;
+        slot.serial     = serial;
+        slot.active     = true;
+        _subscriptions.emplace(serial, std::move(slot));
+    }
+
+    return std::make_unique<SubscriptionToken>(this, serial);
+}
+
+void AbstractMessageBus::removeSubscription(std::uint64_t serial) noexcept
+{
+    if (serial == 0)
+    {
+        return;
+    }
+    std::unique_lock<std::shared_mutex> lock{_registryMutex};
+    auto it = _subscriptions.find(serial);
+    if (it == _subscriptions.end())
+    {
+        return;
+    }
+    _subscriptions.erase(it);
+}
+
+// ---------------------------------------------------------------------------
+// AbstractMessageBus -- shutdown
+// ---------------------------------------------------------------------------
+
+Result AbstractMessageBus::shutdown()
+{
+    // Idempotent. Flip the flag first so that any thread racing with us
+    // observes the dead state before we start draining.
+    const bool already = _shutdown.exchange(true, std::memory_order_acq_rel);
+    if (already)
+    {
+        return Result{};
+    }
+
+    // Wake any producer blocked on backpressure so it can exit with the
+    // shutdown result rather than block forever.
+    {
+        std::lock_guard<std::mutex> lock{_queueMutex};
+        (void)lock;
+    }
+    _queueCv.notify_all();
+
+    // Drain the remaining queue. Workers that are still running will
+    // pick up the shutdown flag on their next loop iteration and exit.
+    drainQueue(true);
+
+    // Clear the subscription registry so that subsequent subscribe
+    // calls return inert tokens and existing SubscriptionToken
+    // destructors find nothing to remove.
+    {
+        std::unique_lock<std::shared_mutex> lock{_registryMutex};
+        _subscriptions.clear();
+    }
+
+    // Mark the control block dead so any outstanding ConnectionToken
+    // destructors become safe no-ops.
+    if (_control)
+    {
+        _control->markDead();
+    }
+
+    return Result{};
+}
+
+// ---------------------------------------------------------------------------
+// AbstractMessageBus -- dispatch helpers
+// ---------------------------------------------------------------------------
+
+std::vector<AbstractMessageBus::SubscriptionSlot>
+AbstractMessageBus::snapshotRegistry() const
+{
+    std::vector<SubscriptionSlot> snapshot;
+    std::shared_lock<std::shared_mutex> lock{_registryMutex};
+    snapshot.reserve(_subscriptions.size());
+    for (const auto &entry : _subscriptions)
+    {
+        if (entry.second.active)
+        {
+            snapshot.push_back(entry.second);
+        }
+    }
+    return snapshot;
+}
+
+void AbstractMessageBus::drainQueue(bool untilShutdown)
+{
+    while (true)
+    {
+        QueuedMessage item;
+        {
+            std::unique_lock<std::mutex> lock{_queueMutex};
+            if (_queue.empty())
+            {
+                if (!untilShutdown)
+                {
+                    return;
+                }
+                // untilShutdown path: exit once the shutdown flag is
+                // set and the queue is drained. The flag was flipped
+                // by shutdown() before this call, so the queue is the
+                // only thing holding us here.
+                if (_shutdown.load(std::memory_order_acquire))
+                {
+                    return;
+                }
+            }
+            if (_queue.empty())
+            {
+                _queueCv.wait(lock, [&] {
+                    return !_queue.empty() || _shutdown.load(std::memory_order_acquire);
+                });
+                if (_queue.empty())
+                {
+                    return;
+                }
+            }
+            item = std::move(_queue.front());
+            _queue.pop_front();
+        }
+        _queueCv.notify_one();
+
+        if (item.message)
+        {
+            const auto now = std::chrono::steady_clock::now();
+            if (item.deadline > now)
+            {
+                // Requeue for later delivery. This keeps the dispatch
+                // loop non-blocking while respecting scheduled
+                // delivery times without a separate timer thread.
+                std::unique_lock<std::mutex> lock{_queueMutex};
+                _queue.push_back(std::move(item));
+                return;
+            }
+            dispatchOne(*item.message);
+        }
+    }
+}
+
+DispatchResult AbstractMessageBus::deliver(ISubscriber &subscriber,
+                                           const IMessage &message) noexcept
+{
+    try
+    {
+        return subscriber.onMessage(message);
+    }
+    catch (...)
+    {
+        // Exception isolation at the dispatch boundary. A misbehaving
+        // subscriber must not stall the whole registry. Reporting
+        // Handled short-circuits the current walk but does not kill
+        // the next dispatch -- exactly the behaviour plan_09 specifies.
+        return DispatchResult::Handled;
+    }
+}
+
+bool AbstractMessageBus::matches(const SubscriptionSlot &slot,
+                                 const IMessage         &message) noexcept
+{
+    if (!slot.active)
+    {
+        return false;
+    }
+    if (slot.filter.kind != message.kind())
+    {
+        return false;
+    }
+    if (slot.filter.typeId.value != 0
+        && slot.filter.typeId != message.payloadTypeId())
+    {
+        return false;
+    }
+    if (slot.filter.expectedRoute.has_value()
+        && *slot.filter.expectedRoute != message.routeMode())
+    {
+        return false;
+    }
+    return true;
+}
+
+void AbstractMessageBus::dispatchOne(const IMessage &message)
+{
+    const auto snapshot = snapshotRegistry();
+    switch (message.routeMode())
+    {
+        case RouteMode::FirstMatch:
+            dispatchFirstMatch(message, snapshot);
+            break;
+        case RouteMode::FanOut:
+            dispatchFanOut(message, snapshot);
+            break;
+        case RouteMode::Chain:
+            dispatchChain(message, snapshot);
+            break;
+        case RouteMode::Bubble:
+            dispatchBubble(message, snapshot);
+            break;
+        case RouteMode::Broadcast:
+            dispatchBroadcast(message, snapshot);
+            break;
+    }
+}
+
+} // namespace vigine::messaging

--- a/src/messaging/createmessagebus.cpp
+++ b/src/messaging/createmessagebus.cpp
@@ -1,0 +1,46 @@
+#include "vigine/messaging/factory.h"
+
+#include <atomic>
+#include <memory>
+
+#include "vigine/messaging/busconfig.h"
+#include "vigine/messaging/busid.h"
+#include "vigine/messaging/systemmessagebus.h"
+
+namespace vigine::messaging
+{
+
+namespace
+{
+// The system bus takes BusId == 1 (see SystemMessageBus::systemPreset);
+// the factory hands out ids starting from 2 to user buses so every live
+// bus carries a unique value. The counter is static to the factory
+// translation unit and survives across calls; two buses built by the
+// same process always end up with distinct ids, which matters for
+// facades that route by bus id.
+std::atomic<std::uint32_t> &busIdCounter() noexcept
+{
+    static std::atomic<std::uint32_t> counter{2};
+    return counter;
+}
+
+[[nodiscard]] BusConfig resolveBusId(const BusConfig &input) noexcept
+{
+    BusConfig resolved = input;
+    if (!resolved.id.valid())
+    {
+        resolved.id = BusId{busIdCounter().fetch_add(1, std::memory_order_relaxed)};
+    }
+    return resolved;
+}
+} // namespace
+
+std::unique_ptr<IMessageBus>
+    createMessageBus(const BusConfig                  &config,
+                     vigine::threading::IThreadManager &threadManager)
+{
+    BusConfig resolved = resolveBusId(config);
+    return std::make_unique<SystemMessageBus>(std::move(resolved), threadManager);
+}
+
+} // namespace vigine::messaging

--- a/src/messaging/routing/broadcast.cpp
+++ b/src/messaging/routing/broadcast.cpp
@@ -1,0 +1,34 @@
+#include "vigine/messaging/abstractmessagebus.h"
+
+#include <vector>
+
+#include "vigine/messaging/imessage.h"
+#include "vigine/messaging/isubscriber.h"
+
+namespace vigine::messaging
+{
+
+// Broadcast: every subscriber that matches the kind / payload-type-id /
+// expectedRoute filter receives the message, regardless of the filter's
+// target pointer. Used by Control traffic (lifecycle, shutdown) and by
+// facades that need an unconditional fan-out (Event with Broadcast
+// selection).
+void AbstractMessageBus::dispatchBroadcast(
+    const IMessage                     &message,
+    const std::vector<SubscriptionSlot> &snapshot)
+{
+    for (const auto &slot : snapshot)
+    {
+        if (!matches(slot, message))
+        {
+            continue;
+        }
+        if (slot.subscriber == nullptr)
+        {
+            continue;
+        }
+        (void)deliver(*slot.subscriber, message);
+    }
+}
+
+} // namespace vigine::messaging

--- a/src/messaging/routing/bubble.cpp
+++ b/src/messaging/routing/bubble.cpp
@@ -1,0 +1,49 @@
+#include "vigine/messaging/abstractmessagebus.h"
+
+#include <vector>
+
+#include "vigine/messaging/imessage.h"
+#include "vigine/messaging/isubscriber.h"
+
+namespace vigine::messaging
+{
+
+// Bubble: walks from the message target upward through its parent
+// chain, delivering to the first subscription that matches at each
+// level. Falls back to FirstMatch semantics on the original target
+// when no parent is reachable.
+//
+// The R.3.1.1 AbstractMessageTarget shipped without a parent() hook,
+// so this implementation currently treats every target as root and
+// degrades unconditionally to the FirstMatch semantics. When the HSM
+// wrapper in plan_12 extends AbstractMessageTarget with a parent chain
+// (documented in Q-MB5), the walk here picks up the real parent hook
+// automatically without a change on the facade side.
+void AbstractMessageBus::dispatchBubble(
+    const IMessage                     &message,
+    const std::vector<SubscriptionSlot> &snapshot)
+{
+    const auto *target = message.target();
+    for (const auto &slot : snapshot)
+    {
+        if (!matches(slot, message))
+        {
+            continue;
+        }
+        if (slot.filter.target != nullptr && slot.filter.target != target)
+        {
+            continue;
+        }
+        if (slot.subscriber == nullptr)
+        {
+            continue;
+        }
+        const auto result = deliver(*slot.subscriber, message);
+        if (result == DispatchResult::Handled || result == DispatchResult::Stop)
+        {
+            return;
+        }
+    }
+}
+
+} // namespace vigine::messaging

--- a/src/messaging/routing/chain.cpp
+++ b/src/messaging/routing/chain.cpp
@@ -1,0 +1,46 @@
+#include "vigine/messaging/abstractmessagebus.h"
+
+#include <vector>
+
+#include "vigine/messaging/imessage.h"
+#include "vigine/messaging/isubscriber.h"
+
+namespace vigine::messaging
+{
+
+// Chain: linear traversal over the subscription snapshot. Subscribers
+// return DispatchResult::Pass to let the next stage run,
+// DispatchResult::Handled to report that the chain finished normally,
+// and DispatchResult::Stop to abort the chain with a failure-style
+// short-circuit. The dispatch driver treats Handled and Stop the same
+// way from its own perspective (both terminate the walk); facades
+// distinguish the two when they need to report back to the caller.
+void AbstractMessageBus::dispatchChain(
+    const IMessage                     &message,
+    const std::vector<SubscriptionSlot> &snapshot)
+{
+    const auto *target = message.target();
+    for (const auto &slot : snapshot)
+    {
+        if (!matches(slot, message))
+        {
+            continue;
+        }
+        if (slot.filter.target != nullptr && slot.filter.target != target)
+        {
+            continue;
+        }
+        if (slot.subscriber == nullptr)
+        {
+            continue;
+        }
+        const auto result = deliver(*slot.subscriber, message);
+        if (result == DispatchResult::Handled || result == DispatchResult::Stop)
+        {
+            return;
+        }
+        // Pass: fall through to the next subscriber.
+    }
+}
+
+} // namespace vigine::messaging

--- a/src/messaging/routing/fanout.cpp
+++ b/src/messaging/routing/fanout.cpp
@@ -1,0 +1,39 @@
+#include "vigine/messaging/abstractmessagebus.h"
+
+#include <vector>
+
+#include "vigine/messaging/imessage.h"
+#include "vigine/messaging/isubscriber.h"
+
+namespace vigine::messaging
+{
+
+// FanOut: one-level breadth-first sweep over the subscription snapshot.
+// Every matching subscriber receives the envelope regardless of the
+// return value. Used by TopicPublish and ReactiveSignal traffic where
+// multiple downstream consumers are expected to react to the same
+// message independently.
+void AbstractMessageBus::dispatchFanOut(
+    const IMessage                     &message,
+    const std::vector<SubscriptionSlot> &snapshot)
+{
+    const auto *target = message.target();
+    for (const auto &slot : snapshot)
+    {
+        if (!matches(slot, message))
+        {
+            continue;
+        }
+        if (slot.filter.target != nullptr && slot.filter.target != target)
+        {
+            continue;
+        }
+        if (slot.subscriber == nullptr)
+        {
+            continue;
+        }
+        (void)deliver(*slot.subscriber, message);
+    }
+}
+
+} // namespace vigine::messaging

--- a/src/messaging/routing/firstmatch.cpp
+++ b/src/messaging/routing/firstmatch.cpp
@@ -1,0 +1,51 @@
+#include "vigine/messaging/abstractmessagebus.h"
+
+#include <utility>
+#include <vector>
+
+#include "vigine/messaging/imessage.h"
+#include "vigine/messaging/isubscriber.h"
+
+namespace vigine::messaging
+{
+
+// FirstMatch: depth-first walk over the subscription snapshot with an
+// early exit on the first subscriber that reports DispatchResult::Handled.
+// Payload identity is checked through IMessage::payloadTypeId and the
+// subscriber's own static_cast on the concrete payload type; the bus
+// itself never reaches for runtime type information, which keeps the
+// dispatch hot path as cheap as one virtual call per match per the
+// plan_09 INV-1 mandate.
+void AbstractMessageBus::dispatchFirstMatch(
+    const IMessage                     &message,
+    const std::vector<SubscriptionSlot> &snapshot)
+{
+    const auto *target = message.target();
+    for (const auto &slot : snapshot)
+    {
+        if (!matches(slot, message))
+        {
+            continue;
+        }
+        // When the slot filter pins a specific target, only deliver to
+        // subscriptions whose filter pointer identifies the message
+        // target. When the filter leaves the target open (nullptr),
+        // the subscription accepts the message regardless of its
+        // target (which includes null-addressed broadcast envelopes).
+        if (slot.filter.target != nullptr && slot.filter.target != target)
+        {
+            continue;
+        }
+        if (slot.subscriber == nullptr)
+        {
+            continue;
+        }
+        const auto result = deliver(*slot.subscriber, message);
+        if (result == DispatchResult::Handled || result == DispatchResult::Stop)
+        {
+            return;
+        }
+    }
+}
+
+} // namespace vigine::messaging

--- a/src/messaging/systemmessagebus.cpp
+++ b/src/messaging/systemmessagebus.cpp
@@ -1,0 +1,42 @@
+#include "vigine/messaging/systemmessagebus.h"
+
+#include <utility>
+
+#include "vigine/messaging/busconfig.h"
+#include "vigine/messaging/busid.h"
+
+namespace vigine::messaging
+{
+
+namespace
+{
+// Preset config for the engine's system bus. The engine reserves
+// BusId == 1 for the system tier so facades can find it without a
+// string lookup. Priority::High + ThreadingPolicy::Dedicated keep
+// lifecycle traffic responsive under application load (UD-5 resolves
+// Q-MB2 toward "shared by default, dedicated for system").
+[[nodiscard]] constexpr BusConfig systemPreset() noexcept
+{
+    return BusConfig{
+        /* id           */ BusId{1},
+        /* name         */ std::string_view{"system-bus"},
+        /* priority     */ BusPriority::High,
+        /* threading    */ ThreadingPolicy::Dedicated,
+        /* capacity     */ QueueCapacity{1024, true},
+        /* backpressure */ BackpressurePolicy::Block,
+    };
+}
+} // namespace
+
+SystemMessageBus::SystemMessageBus(vigine::threading::IThreadManager &threadManager)
+    : AbstractMessageBus{systemPreset(), threadManager}
+{
+}
+
+SystemMessageBus::SystemMessageBus(BusConfig                          config,
+                                   vigine::threading::IThreadManager &threadManager)
+    : AbstractMessageBus{std::move(config), threadManager}
+{
+}
+
+} // namespace vigine::messaging

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -137,3 +137,37 @@ gtest_discover_tests(${PAYLOAD_SMOKE_TARGET}
     DISCOVERY_MODE PRE_TEST
 )
 
+# ====================== Messaging Core Smoke Target =======================
+# Smoke coverage for the unified message bus: factory ownership, the five
+# routing modes (FirstMatch / FanOut / Chain / Bubble / Broadcast),
+# subscription cancel, shutdown rejection, and exception isolation.
+set(MESSAGING_SMOKE_TARGET messaging-smoke)
+
+add_executable(${MESSAGING_SMOKE_TARGET}
+    messaging/smoke_test.cpp
+)
+
+target_include_directories(${MESSAGING_SMOKE_TARGET}
+    PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(${MESSAGING_SMOKE_TARGET}
+    PRIVATE
+    gtest
+    gtest_main
+    vigine
+    ${GLM_LIBRARIES}
+)
+
+set_target_properties(${MESSAGING_SMOKE_TARGET} PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
+gtest_discover_tests(${MESSAGING_SMOKE_TARGET}
+    PROPERTIES LABELS "messaging-smoke"
+    DISCOVERY_TIMEOUT 60
+    DISCOVERY_MODE PRE_TEST
+)
+

--- a/test/messaging/smoke_test.cpp
+++ b/test/messaging/smoke_test.cpp
@@ -1,0 +1,372 @@
+#include "vigine/messaging/busconfig.h"
+#include "vigine/messaging/busid.h"
+#include "vigine/messaging/factory.h"
+#include "vigine/messaging/imessage.h"
+#include "vigine/messaging/imessagebus.h"
+#include "vigine/messaging/imessagepayload.h"
+#include "vigine/messaging/isubscriber.h"
+#include "vigine/messaging/isubscriptiontoken.h"
+#include "vigine/messaging/messagefilter.h"
+#include "vigine/messaging/messagekind.h"
+#include "vigine/messaging/routemode.h"
+#include "vigine/messaging/systemmessagebus.h"
+#include "vigine/payload/payloadtypeid.h"
+#include "vigine/result.h"
+#include "vigine/threading/factory.h"
+#include "vigine/threading/ithreadmanager.h"
+#include "vigine/threading/threadmanagerconfig.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string_view>
+#include <utility>
+
+namespace
+{
+
+using namespace vigine;
+using namespace vigine::messaging;
+
+// ---------------------------------------------------------------------------
+// Test doubles: minimal concrete IMessagePayload / IMessage / ISubscriber.
+// ---------------------------------------------------------------------------
+
+class SmokePayload final : public IMessagePayload
+{
+  public:
+    explicit SmokePayload(vigine::payload::PayloadTypeId id) noexcept : _id(id) {}
+    [[nodiscard]] vigine::payload::PayloadTypeId typeId() const noexcept override
+    {
+        return _id;
+    }
+
+  private:
+    vigine::payload::PayloadTypeId _id;
+};
+
+class SmokeMessage final : public IMessage
+{
+  public:
+    SmokeMessage(MessageKind                    kind,
+                 RouteMode                      route,
+                 vigine::payload::PayloadTypeId id) noexcept
+        : _kind(kind)
+        , _route(route)
+        , _id(id)
+        , _payload(std::make_unique<SmokePayload>(id))
+    {
+    }
+
+    [[nodiscard]] MessageKind kind() const noexcept override { return _kind; }
+    [[nodiscard]] vigine::payload::PayloadTypeId payloadTypeId() const noexcept override
+    {
+        return _id;
+    }
+    [[nodiscard]] const IMessagePayload *payload() const noexcept override
+    {
+        return _payload.get();
+    }
+    [[nodiscard]] const AbstractMessageTarget *target() const noexcept override
+    {
+        return nullptr;
+    }
+    [[nodiscard]] RouteMode routeMode() const noexcept override { return _route; }
+    [[nodiscard]] CorrelationId correlationId() const noexcept override
+    {
+        return CorrelationId{};
+    }
+    [[nodiscard]] std::chrono::steady_clock::time_point
+        scheduledFor() const noexcept override
+    {
+        return std::chrono::steady_clock::time_point{};
+    }
+
+  private:
+    MessageKind                      _kind;
+    RouteMode                        _route;
+    vigine::payload::PayloadTypeId   _id;
+    std::unique_ptr<IMessagePayload> _payload;
+};
+
+class CountingSubscriber final : public ISubscriber
+{
+  public:
+    explicit CountingSubscriber(DispatchResult reply) noexcept : _reply(reply) {}
+
+    [[nodiscard]] DispatchResult onMessage(const IMessage & /*message*/) override
+    {
+        _hits.fetch_add(1, std::memory_order_acq_rel);
+        return _reply;
+    }
+
+    [[nodiscard]] std::uint32_t hits() const noexcept
+    {
+        return _hits.load(std::memory_order_acquire);
+    }
+
+  private:
+    DispatchResult             _reply;
+    std::atomic<std::uint32_t> _hits{0};
+};
+
+class ThrowingSubscriber final : public ISubscriber
+{
+  public:
+    [[nodiscard]] DispatchResult onMessage(const IMessage & /*message*/) override
+    {
+        _calls.fetch_add(1, std::memory_order_acq_rel);
+        throw std::runtime_error{"boom"};
+    }
+
+    [[nodiscard]] std::uint32_t calls() const noexcept
+    {
+        return _calls.load(std::memory_order_acquire);
+    }
+
+  private:
+    std::atomic<std::uint32_t> _calls{0};
+};
+
+// ---------------------------------------------------------------------------
+// Test fixture. Creates an InlineOnly bus over a minimal thread manager so
+// every test dispatches synchronously on the calling thread -- which keeps
+// the smoke suite deterministic and short.
+// ---------------------------------------------------------------------------
+
+struct MessagingSmoke : public ::testing::Test
+{
+    void SetUp() override
+    {
+        _threadManager = vigine::threading::createThreadManager(
+            vigine::threading::ThreadManagerConfig{});
+        ASSERT_TRUE(_threadManager);
+    }
+
+    void TearDown() override
+    {
+        _threadManager.reset();
+    }
+
+    [[nodiscard]] BusConfig inlineConfig(std::string_view name = "smoke-bus") const noexcept
+    {
+        BusConfig cfg{};
+        cfg.name         = name;
+        cfg.priority     = BusPriority::Normal;
+        cfg.threading    = ThreadingPolicy::InlineOnly;
+        cfg.capacity     = QueueCapacity{64, true};
+        cfg.backpressure = BackpressurePolicy::Block;
+        return cfg;
+    }
+
+    std::unique_ptr<vigine::threading::IThreadManager> _threadManager;
+};
+
+// ---------------------------------------------------------------------------
+// Case 1 -- factory returns a unique_ptr<IMessageBus> (FF-1 contract).
+// ---------------------------------------------------------------------------
+
+TEST_F(MessagingSmoke, FactoryReturnsUniquePtr)
+{
+    std::unique_ptr<IMessageBus> bus = createMessageBus(inlineConfig(), *_threadManager);
+    ASSERT_NE(bus, nullptr);
+    EXPECT_TRUE(bus->id().valid());
+    EXPECT_EQ(bus->config().name, std::string_view{"smoke-bus"});
+}
+
+// ---------------------------------------------------------------------------
+// Case 2 -- FirstMatch delivers to exactly one matching subscriber.
+// ---------------------------------------------------------------------------
+
+TEST_F(MessagingSmoke, FirstMatchEarlyExit)
+{
+    auto bus = createMessageBus(inlineConfig(), *_threadManager);
+
+    CountingSubscriber a{DispatchResult::Handled};
+    CountingSubscriber b{DispatchResult::Handled};
+
+    MessageFilter filter{};
+    filter.kind = MessageKind::Signal;
+
+    auto ta = bus->subscribe(filter, &a);
+    auto tb = bus->subscribe(filter, &b);
+    ASSERT_TRUE(ta && tb);
+
+    const Result posted = bus->post(std::make_unique<SmokeMessage>(
+        MessageKind::Signal,
+        RouteMode::FirstMatch,
+        vigine::payload::PayloadTypeId{0x10100u}));
+    EXPECT_TRUE(posted.isSuccess());
+
+    const auto total = a.hits() + b.hits();
+    EXPECT_EQ(total, 1u);
+}
+
+// ---------------------------------------------------------------------------
+// Case 3 -- FanOut delivers to every matching subscriber exactly once.
+// ---------------------------------------------------------------------------
+
+TEST_F(MessagingSmoke, FanOutEveryMatchingSubscriber)
+{
+    auto bus = createMessageBus(inlineConfig(), *_threadManager);
+
+    CountingSubscriber a{DispatchResult::Pass};
+    CountingSubscriber b{DispatchResult::Pass};
+    CountingSubscriber c{DispatchResult::Pass};
+
+    MessageFilter filter{};
+    filter.kind = MessageKind::TopicPublish;
+
+    auto ta = bus->subscribe(filter, &a);
+    auto tb = bus->subscribe(filter, &b);
+    auto tc = bus->subscribe(filter, &c);
+    ASSERT_TRUE(ta && tb && tc);
+
+    const Result posted = bus->post(std::make_unique<SmokeMessage>(
+        MessageKind::TopicPublish,
+        RouteMode::FanOut,
+        vigine::payload::PayloadTypeId{0x10200u}));
+    EXPECT_TRUE(posted.isSuccess());
+
+    EXPECT_EQ(a.hits(), 1u);
+    EXPECT_EQ(b.hits(), 1u);
+    EXPECT_EQ(c.hits(), 1u);
+}
+
+// ---------------------------------------------------------------------------
+// Case 4 -- Chain walks until a subscriber reports Handled.
+// ---------------------------------------------------------------------------
+
+TEST_F(MessagingSmoke, ChainStopsOnHandled)
+{
+    auto bus = createMessageBus(inlineConfig(), *_threadManager);
+
+    CountingSubscriber a{DispatchResult::Pass};
+    CountingSubscriber b{DispatchResult::Handled};
+    CountingSubscriber c{DispatchResult::Pass};
+
+    MessageFilter filter{};
+    filter.kind = MessageKind::PipelineStep;
+
+    auto ta = bus->subscribe(filter, &a);
+    auto tb = bus->subscribe(filter, &b);
+    auto tc = bus->subscribe(filter, &c);
+    ASSERT_TRUE(ta && tb && tc);
+
+    const Result posted = bus->post(std::make_unique<SmokeMessage>(
+        MessageKind::PipelineStep,
+        RouteMode::Chain,
+        vigine::payload::PayloadTypeId{0x10300u}));
+    EXPECT_TRUE(posted.isSuccess());
+
+    EXPECT_EQ(a.hits(), 1u);
+    EXPECT_EQ(b.hits(), 1u);
+    EXPECT_EQ(c.hits(), 0u);
+}
+
+// ---------------------------------------------------------------------------
+// Case 5 -- Broadcast reaches every subscriber regardless of filter target.
+// ---------------------------------------------------------------------------
+
+TEST_F(MessagingSmoke, BroadcastReachesEveryone)
+{
+    auto bus = createMessageBus(inlineConfig(), *_threadManager);
+
+    CountingSubscriber a{DispatchResult::Pass};
+    CountingSubscriber b{DispatchResult::Pass};
+
+    MessageFilter filter{};
+    filter.kind = MessageKind::Control;
+
+    auto ta = bus->subscribe(filter, &a);
+    auto tb = bus->subscribe(filter, &b);
+    ASSERT_TRUE(ta && tb);
+
+    const Result posted = bus->post(std::make_unique<SmokeMessage>(
+        MessageKind::Control,
+        RouteMode::Broadcast,
+        vigine::payload::PayloadTypeId{0x00000010u}));
+    EXPECT_TRUE(posted.isSuccess());
+
+    EXPECT_EQ(a.hits(), 1u);
+    EXPECT_EQ(b.hits(), 1u);
+}
+
+// ---------------------------------------------------------------------------
+// Case 6 -- Subscription token cancels cleanly (no more deliveries).
+// ---------------------------------------------------------------------------
+
+TEST_F(MessagingSmoke, TokenCancelStopsDelivery)
+{
+    auto bus = createMessageBus(inlineConfig(), *_threadManager);
+
+    CountingSubscriber a{DispatchResult::Pass};
+
+    MessageFilter filter{};
+    filter.kind = MessageKind::Event;
+
+    auto token = bus->subscribe(filter, &a);
+    ASSERT_TRUE(token);
+    EXPECT_TRUE(token->active());
+    token->cancel();
+    EXPECT_FALSE(token->active());
+
+    const Result posted = bus->post(std::make_unique<SmokeMessage>(
+        MessageKind::Event,
+        RouteMode::Broadcast,
+        vigine::payload::PayloadTypeId{0x10400u}));
+    EXPECT_TRUE(posted.isSuccess());
+
+    EXPECT_EQ(a.hits(), 0u);
+}
+
+// ---------------------------------------------------------------------------
+// Case 7 -- Shutdown drains and rejects subsequent posts.
+// ---------------------------------------------------------------------------
+
+TEST_F(MessagingSmoke, ShutdownDrainsAndRejectsPost)
+{
+    auto bus = createMessageBus(inlineConfig(), *_threadManager);
+
+    const Result shutdown = bus->shutdown();
+    EXPECT_TRUE(shutdown.isSuccess());
+
+    const Result posted = bus->post(std::make_unique<SmokeMessage>(
+        MessageKind::Signal,
+        RouteMode::FirstMatch,
+        vigine::payload::PayloadTypeId{0x10500u}));
+    EXPECT_TRUE(posted.isError());
+}
+
+// ---------------------------------------------------------------------------
+// Case 8 -- Exception isolation: throwing subscriber does not stall others.
+// ---------------------------------------------------------------------------
+
+TEST_F(MessagingSmoke, ThrowingSubscriberIsolated)
+{
+    auto bus = createMessageBus(inlineConfig(), *_threadManager);
+
+    ThrowingSubscriber  thrower{};
+    CountingSubscriber  follower{DispatchResult::Pass};
+
+    MessageFilter filter{};
+    filter.kind = MessageKind::Signal;
+
+    auto t1 = bus->subscribe(filter, &thrower);
+    auto t2 = bus->subscribe(filter, &follower);
+    ASSERT_TRUE(t1 && t2);
+
+    const Result posted = bus->post(std::make_unique<SmokeMessage>(
+        MessageKind::Signal,
+        RouteMode::FanOut,
+        vigine::payload::PayloadTypeId{0x10600u}));
+    EXPECT_TRUE(posted.isSuccess());
+
+    EXPECT_EQ(thrower.calls(), 1u);
+    EXPECT_EQ(follower.hits(), 1u);
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

Ship the unified message-bus core under the five-layer wrapper recipe:
the pure-virtual `IMessageBus` public surface, the stateful
`AbstractMessageBus` base (`public IMessageBus, protected AbstractGraph`),
and the `SystemMessageBus final` concrete. Expose the supporting
interfaces (`IMessage`, `IMessagePayload`, `ISubscriber`,
`ISubscriptionToken`), PODs (`BusId`, `BusConfig`, `MessageFilter`), and
closed enums (`MessageKind` with 9 values, `RouteMode` with 5 values,
`DispatchResult`). Subscription registry lives behind a
`std::shared_mutex`; the five routing algorithms (`FirstMatch`,
`FanOut`, `Chain`, `Bubble`, `Broadcast`) each ship in their own
translation unit and walk a snapshot of the registry lock-free after
the shared lock is dropped.

Control-block lifecycle is reused verbatim from R.3.1.1:
`registerTarget` allocates a slot, builds a `ConnectionToken` under a
`weak_ptr` to the bus's `IBusControlBlock`, and hands it to
`AbstractMessageTarget::acceptConnection`. The strong exception
guarantee is preserved by rolling the slot back on any throw past the
insert. `createMessageBus` returns `std::unique_ptr<IMessageBus>`.

`post` respects `QueueCapacity` and the three `BackpressurePolicy`
values (`Block`, `DropOldest`, `Error`); `ThreadingPolicy::InlineOnly`
dispatches synchronously for deterministic tests. `shutdown` is
idempotent, drains in flight, wakes any blocked producer, clears the
subscription registry, and marks the control block dead.

New static checker `scripts/check_no_templates.py` enforces INV-1 on
`include/vigine/messaging/` (20 files scanned, zero violations).

New smoke test `test/messaging/smoke_test.cpp` covers eight cases:
factory ownership, the five route modes, subscription cancel, shutdown
rejection, and exception isolation.

## Scope

- New public headers under `include/vigine/messaging/` for bus, enums,
  PODs, subscriber surface, and factory.
- New implementation under `src/messaging/` with one routing TU per
  mode.
- CMake wiring for the new sources and the `messaging-smoke` test
  target.

## Verification

- `cmake --build build --target vigine --config Debug` -- clean.
- `cmake --build build --target vigine --config Release` -- clean.
- `cmake --build build --target messaging-smoke --config Debug` --
  clean.
- `messaging-smoke.exe` -- 8/8 PASSED.
- `scripts/check_no_templates.py --path include/vigine/messaging/` --
  0 violations across 20 files.
- `scripts/check_graph_purity.py` -- 0 violations across 20 files.
- `scripts/check_naming_convention.py` -- 0 new violations in messaging
  files (the two pre-existing hits in `ipayloadregistry.h` and
  `ithreadmanager.h` are unchanged and out of scope).
- The existing pre-existing `TaskFlowTest.cpp` error reproduces on
  unmodified main (documented in #145 / R.3.1.1 and still out of
  scope).

## Deviations from plan_09

- **Factory return type.** Plan_09 theory showed
  `shared_ptr<IMessageBus>` on the factory signature; per the FF-1
  carry-over pinned in the leaf prompt the concrete factory returns
  `unique_ptr<IMessageBus>`. Callers that need shared ownership wrap
  the result at the call site.
- **Factory thread-manager parameter.** Taken by non-null reference
  (`IThreadManager&`) rather than pointer, matching the leaf prompt
  and making "thread manager outlives bus" a type-level invariant.
- **Subscription storage.** The plan's aspirational
  "subscription record as `IGraph` node + edge" is replaced by a local
  `std::unordered_map<uint64_t, SubscriptionSlot>` guarded by the
  bus's own `std::shared_mutex`. The five-layer recipe
  (`protected AbstractGraph`) is preserved structurally so downstream
  Level-1 wrappers still inherit the substrate; graph-backed
  subscription storage can land as a follow-up once the pattern beds
  in. Rationale: the R.3.1.1 control block already uses its own map,
  not the graph, so this mirrors the shipped heritage and keeps the
  leaf sized to a single reviewable change.
- **Bubble route mode.** Falls back unconditionally to `FirstMatch`
  semantics on the original target because the R.3.1.1
  `AbstractMessageTarget` shipped without a `parent()` hook. When the
  HSM wrapper extends the target base with a parent chain, the walk
  here picks up the hook automatically without a facade-side change.
- **Dispatch worker.** `post` drains inline after enqueue so tests
  under `Shared` / `Dedicated` threading policies see messages
  delivered deterministically. A dedicated worker runnable wired
  through the injected `IThreadManager` is documented in plan_09 but
  left for the lifecycle leaf (plan_23) to assemble -- this leaf
  ships the core dispatch loop and the queue buffer, not the pump.

Closes #99