### PR TITLE
feat(service): IService + AbstractService + ServiceRegistry (R.4.1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,12 +310,26 @@ set(HEADER_SERVICE
     ${INCLUDE_DIR}/vigine/service/databaseservice.h
     ${INCLUDE_DIR}/vigine/service/graphicsservice.h
     ${INCLUDE_DIR}/vigine/service/platformservice.h
+    # Level-1 service wrapper (R.4.1) — public surface.
+    ${INCLUDE_DIR}/vigine/service/serviceid.h
+    ${INCLUDE_DIR}/vigine/service/dependencykind.h
+    ${INCLUDE_DIR}/vigine/service/initpolicy.h
+    ${INCLUDE_DIR}/vigine/service/iservice.h
+    ${INCLUDE_DIR}/vigine/service/abstractservice.h
+    ${INCLUDE_DIR}/vigine/service/factory.h
 )
 
 set(SOURCES_SERVICE
     ${SRC_DIR}/service/databaseservice.cpp
     ${SRC_DIR}/service/graphicsservice.cpp
     ${SRC_DIR}/service/platformservice.cpp
+    # Level-1 service wrapper (R.4.1) — internal registry + base impl.
+    ${SRC_DIR}/service/serviceregistry.h
+    ${SRC_DIR}/service/serviceregistry.cpp
+    ${SRC_DIR}/service/abstractservice.cpp
+    ${SRC_DIR}/service/defaultservice.h
+    ${SRC_DIR}/service/defaultservice.cpp
+    ${SRC_DIR}/service/factory.cpp
 )
 
 # Add source files

--- a/include/vigine/service/abstractservice.h
+++ b/include/vigine/service/abstractservice.h
@@ -1,0 +1,142 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "vigine/result.h"
+#include "vigine/service/iservice.h"
+#include "vigine/service/serviceid.h"
+
+namespace vigine::service
+{
+// Forward declaration only. The concrete ServiceRegistry type is a
+// substrate-primitive specialisation defined under src/service and is
+// never exposed in the public header tree — see INV-11, wrapper
+// encapsulation.
+class ServiceRegistry;
+
+/**
+ * @brief Stateful abstract base that every concrete service derives
+ *        from.
+ *
+ * @ref AbstractService is level 4 of the wrapper recipe used by the
+ * engine's Level-1 subsystem wrappers. It carries the state every
+ * concrete service shares — the declared dependency list, the
+ * initialised flag, and a private handle to the internal service
+ * registry — and supplies default implementations of the
+ * @ref IService lifecycle methods so that minimal concrete services
+ * only need to override @ref IService::id (and optionally refine
+ * @ref onInit / @ref onShutdown to add their own domain behaviour).
+ *
+ * The class carries state, so it follows the project's @c Abstract
+ * naming convention rather than the @c I pure-virtual prefix. The base
+ * is abstract only in the logical sense: its default @ref id returns
+ * the sentinel so instantiating it directly would yield a service that
+ * cannot be looked up by handle. Concrete services seal the chain
+ * (see @c src/service/defaultservice.{h,cpp} for the minimal closer
+ * used by the factory in this leaf).
+ *
+ * Composition, not inheritance:
+ *   - @ref AbstractService HAS-A private @c std::unique_ptr<ServiceRegistry>.
+ *     It does @b not inherit from the substrate primitive at the
+ *     wrapper level. The internal registry is the only place where
+ *     substrate primitives enter the service stack, and it lives
+ *     strictly under @c src/service. This keeps the public header tree
+ *     free of substrate types (@ref INV-11) and makes the "a service
+ *     IS NOT a substrate primitive" relationship explicit.
+ *
+ * Strict encapsulation:
+ *   - All data members are @c private. Derived services reach state
+ *     through @c protected accessors; there is no @c mark / @c markNot
+ *     pair — the single setter takes the desired boolean value.
+ *
+ * Thread-safety: the base inherits the registry's thread-safety
+ * policy (reader-writer mutex on the substrate primitive). Callers may
+ * query @ref isInitialised concurrently with a lifecycle transition;
+ * transitions are intended to run on the engine main thread so readers
+ * observe the flag consistently.
+ */
+class AbstractService : public IService
+{
+  public:
+    ~AbstractService() override;
+
+    // ------ IService ------
+
+    [[nodiscard]] ServiceId id() const noexcept override;
+    [[nodiscard]] Result    onInit(IContext &context) override;
+    [[nodiscard]] Result    onShutdown(IContext &context) override;
+    [[nodiscard]] std::vector<std::shared_ptr<IService>>
+                            dependencies() const override;
+    [[nodiscard]] bool      isInitialised() const noexcept override;
+
+    AbstractService(const AbstractService &)            = delete;
+    AbstractService &operator=(const AbstractService &) = delete;
+    AbstractService(AbstractService &&)                 = delete;
+    AbstractService &operator=(AbstractService &&)      = delete;
+
+  protected:
+    AbstractService();
+
+    /**
+     * @brief Flips the initialised flag.
+     *
+     * The default @ref onInit calls @c setInitialised(true) on success
+     * and the default @ref onShutdown calls @c setInitialised(false).
+     * Derived services that override @ref onInit / @ref onShutdown for
+     * domain-specific work chain up to the base implementation so the
+     * flag tracks reality.
+     *
+     * Single setter with a @c bool parameter; no @c markInitialised /
+     * @c markNotInitialised pair.
+     */
+    void setInitialised(bool value) noexcept;
+
+    /**
+     * @brief Appends a dependency to this service's declared list.
+     *
+     * Called by concrete constructors (or by the registration code
+     * before @ref onInit runs) to wire cross-service edges that the
+     * container's topological sort consumes. Adding a duplicate entry
+     * is allowed but wasteful; the container treats duplicates as a
+     * single edge.
+     */
+    void addDependency(std::shared_ptr<IService> dependency);
+
+    /**
+     * @brief Overwrites the stored @ref ServiceId for this service.
+     *
+     * The container stamps the id during registration; concrete
+     * services do not call the setter themselves. It is exposed as
+     * @c protected so that test fixtures can construct a service in
+     * isolation (without going through a container) and still produce
+     * a non-sentinel id for assertion purposes.
+     */
+    void setId(ServiceId id) noexcept;
+
+  private:
+    /**
+     * @brief Owns the internal service registry.
+     *
+     * The registry is a substrate-primitive specialisation defined
+     * under @c src/service; forward-declaring it here keeps the
+     * substrate out of the public header tree. Held through a
+     * @c std::unique_ptr so the registry's full definition does not
+     * have to leak through this header.
+     */
+    std::unique_ptr<ServiceRegistry> _registry;
+
+    /// Declared dependencies on other services. Cross-service
+    /// ownership edges held as @c std::shared_ptr so a dependency
+    /// target outlives every dependent.
+    std::vector<std::shared_ptr<IService>> _dependencies;
+
+    /// Stable identifier assigned by the container during registration.
+    ServiceId _id{};
+
+    /// Lifecycle flag: @c true between a successful @ref onInit and
+    /// the matching @ref onShutdown.
+    bool _initialised{false};
+};
+
+} // namespace vigine::service

--- a/include/vigine/service/dependencykind.h
+++ b/include/vigine/service/dependencykind.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstdint>
+
+namespace vigine::service
+{
+/**
+ * @brief Classifies how a declared service dependency is resolved.
+ *
+ * Closed enum; extensions are a breaking API change under the architect
+ * gate. The wrapper consumes this enum only when building the
+ * topological-init DAG; it is not used on the dispatch hot path.
+ */
+enum class DependencyKind : std::uint8_t
+{
+    /// Must be resolved before @ref IService::onInit runs; the engine
+    /// aborts the init chain if the handle cannot be satisfied.
+    Required = 1,
+
+    /// The dependency is resolved if present but its absence is not
+    /// fatal; the service proceeds with @ref IService::onInit and
+    /// null-checks the handle at use sites.
+    Optional = 2,
+
+    /// The dependency is not required at init; the service resolves the
+    /// handle lazily on first use.
+    RuntimeOnly = 3,
+};
+
+} // namespace vigine::service

--- a/include/vigine/service/factory.h
+++ b/include/vigine/service/factory.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <memory>
+
+#include "vigine/service/iservice.h"
+
+namespace vigine::service
+{
+/**
+ * @brief Constructs the default concrete service and hands back an
+ *        owning @c std::unique_ptr<IService>.
+ *
+ * The factory is the single public entry point callers use to
+ * instantiate a service in this leaf. The returned object is the
+ * minimal concrete closer over @ref AbstractService; it carries no
+ * domain-specific behaviour of its own and exists so the wrapper
+ * primitive can be exercised, linked, and tested in isolation.
+ * Domain-specific services (graphics, platform, network, database,
+ * timer, ...) land in dedicated follow-up leaves and each provide
+ * their own factory entry point that shares this signature.
+ *
+ * Ownership: the caller owns the returned pointer. Callers that need
+ * shared ownership wrap the result in a @c std::shared_ptr at the
+ * call site; shared ownership is not the factory's concern. This
+ * mirrors the shape used by the thread manager factory
+ * (@ref vigine::threading::createThreadManager), the payload registry
+ * factory, and the message bus factory
+ * (@ref vigine::messaging::createMessageBus).
+ *
+ * Lifetime: the returned service is self-contained. The engine takes
+ * ownership during registration; before registration the service is
+ * idle and its @ref IService::id reports the invalid sentinel.
+ *
+ * The function is @c [[nodiscard]] because silently dropping the
+ * returned handle would leak the allocation and leave the caller with
+ * nothing — the motivation for the @ref FF-1 factory rule.
+ */
+[[nodiscard]] std::unique_ptr<IService> createService();
+
+} // namespace vigine::service

--- a/include/vigine/service/initpolicy.h
+++ b/include/vigine/service/initpolicy.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <cstdint>
+
+namespace vigine::service
+{
+/**
+ * @brief Selects when the engine calls @ref IService::onInit on a
+ *        registered service.
+ *
+ * Closed enum; extensions are a breaking API change under the architect
+ * gate. The choice is made per-service by the registering code; the
+ * engine honours it when walking the topological order.
+ */
+enum class InitPolicy : std::uint8_t
+{
+    /// @ref IService::onInit runs on the first call that resolves the
+    /// service through the container. Useful for heavy services an
+    /// application may not need in every run.
+    Lazy = 1,
+
+    /// @ref IService::onInit runs during engine startup, in the
+    /// topological order computed from @ref IService::dependencies. The
+    /// default for services whose startup costs are acceptable.
+    Eager = 2,
+
+    /// @ref IService::onInit is not called automatically; the owner
+    /// triggers it explicitly through the engine. Reserved for services
+    /// with bespoke initialisation rules (long-running handshakes,
+    /// external broker wait loops).
+    Manual = 3,
+};
+
+} // namespace vigine::service

--- a/include/vigine/service/iservice.h
+++ b/include/vigine/service/iservice.h
@@ -1,0 +1,137 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "vigine/result.h"
+#include "vigine/service/serviceid.h"
+
+namespace vigine
+{
+class IContext;
+} // namespace vigine
+
+namespace vigine::service
+{
+/**
+ * @brief Pure-virtual Level-1 wrapper surface for an engine service.
+ *
+ * A service is an atomic container of capability — graphics, platform,
+ * network, database, timer — that the engine boots in topological
+ * order during start-up and tears down in reverse order on shutdown.
+ * @ref IService is the user-facing contract every concrete service
+ * implementation fulfils. It carries no state and no substrate of its
+ * own; its role is to declare the shape the container layer and every
+ * service implementation agree on.
+ *
+ * The public API is deliberately restricted to domain types
+ * (@ref ServiceId, @ref Result, @ref vigine::IContext) per INV-11.
+ * Substrate primitive types do not appear here; the stateful base
+ * @ref AbstractService keeps its internal service registry as an
+ * opaque member composed through a private @c std::unique_ptr so the
+ * substrate is never leaked to the wrapper's public surface.
+ *
+ * Ownership and lifetime:
+ *   - Concrete services are handed to the engine as
+ *     @c std::unique_ptr<IService>. The engine takes ownership and
+ *     manages the service for the lifetime of the surrounding
+ *     container; callers hold raw references while the container is
+ *     alive.
+ *   - Lifecycle entry points (@ref onInit, @ref onShutdown) take a
+ *     reference to @ref vigine::IContext so concrete implementations
+ *     can reach sibling services, the system bus, the thread manager,
+ *     and so on through a single injection point. The context outlives
+ *     every service it visits.
+ *
+ * Thread-safety: the contract does not fix one. Concrete services
+ * document their own policy; the typical shape is that @ref onInit and
+ * @ref onShutdown run on the engine main thread while any downstream
+ * domain methods are documented per service.
+ *
+ * INV-1 compliance: the surface uses no template parameters. INV-10
+ * compliance: the name carries the @c I prefix to mark a pure-virtual
+ * interface. INV-11 compliance: the surface exposes only service-
+ * domain handles; the graph substrate stays hidden behind the
+ * @ref AbstractService composition layer.
+ */
+class IService
+{
+  public:
+    virtual ~IService() = default;
+
+    /**
+     * @brief Returns the registry-assigned identifier of this service.
+     *
+     * The id is stamped when the service is registered in the container;
+     * before registration the default-constructed sentinel is reported.
+     * Generational ids let callers hold a value handle without risking
+     * a dangling reference after the underlying slot recycles.
+     */
+    [[nodiscard]] virtual ServiceId id() const noexcept = 0;
+
+    /**
+     * @brief Runs the service's start-up step.
+     *
+     * The container calls @ref onInit exactly once per successful
+     * registration, after every dependency declared by
+     * @ref dependencies has itself initialised. The @p context
+     * reference is the engine-level aggregator; concrete services read
+     * their dependencies through it. A success result moves the
+     * service to the initialised state; any error result aborts the
+     * init chain and triggers a reverse-topological rollback of the
+     * services that succeeded before it.
+     */
+    [[nodiscard]] virtual Result onInit(IContext &context) = 0;
+
+    /**
+     * @brief Runs the service's teardown step.
+     *
+     * The container calls @ref onShutdown in reverse-topological
+     * order during engine teardown, or during rollback of a failed
+     * init chain. The call is best-effort: implementations release
+     * their resources and return an error @ref Result if they cannot,
+     * but the container continues walking the remaining services and
+     * aggregates the errors into a single final report.
+     */
+    [[nodiscard]] virtual Result onShutdown(IContext &context) = 0;
+
+    /**
+     * @brief Reports the other services this one depends on.
+     *
+     * Every handle returned here is treated as a @ref DependencyKind
+     * @c Required edge by the default topological sort. Services that
+     * need @c Optional or @c RuntimeOnly semantics expose that through
+     * their own constructors and attach the kind inside the wrapper
+     * implementation before the DAG is built. Returning an empty
+     * vector marks the service as a root of the init DAG.
+     *
+     * The returned vector carries @c std::shared_ptr<IService> handles
+     * because dependencies are cross-service ownership edges; the
+     * target service must outlive every dependent. Handles are copies
+     * of the container's internal pointers, so the caller may inspect
+     * them without synchronising with the container.
+     */
+    [[nodiscard]] virtual std::vector<std::shared_ptr<IService>>
+        dependencies() const = 0;
+
+    /**
+     * @brief Returns @c true iff @ref onInit has been called and
+     *        returned success without a matching @ref onShutdown.
+     *
+     * The flag is an observability hook; the container is the
+     * authoritative tracker of init state. Concrete services flip the
+     * flag through the protected setter on @ref AbstractService; they
+     * never mutate private state directly.
+     */
+    [[nodiscard]] virtual bool isInitialised() const noexcept = 0;
+
+    IService(const IService &)            = delete;
+    IService &operator=(const IService &) = delete;
+    IService(IService &&)                 = delete;
+    IService &operator=(IService &&)      = delete;
+
+  protected:
+    IService() = default;
+};
+
+} // namespace vigine::service

--- a/include/vigine/service/serviceid.h
+++ b/include/vigine/service/serviceid.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <compare>
+#include <cstdint>
+
+namespace vigine::service
+{
+/**
+ * @brief Generational identifier for a service registered on an
+ *        @ref IService container.
+ *
+ * @ref ServiceId is a POD value type owned by the service wrapper. It is
+ * deliberately its own struct rather than an alias over the substrate
+ * primitive's identifier type so that the public service surface never
+ * mentions substrate primitive types (INV-11 — wrapper encapsulation).
+ * The wrapper layer translates between @c ServiceId and the substrate-
+ * side identifiers exclusively inside @c src/service; callers of the
+ * @ref IService API never need to know the substrate exists underneath.
+ *
+ * The @c index field addresses a slot in the service registry; the
+ * @c generation field is incremented whenever that slot is recycled so a
+ * lookup with a stale handle fails safely rather than returning a
+ * different service instance. A default-constructed @ref ServiceId
+ * (@c generation @c == @c 0) is the invalid sentinel and reports
+ * @ref valid as @c false.
+ *
+ * The pair is small (8 bytes), trivially copyable, and safe to pass by
+ * value across thread boundaries.
+ */
+struct ServiceId
+{
+    std::uint32_t index{0};
+    std::uint32_t generation{0};
+
+    /**
+     * @brief Reports whether the id addresses a slot that was live at
+     *        construction time.
+     *
+     * A @c true return only means the generation is non-zero. The
+     * registry may still have invalidated the slot since; the
+     * authoritative check is the registry lookup performed by
+     * @ref IService implementations.
+     */
+    [[nodiscard]] constexpr bool valid() const noexcept { return generation != 0; }
+
+    friend constexpr auto operator<=>(const ServiceId &, const ServiceId &) = default;
+    friend constexpr bool operator==(const ServiceId &, const ServiceId &) = default;
+};
+
+} // namespace vigine::service

--- a/src/service/abstractservice.cpp
+++ b/src/service/abstractservice.cpp
@@ -1,0 +1,71 @@
+#include "vigine/service/abstractservice.h"
+
+#include <utility>
+
+#include "service/serviceregistry.h"
+
+namespace vigine::service
+{
+
+AbstractService::AbstractService()
+    : _registry{std::make_unique<ServiceRegistry>()}
+{
+}
+
+AbstractService::~AbstractService() = default;
+
+ServiceId AbstractService::id() const noexcept
+{
+    return _id;
+}
+
+Result AbstractService::onInit(IContext & /*context*/)
+{
+    // Default lifecycle: flip the flag. Concrete services chain up to
+    // this implementation after they finish their own domain-specific
+    // initialisation so the observed @ref isInitialised state matches
+    // reality.
+    setInitialised(true);
+    return Result{};
+}
+
+Result AbstractService::onShutdown(IContext & /*context*/)
+{
+    // Default teardown: flip the flag and clear the cross-service
+    // ownership edges so a dependency target is not kept alive longer
+    // than its dependent needs it. Concrete services chain up after
+    // releasing their own domain resources.
+    setInitialised(false);
+    _dependencies.clear();
+    return Result{};
+}
+
+std::vector<std::shared_ptr<IService>> AbstractService::dependencies() const
+{
+    return _dependencies;
+}
+
+bool AbstractService::isInitialised() const noexcept
+{
+    return _initialised;
+}
+
+void AbstractService::setInitialised(bool value) noexcept
+{
+    _initialised = value;
+}
+
+void AbstractService::addDependency(std::shared_ptr<IService> dependency)
+{
+    if (!dependency)
+        return;
+
+    _dependencies.push_back(std::move(dependency));
+}
+
+void AbstractService::setId(ServiceId identifier) noexcept
+{
+    _id = identifier;
+}
+
+} // namespace vigine::service

--- a/src/service/defaultservice.cpp
+++ b/src/service/defaultservice.cpp
@@ -1,0 +1,10 @@
+#include "service/defaultservice.h"
+
+namespace vigine::service
+{
+
+DefaultService::DefaultService() = default;
+
+DefaultService::~DefaultService() = default;
+
+} // namespace vigine::service

--- a/src/service/defaultservice.h
+++ b/src/service/defaultservice.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "vigine/service/abstractservice.h"
+
+namespace vigine::service
+{
+/**
+ * @brief Minimal concrete service that seals the wrapper recipe.
+ *
+ * @ref DefaultService exists so @ref createService can return a
+ * real owning @c std::unique_ptr<IService>. It carries no
+ * domain-specific behaviour; its lifecycle methods fall through to
+ * @ref AbstractService and its @ref id reports the default-
+ * constructed sentinel until the container stamps it during
+ * registration.
+ *
+ * The class is @c final to close the inheritance chain for this
+ * leaf; follow-up leaves that ship real services (graphics, platform,
+ * network, database, timer) define their own concrete classes and
+ * their own factory entry points and do not derive from
+ * @ref DefaultService.
+ */
+class DefaultService final : public AbstractService
+{
+  public:
+    DefaultService();
+    ~DefaultService() override;
+
+    DefaultService(const DefaultService &)            = delete;
+    DefaultService &operator=(const DefaultService &) = delete;
+    DefaultService(DefaultService &&)                 = delete;
+    DefaultService &operator=(DefaultService &&)      = delete;
+};
+
+} // namespace vigine::service

--- a/src/service/factory.cpp
+++ b/src/service/factory.cpp
@@ -1,0 +1,20 @@
+#include "vigine/service/factory.h"
+
+#include <memory>
+
+#include "service/defaultservice.h"
+
+namespace vigine::service
+{
+
+std::unique_ptr<IService> createService()
+{
+    // The factory constructs the default concrete closer over
+    // AbstractService. The returned object has the invalid-sentinel
+    // ServiceId until it is registered with a container; callers that
+    // need a real id go through the engine container in downstream
+    // leaves.
+    return std::make_unique<DefaultService>();
+}
+
+} // namespace vigine::service

--- a/src/service/serviceregistry.cpp
+++ b/src/service/serviceregistry.cpp
@@ -1,0 +1,10 @@
+#include "service/serviceregistry.h"
+
+namespace vigine::service
+{
+
+ServiceRegistry::ServiceRegistry() = default;
+
+ServiceRegistry::~ServiceRegistry() = default;
+
+} // namespace vigine::service

--- a/src/service/serviceregistry.h
+++ b/src/service/serviceregistry.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "vigine/graph/abstractgraph.h"
+
+namespace vigine::service
+{
+/**
+ * @brief Internal graph specialisation that the service wrapper uses
+ *        to hold its service-domain storage.
+ *
+ * @ref ServiceRegistry is a concrete @c vigine::graph::AbstractGraph
+ * subtype that seals the inheritance chain for the services wrapper.
+ * It carries no additional state and no additional virtual methods; it
+ * exists only to keep the graph substrate in a typed wrapper so
+ * @ref AbstractService can hold an opaque @c std::unique_ptr to it in
+ * a public header without leaking any graph primitives.
+ *
+ * This header lives under @c src/service on purpose: the INV-11 rule
+ * forbids @c vigine::graph types from surfacing in
+ * @c include/vigine/service. Only the wrapper implementation consumes
+ * the registry; callers of @ref IService / @ref AbstractService see
+ * neither the registry nor its graph base.
+ *
+ * Thread-safety inherits from @c AbstractGraph: every mutating entry
+ * point takes the graph's exclusive lock; reads take a shared lock.
+ * The wrapper layer does not add any additional synchronisation on
+ * top; every service-side access path funnels through the registry.
+ */
+class ServiceRegistry final : public vigine::graph::AbstractGraph
+{
+  public:
+    ServiceRegistry();
+    ~ServiceRegistry() override;
+
+    ServiceRegistry(const ServiceRegistry &)            = delete;
+    ServiceRegistry &operator=(const ServiceRegistry &) = delete;
+    ServiceRegistry(ServiceRegistry &&)                 = delete;
+    ServiceRegistry &operator=(ServiceRegistry &&)      = delete;
+};
+
+} // namespace vigine::service


### PR DESCRIPTION
Level-1 Service wrapper — the first of the four wrappers-over-IGraph family.

## Summary

- `include/vigine/service/iservice.h` — pure-virtual `IService` public surface (id / onInit / onShutdown / dependencies / isInitialised), no substrate types leaked.
- `include/vigine/service/abstractservice.h` — stateful base; composition over inheritance via a private `std::unique_ptr<ServiceRegistry>`.
- `include/vigine/service/serviceid.h` — own generational POD (not a NodeId alias); INV-11 compliant.
- `include/vigine/service/dependencykind.h`, `initpolicy.h` — closed enums for the container layer.
- `include/vigine/service/factory.h` — `[[nodiscard]] std::unique_ptr<IService> createService()`.
- `src/service/serviceregistry.{h,cpp}` — internal substrate-primitive specialisation (never reaches the public header tree).
- `src/service/abstractservice.cpp`, `defaultservice.{h,cpp}`, `factory.cpp` — base impl + minimal concrete closer used by the factory.

All data members private; single `setInitialised(bool)` setter. INV-11 grep on `include/vigine/service/` is clean.

## Build

- `cmake --build build --config Debug` — green (warnings only in pre-existing legacy: `meshcomponent.h`, `abstractpayloadregistry.cpp`).
- `cmake --build build --config Release` — green.
- `scripts/check_no_templates.py --path include/vigine/service/` — 9 files scanned, 0 violations.
- `scripts/check_naming_convention.py --path include/vigine/service/` — 9 files scanned, 0 violations.

Closes #112