### PR TITLE
feat(ecs): IECS + AbstractECS + EntityWorld + EntityId POD (R.4.2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,6 +318,25 @@ set(SOURCES_SERVICE
     ${SRC_DIR}/service/platformservice.cpp
 )
 
+# Level-1 ECS wrapper (R.4.2) -- public surface.
+set(HEADER_ECS_CORE
+    ${INCLUDE_DIR}/vigine/ecs/ecstypes.h
+    ${INCLUDE_DIR}/vigine/ecs/iecs.h
+    ${INCLUDE_DIR}/vigine/ecs/icomponentstore.h
+    ${INCLUDE_DIR}/vigine/ecs/abstractecs.h
+    ${INCLUDE_DIR}/vigine/ecs/factory.h
+)
+
+# Level-1 ECS wrapper (R.4.2) -- internal entity world + base impl.
+set(SOURCES_ECS_CORE
+    ${SRC_DIR}/ecs/entityworld.h
+    ${SRC_DIR}/ecs/entityworld.cpp
+    ${SRC_DIR}/ecs/abstractecs.cpp
+    ${SRC_DIR}/ecs/defaultecs.h
+    ${SRC_DIR}/ecs/defaultecs.cpp
+    ${SRC_DIR}/ecs/factory.cpp
+)
+
 # Add source files
 if(ENABLE_POSTGRESQL)
     set(HEADER_POSTGRESQL
@@ -394,6 +413,8 @@ add_library(${PROJECT_NAME}
     ${SOURCES}
     ${HEADER_SERVICE}
     ${SOURCES_SERVICE}
+    ${HEADER_ECS_CORE}
+    ${SOURCES_ECS_CORE}
     ${HEADER_POSTGRESQL}
     ${SOURCES_POSTGRESQL}
     ${SOURCES_POSTGRESQL_EXTRA}

--- a/include/vigine/ecs/abstractecs.h
+++ b/include/vigine/ecs/abstractecs.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "vigine/ecs/ecstypes.h"
+#include "vigine/ecs/iecs.h"
+#include "vigine/result.h"
+
+namespace vigine::ecs
+{
+// Forward declaration only. The concrete EntityWorld type is a
+// substrate-primitive specialisation defined under @c src/ecs and is
+// never exposed in the public header tree — see INV-11, wrapper
+// encapsulation.
+class EntityWorld;
+
+/**
+ * @brief Stateful abstract base that every concrete ECS derives from.
+ *
+ * @ref AbstractECS is level 4 of the wrapper recipe used by the
+ * engine's Level-1 subsystem wrappers. It carries the state every
+ * concrete ECS shares — a private handle to the internal entity
+ * world — and supplies default implementations of every
+ * @ref IECS lifecycle and query method so that a minimal concrete
+ * ECS only needs to seal the inheritance chain. The internal entity
+ * world specialises the graph substrate (@c vigine::graph::AbstractGraph)
+ * and translates between @ref EntityId and the substrate's own
+ * identifier types inside its implementation.
+ *
+ * The class carries state, so it follows the project's @c Abstract
+ * naming convention rather than the @c I pure-virtual prefix. The
+ * base is abstract in the logical sense; its default constructor
+ * wires up a fresh internal entity world so every concrete ECS has a
+ * live substrate to delegate to.
+ *
+ * Composition, not inheritance:
+ *   - @ref AbstractECS HAS-A private @c std::unique_ptr<EntityWorld>.
+ *     It does @b not inherit from the substrate primitive at the
+ *     wrapper level. The internal entity world is the only place
+ *     where substrate primitives enter the ECS stack, and it lives
+ *     strictly under @c src/ecs. This keeps the public header tree
+ *     free of substrate types (INV-11) and makes the "an ECS IS NOT
+ *     a substrate graph" relationship explicit.
+ *
+ * Strict encapsulation:
+ *   - All data members are @c private. Derived ECS classes reach
+ *     internal state through @c protected accessors; the single
+ *     getter returns a reference to the entity world so concrete
+ *     derivatives can extend the default implementation without
+ *     re-exporting the substrate on their own public surface.
+ *
+ * Thread-safety: the base inherits the entity world's thread-safety
+ * policy (reader-writer mutex on the substrate primitive). Callers
+ * may query and mutate concurrently; each mutation takes the
+ * exclusive lock while each query takes a shared lock. The wrapper
+ * layer does not add further synchronisation — every ECS-side access
+ * path funnels through the world.
+ */
+class AbstractECS : public IECS
+{
+  public:
+    ~AbstractECS() override;
+
+    // ------ IECS: entity lifecycle ------
+
+    [[nodiscard]] EntityId createEntity() override;
+    Result                 removeEntity(EntityId entity) override;
+    [[nodiscard]] bool     hasEntity(EntityId entity) const noexcept override;
+
+    // ------ IECS: component lifecycle ------
+
+    [[nodiscard]] ComponentHandle
+        attachComponent(EntityId entity, std::unique_ptr<IComponent> component) override;
+    Result detachComponent(EntityId entity, ComponentTypeId typeId) override;
+    [[nodiscard]] const IComponent *
+        findComponent(EntityId entity, ComponentTypeId typeId) const override;
+    [[nodiscard]] std::vector<const IComponent *>
+        componentsOf(EntityId entity) const override;
+
+    // ------ IECS: bulk query ------
+
+    [[nodiscard]] std::vector<EntityId>
+        entitiesWith(ComponentTypeId typeId) const override;
+
+    AbstractECS(const AbstractECS &)            = delete;
+    AbstractECS &operator=(const AbstractECS &) = delete;
+    AbstractECS(AbstractECS &&)                 = delete;
+    AbstractECS &operator=(AbstractECS &&)      = delete;
+
+  protected:
+    AbstractECS();
+
+    /**
+     * @brief Returns a mutable reference to the internal entity world.
+     *
+     * Exposed as @c protected so that follow-up concrete ECS classes
+     * can add their own specialised cache or traversal on top of the
+     * default implementation without re-exporting the substrate on
+     * the public surface. The reference is stable for the lifetime of
+     * the @ref AbstractECS instance.
+     */
+    [[nodiscard]] EntityWorld       &world() noexcept;
+    [[nodiscard]] const EntityWorld &world() const noexcept;
+
+  private:
+    /**
+     * @brief Owns the internal entity world.
+     *
+     * The world is a substrate-primitive specialisation defined
+     * under @c src/ecs; forward-declaring it here keeps the substrate
+     * out of the public header tree. Held through a
+     * @c std::unique_ptr so the world's full definition does not
+     * have to leak through this header.
+     */
+    std::unique_ptr<EntityWorld> _world;
+};
+
+} // namespace vigine::ecs

--- a/include/vigine/ecs/ecstypes.h
+++ b/include/vigine/ecs/ecstypes.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include <compare>
+#include <cstdint>
+
+namespace vigine::ecs
+{
+/**
+ * @brief Generational identifier for an entity managed by an @ref IECS.
+ *
+ * @ref EntityId is a POD value type owned by the ECS wrapper. It is
+ * deliberately its own struct rather than an alias over the substrate
+ * primitive's identifier type so that the public ECS surface never
+ * mentions substrate primitive types (INV-11 — wrapper encapsulation).
+ * The wrapper layer translates between @c EntityId and the substrate-
+ * side identifiers exclusively inside @c src/ecs; callers of the
+ * @ref IECS API never need to know the substrate exists.
+ *
+ * The @c index field addresses a slot in the internal entity world; the
+ * @c generation field is incremented whenever that slot is recycled so a
+ * lookup with a stale handle fails safely rather than returning a
+ * different entity. A default-constructed @ref EntityId
+ * (@c generation @c == @c 0) is the invalid sentinel and reports
+ * @ref valid as @c false.
+ *
+ * The pair is small (8 bytes), trivially copyable, and safe to pass by
+ * value across thread boundaries.
+ *
+ * @note The retroactive fix from user decision UD-8 replaces the
+ *       earlier typedef alias with this own POD. The layout is
+ *       structurally identical but the named type keeps substrate
+ *       types out of the public header tree.
+ */
+struct EntityId
+{
+    std::uint32_t index{0};
+    std::uint32_t generation{0};
+
+    /**
+     * @brief Reports whether the id addresses a slot that was live at
+     *        construction time.
+     *
+     * A @c true return only means the generation is non-zero. The
+     * underlying entity world may still have invalidated the slot since;
+     * the authoritative check is an @ref IECS lookup.
+     */
+    [[nodiscard]] constexpr bool valid() const noexcept { return generation != 0; }
+
+    friend constexpr auto operator<=>(const EntityId &, const EntityId &) = default;
+    friend constexpr bool operator==(const EntityId &, const EntityId &)  = default;
+};
+
+/**
+ * @brief Generational handle for an individual component attached to an
+ *        entity.
+ *
+ * @ref ComponentHandle is the second own POD owned by the ECS wrapper.
+ * It identifies a specific component-attachment slot — the combination
+ * of an entity and a component type stored under the entity's
+ * attachment list — without exposing substrate primitive identifier
+ * types. A default-constructed handle is the invalid sentinel.
+ *
+ * The handle stays stable across lookups while the component remains
+ * attached; detaching the component bumps the slot generation so stale
+ * handles fail safely.
+ */
+struct ComponentHandle
+{
+    std::uint32_t index{0};
+    std::uint32_t generation{0};
+
+    /**
+     * @brief Reports whether the handle referenced a live component at
+     *        construction time.
+     */
+    [[nodiscard]] constexpr bool valid() const noexcept { return generation != 0; }
+
+    friend constexpr auto operator<=>(const ComponentHandle &, const ComponentHandle &) = default;
+    friend constexpr bool operator==(const ComponentHandle &, const ComponentHandle &)  = default;
+};
+
+/**
+ * @brief Opaque tag used to classify a component type.
+ *
+ * Concrete component implementations report a stable value from
+ * @ref IComponent::componentTypeId. Reserved ranges mirror the
+ * @c PayloadTypeId discipline used by the messaging wrapper:
+ *   - @c [0..127] — engine-bundled component types.
+ *   - @c [128..) — user-space component types.
+ *
+ * @ref IECS treats the id as opaque; concrete component receivers
+ * assert on the expected value and @c static_cast down to the concrete
+ * type. No @c dynamic_cast and no @c std::any on the subscriber path
+ * (INV-1).
+ */
+using ComponentTypeId = std::uint32_t;
+
+} // namespace vigine::ecs

--- a/include/vigine/ecs/factory.h
+++ b/include/vigine/ecs/factory.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <memory>
+
+#include "vigine/ecs/iecs.h"
+
+namespace vigine::ecs
+{
+/**
+ * @brief Constructs the default concrete ECS and hands back an owning
+ *        @c std::unique_ptr<IECS>.
+ *
+ * The factory is the single public entry point callers use to
+ * instantiate an ECS in this leaf. The returned object is the minimal
+ * concrete closer over @ref AbstractECS; it carries no domain-
+ * specific behaviour of its own and exists so the wrapper primitive
+ * can be exercised, linked, and tested in isolation.
+ *
+ * Ownership: the caller owns the returned pointer. Callers that need
+ * shared ownership wrap the result in a @c std::shared_ptr at the
+ * call site; shared ownership is not the factory's concern. This
+ * mirrors the shape used by the service factory
+ * (@ref vigine::service::createService), the thread manager factory
+ * (@ref vigine::threading::createThreadManager), the payload registry
+ * factory, and the message bus factory
+ * (@ref vigine::messaging::createMessageBus).
+ *
+ * Lifetime: the returned ECS is self-contained. The internal entity
+ * world is constructed eagerly during the factory call; every entity
+ * created afterwards lives for the lifetime of the returned handle
+ * (or until explicit removal via @ref IECS::removeEntity).
+ *
+ * The function is @c [[nodiscard]] because silently dropping the
+ * returned handle would leak the allocation and leave the caller
+ * with nothing — the motivation for the @ref FF-1 factory rule.
+ */
+[[nodiscard]] std::unique_ptr<IECS> createECS();
+
+} // namespace vigine::ecs

--- a/include/vigine/ecs/icomponentstore.h
+++ b/include/vigine/ecs/icomponentstore.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "vigine/ecs/ecstypes.h"
+#include "vigine/ecs/iecs.h"
+#include "vigine/result.h"
+
+namespace vigine::ecs
+{
+/**
+ * @brief Thin read-write view over an @ref IECS that presents only
+ *        the component-attachment surface.
+ *
+ * @ref IComponentStore mirrors the four component-lifecycle methods
+ * on @ref IECS (@c attachComponent, @c detachComponent,
+ * @c findComponent, @c componentsOf) without re-exposing the entity
+ * lifecycle and bulk-query surface. Systems that only need to manage
+ * their own component type on behalf of externally created entities
+ * depend on this narrower contract instead of taking a full
+ * @ref IECS reference, which keeps their dependency surface minimal
+ * and makes unit testing easier — a mock @ref IComponentStore is
+ * trivial to stand up.
+ *
+ * The store is a view, not a second storage layer: every concrete
+ * @ref IComponentStore delegates to the underlying @ref IECS. The
+ * split exists for the user, not for duplication.
+ *
+ * Ownership semantics mirror @ref IECS exactly: the store takes
+ * unique ownership of the component on attach and releases it on
+ * detach or entity removal.
+ *
+ * INV-1 compliance: no template parameters. INV-10 compliance: @c I
+ * prefix on a pure-virtual interface. INV-11 compliance: the surface
+ * exposes only ECS domain handles; substrate graph types stay hidden.
+ */
+class IComponentStore
+{
+  public:
+    virtual ~IComponentStore() = default;
+
+    /**
+     * @brief Takes ownership of @p component and attaches it to
+     *        @p entity.
+     *
+     * Delegates to @ref IECS::attachComponent. Returns a successful
+     * @ref Result when the attach succeeds; any error reported by the
+     * underlying ECS (stale entity, null pointer) surfaces unchanged.
+     */
+    [[nodiscard]] virtual Result
+        add(EntityId entity, std::unique_ptr<IComponent> component) = 0;
+
+    /**
+     * @brief Returns a non-owning view of the first component on
+     *        @p entity whose type id matches @p typeId, or @c nullptr
+     *        when no such component exists.
+     *
+     * Delegates to @ref IECS::findComponent.
+     */
+    [[nodiscard]] virtual const IComponent *
+        find(EntityId entity, ComponentTypeId typeId) const = 0;
+
+    /**
+     * @brief Releases the first component on @p entity whose type id
+     *        matches @p typeId.
+     *
+     * Delegates to @ref IECS::detachComponent. Idempotent.
+     */
+    [[nodiscard]] virtual Result
+        remove(EntityId entity, ComponentTypeId typeId) = 0;
+
+    /**
+     * @brief Returns non-owning views of every component currently
+     *        attached to @p entity.
+     *
+     * Delegates to @ref IECS::componentsOf.
+     */
+    [[nodiscard]] virtual std::vector<const IComponent *>
+        componentsOf(EntityId entity) const = 0;
+
+    IComponentStore(const IComponentStore &)            = delete;
+    IComponentStore &operator=(const IComponentStore &) = delete;
+    IComponentStore(IComponentStore &&)                 = delete;
+    IComponentStore &operator=(IComponentStore &&)      = delete;
+
+  protected:
+    IComponentStore() = default;
+};
+
+} // namespace vigine::ecs

--- a/include/vigine/ecs/iecs.h
+++ b/include/vigine/ecs/iecs.h
@@ -1,0 +1,205 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "vigine/ecs/ecstypes.h"
+#include "vigine/result.h"
+
+namespace vigine::ecs
+{
+/**
+ * @brief Pure-virtual root of every component type attached to an
+ *        entity through an @ref IECS.
+ *
+ * A component is a piece of state owned by a specific entity; the
+ * engine attaches, enumerates, and detaches components through the
+ * @ref IECS surface. Concrete components carry their domain payload
+ * (render mesh, window handle, postgres connection parameters, ...)
+ * and report a stable @ref ComponentTypeId so the receiver can
+ * downcast safely without @c dynamic_cast.
+ *
+ * Ownership: the ECS takes unique ownership of the component when it
+ * is attached (@ref IECS::attachComponent). The component stays live
+ * until the matching detach or until the owning entity is removed.
+ *
+ * Copy and move are deleted to keep the pinning invariant explicit:
+ * once attached, a component never migrates between entities.
+ *
+ * INV-1 compliance: no template parameters on the interface. Concrete
+ * component types override @ref componentTypeId with a constant from
+ * the engine or user-space range.
+ */
+class IComponent
+{
+  public:
+    virtual ~IComponent() = default;
+
+    /**
+     * @brief Reports the engine-wide classifier of this component
+     *        type.
+     *
+     * Constant for the lifetime of a concrete implementation; the
+     * value is typically defined as a @c constexpr member on the
+     * concrete class. Receivers compare the id against the expected
+     * value before casting down.
+     */
+    [[nodiscard]] virtual ComponentTypeId componentTypeId() const noexcept = 0;
+
+    IComponent(const IComponent &)            = delete;
+    IComponent &operator=(const IComponent &) = delete;
+    IComponent(IComponent &&)                 = delete;
+    IComponent &operator=(IComponent &&)      = delete;
+
+  protected:
+    IComponent() = default;
+};
+
+/**
+ * @brief Pure-virtual Level-1 wrapper surface for the entity component
+ *        system.
+ *
+ * @ref IECS is the user-facing contract over the ECS substrate: it
+ * creates and removes entities, attaches and detaches components, and
+ * surfaces bulk queries over component types. The interface knows
+ * nothing about the underlying graph storage; substrate primitive
+ * types never appear in the public API per INV-11. The stateful base
+ * @ref AbstractECS carries an opaque internal entity world through a
+ * private @c std::unique_ptr so the substrate stays hidden from
+ * consumers of this header.
+ *
+ * Ownership and lifetime:
+ *   - Concrete ECS instances are constructed through the non-template
+ *     factory in @ref factory.h and handed back as
+ *     @c std::unique_ptr<IECS>. The caller owns the returned pointer.
+ *   - Entities are value handles (@ref EntityId); removing an entity
+ *     cascades removal of every attached component automatically.
+ *   - Components are owned by the ECS after @ref attachComponent
+ *     succeeds. Detach or entity removal both release ownership.
+ *
+ * Thread-safety: the contract does not fix one. The default
+ * implementation inherits the substrate's reader-writer policy; the
+ * concrete ECS exposed through @c createECS serialises mutations with
+ * the same @c std::shared_mutex the underlying graph uses. Concurrent
+ * queries are safe with each other; concurrent mutations take the
+ * exclusive lock.
+ *
+ * INV-1 compliance: the surface uses no template parameters. INV-10
+ * compliance: the name carries the @c I prefix for a pure-virtual
+ * interface. INV-11 compliance: the public API mentions only ECS
+ * domain handles (@ref EntityId, @ref ComponentHandle,
+ * @ref ComponentTypeId, @ref IComponent); no graph primitive types
+ * cross the boundary.
+ */
+class IECS
+{
+  public:
+    virtual ~IECS() = default;
+
+    // ------ Entity lifecycle ------
+
+    /**
+     * @brief Allocates a fresh entity slot and returns its generational
+     *        handle.
+     *
+     * The returned handle is always valid; implementations never
+     * report a generation of zero from @ref createEntity. Callers pass
+     * the handle to @ref attachComponent, @ref detachComponent,
+     * @ref removeEntity, and the query methods.
+     */
+    [[nodiscard]] virtual EntityId createEntity() = 0;
+
+    /**
+     * @brief Removes the entity addressed by @p entity along with
+     *        every attached component.
+     *
+     * Idempotent: removing a stale handle reports a
+     * @ref Result::Code::Error status without side effects. On success
+     * every previously attached component is released in the reverse
+     * order it was attached; holders of dangling @ref ComponentHandle
+     * values observe them as invalid on the next lookup.
+     */
+    virtual Result removeEntity(EntityId entity) = 0;
+
+    /**
+     * @brief Reports whether the ECS currently tracks the entity
+     *        addressed by @p entity.
+     *
+     * Useful for pre-flight checks in systems that want to skip
+     * silently rather than error out when an entity has been removed
+     * by another path between ticks.
+     */
+    [[nodiscard]] virtual bool hasEntity(EntityId entity) const noexcept = 0;
+
+    // ------ Component lifecycle ------
+
+    /**
+     * @brief Takes ownership of @p component and attaches it to the
+     *        entity addressed by @p entity.
+     *
+     * Returns a fresh generational @ref ComponentHandle that addresses
+     * the new attachment. Passing a null pointer or a stale entity
+     * handle is a programming error; the implementation reports an
+     * invalid handle in that case.
+     */
+    [[nodiscard]] virtual ComponentHandle
+        attachComponent(EntityId entity, std::unique_ptr<IComponent> component) = 0;
+
+    /**
+     * @brief Releases the first component attached to @p entity whose
+     *        @ref IComponent::componentTypeId matches @p typeId.
+     *
+     * Returns a successful @ref Result when a matching component was
+     * detached; reports @ref Result::Code::Error when no attached
+     * component carries the requested type. Implementations are
+     * idempotent: subsequent calls with the same parameters after the
+     * first detach return an error without side effects.
+     */
+    virtual Result detachComponent(EntityId entity, ComponentTypeId typeId) = 0;
+
+    /**
+     * @brief Returns a non-owning view of the first component on
+     *        @p entity whose type id matches @p typeId, or @c nullptr
+     *        when no such component exists.
+     *
+     * The returned pointer is valid until the next ECS mutation that
+     * touches @p entity; callers that need longer-lived references
+     * should keep the @ref ComponentHandle and re-resolve through the
+     * ECS.
+     */
+    [[nodiscard]] virtual const IComponent *
+        findComponent(EntityId entity, ComponentTypeId typeId) const = 0;
+
+    /**
+     * @brief Returns non-owning views of every component currently
+     *        attached to @p entity.
+     *
+     * Returns an empty vector when @p entity is stale or carries no
+     * components. The order matches attach order; equal-type
+     * components keep their relative attach order.
+     */
+    [[nodiscard]] virtual std::vector<const IComponent *>
+        componentsOf(EntityId entity) const = 0;
+
+    // ------ Bulk query ------
+
+    /**
+     * @brief Returns every entity that currently carries at least one
+     *        component whose type id matches @p typeId.
+     *
+     * The vector is a snapshot; subsequent mutations do not invalidate
+     * it. Callers iterate freely without holding any ECS lock.
+     */
+    [[nodiscard]] virtual std::vector<EntityId>
+        entitiesWith(ComponentTypeId typeId) const = 0;
+
+    IECS(const IECS &)            = delete;
+    IECS &operator=(const IECS &) = delete;
+    IECS(IECS &&)                 = delete;
+    IECS &operator=(IECS &&)      = delete;
+
+  protected:
+    IECS() = default;
+};
+
+} // namespace vigine::ecs

--- a/src/ecs/abstractecs.cpp
+++ b/src/ecs/abstractecs.cpp
@@ -1,0 +1,93 @@
+#include "vigine/ecs/abstractecs.h"
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "ecs/entityworld.h"
+#include "vigine/ecs/ecstypes.h"
+#include "vigine/ecs/iecs.h"
+#include "vigine/result.h"
+
+namespace vigine::ecs
+{
+
+AbstractECS::AbstractECS()
+    : _world{std::make_unique<EntityWorld>()}
+{
+}
+
+AbstractECS::~AbstractECS() = default;
+
+// ---------------------------------------------------------------------------
+// Protected accessors — the derived classes reach the internal world
+// through these so the substrate stays invisible on the wrapper's
+// public surface.
+// ---------------------------------------------------------------------------
+
+EntityWorld &AbstractECS::world() noexcept
+{
+    return *_world;
+}
+
+const EntityWorld &AbstractECS::world() const noexcept
+{
+    return *_world;
+}
+
+// ---------------------------------------------------------------------------
+// IECS: entity lifecycle. Each delegation is a one-liner; the world does
+// the substrate translation so the wrapper stays thin.
+// ---------------------------------------------------------------------------
+
+EntityId AbstractECS::createEntity()
+{
+    return _world->createEntity();
+}
+
+Result AbstractECS::removeEntity(EntityId entity)
+{
+    return _world->removeEntity(entity);
+}
+
+bool AbstractECS::hasEntity(EntityId entity) const noexcept
+{
+    return _world->hasEntity(entity);
+}
+
+// ---------------------------------------------------------------------------
+// IECS: component lifecycle.
+// ---------------------------------------------------------------------------
+
+ComponentHandle AbstractECS::attachComponent(
+    EntityId entity, std::unique_ptr<IComponent> component)
+{
+    return _world->attachComponent(entity, std::move(component));
+}
+
+Result AbstractECS::detachComponent(EntityId entity, ComponentTypeId typeId)
+{
+    return _world->detachComponent(entity, typeId);
+}
+
+const IComponent *AbstractECS::findComponent(
+    EntityId entity, ComponentTypeId typeId) const
+{
+    return _world->findComponent(entity, typeId);
+}
+
+std::vector<const IComponent *> AbstractECS::componentsOf(EntityId entity) const
+{
+    return _world->componentsOf(entity);
+}
+
+// ---------------------------------------------------------------------------
+// IECS: bulk query.
+// ---------------------------------------------------------------------------
+
+std::vector<EntityId> AbstractECS::entitiesWith(ComponentTypeId typeId) const
+{
+    return _world->entitiesWith(typeId);
+}
+
+} // namespace vigine::ecs

--- a/src/ecs/defaultecs.cpp
+++ b/src/ecs/defaultecs.cpp
@@ -1,0 +1,10 @@
+#include "ecs/defaultecs.h"
+
+namespace vigine::ecs
+{
+
+DefaultECS::DefaultECS() = default;
+
+DefaultECS::~DefaultECS() = default;
+
+} // namespace vigine::ecs

--- a/src/ecs/defaultecs.h
+++ b/src/ecs/defaultecs.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "vigine/ecs/abstractecs.h"
+
+namespace vigine::ecs
+{
+/**
+ * @brief Minimal concrete ECS that seals the wrapper recipe.
+ *
+ * @ref DefaultECS exists so @ref createECS can return a real owning
+ * @c std::unique_ptr<IECS>. It carries no domain-specific behaviour;
+ * every @ref IECS method falls through to @ref AbstractECS, which in
+ * turn delegates to the internal entity world.
+ *
+ * The class is @c final to close the inheritance chain for this leaf;
+ * follow-up leaves that specialise the ECS with their own caches or
+ * indices define their own concrete classes and their own factory
+ * entry points and do not derive from @ref DefaultECS.
+ */
+class DefaultECS final : public AbstractECS
+{
+  public:
+    DefaultECS();
+    ~DefaultECS() override;
+
+    DefaultECS(const DefaultECS &)            = delete;
+    DefaultECS &operator=(const DefaultECS &) = delete;
+    DefaultECS(DefaultECS &&)                 = delete;
+    DefaultECS &operator=(DefaultECS &&)      = delete;
+};
+
+} // namespace vigine::ecs

--- a/src/ecs/entityworld.cpp
+++ b/src/ecs/entityworld.cpp
@@ -1,0 +1,478 @@
+#include "ecs/entityworld.h"
+
+#include <algorithm>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <utility>
+#include <vector>
+
+#include "vigine/ecs/ecstypes.h"
+#include "vigine/ecs/iecs.h"
+#include "vigine/ecs/kind.h"
+#include "vigine/graph/abstractgraph.h"
+#include "vigine/graph/edgeid.h"
+#include "vigine/graph/iedge.h"
+#include "vigine/graph/igraphquery.h"
+#include "vigine/graph/inode.h"
+#include "vigine/graph/kind.h"
+#include "vigine/graph/nodeid.h"
+#include "vigine/result.h"
+
+namespace vigine::ecs
+{
+
+// ---------------------------------------------------------------------------
+// Private helper nodes / edges. These types live entirely inside the
+// translation unit — the wrapper's public header never mentions them, so
+// they are free to refer to substrate types directly without breaching
+// INV-11.
+// ---------------------------------------------------------------------------
+
+namespace
+{
+
+/**
+ * @brief Entity vertex stored inside the specialised entity world.
+ *
+ * Carries only the @c vigine::ecs::kind::Entity tag and cooperates with
+ * @c AbstractGraph::IdStamp so the assigned generational id flows back
+ * to @c id() without a round-trip through the graph.
+ */
+class EntityNode final
+    : public vigine::graph::INode
+    , public vigine::graph::AbstractGraph::IdStamp
+{
+  public:
+    EntityNode() = default;
+
+    [[nodiscard]] vigine::graph::NodeId id() const noexcept override { return _id; }
+    [[nodiscard]] vigine::graph::NodeKind kind() const noexcept override
+    {
+        return vigine::ecs::kind::Entity;
+    }
+
+    void onGraphIdAssigned(
+        vigine::graph::NodeId nodeId,
+        vigine::graph::EdgeId edgeId) noexcept override
+    {
+        _id = nodeId;
+        (void)edgeId;
+    }
+
+  private:
+    vigine::graph::NodeId _id{};
+};
+
+/**
+ * @brief Component vertex that owns the attached @ref IComponent.
+ *
+ * The component is released together with the node when the entity
+ * world removes the slot, so every attached component lives for
+ * exactly as long as the graph tracks it.
+ */
+class ComponentNode final
+    : public vigine::graph::INode
+    , public vigine::graph::AbstractGraph::IdStamp
+{
+  public:
+    explicit ComponentNode(std::unique_ptr<IComponent> component) noexcept
+        : _component{std::move(component)}
+    {
+    }
+
+    [[nodiscard]] vigine::graph::NodeId id() const noexcept override { return _id; }
+    [[nodiscard]] vigine::graph::NodeKind kind() const noexcept override
+    {
+        return vigine::ecs::kind::Component;
+    }
+
+    /**
+     * @brief Returns a non-owning reference to the wrapped component.
+     *
+     * Never returns @c nullptr on a live node: the attach path on
+     * @ref EntityWorld rejects a null component before construction.
+     */
+    [[nodiscard]] const IComponent *component() const noexcept { return _component.get(); }
+
+    void onGraphIdAssigned(
+        vigine::graph::NodeId nodeId,
+        vigine::graph::EdgeId edgeId) noexcept override
+    {
+        _id = nodeId;
+        (void)edgeId;
+    }
+
+  private:
+    vigine::graph::NodeId       _id{};
+    std::unique_ptr<IComponent> _component;
+};
+
+/**
+ * @brief Directed edge that ties a component vertex back to its
+ *        owning entity.
+ *
+ * Carries no payload — the attachment itself is the semantic; the
+ * component node on the @c to() end keeps the component pointer.
+ */
+class AttachedEdge final
+    : public vigine::graph::IEdge
+    , public vigine::graph::AbstractGraph::IdStamp
+{
+  public:
+    AttachedEdge(vigine::graph::NodeId from, vigine::graph::NodeId to) noexcept
+        : _from{from}, _to{to}
+    {
+    }
+
+    [[nodiscard]] vigine::graph::EdgeId   id() const noexcept override { return _id; }
+    [[nodiscard]] vigine::graph::EdgeKind kind() const noexcept override
+    {
+        return vigine::ecs::edge_kind::Attached;
+    }
+    [[nodiscard]] vigine::graph::NodeId from() const noexcept override { return _from; }
+    [[nodiscard]] vigine::graph::NodeId to() const noexcept override { return _to; }
+    [[nodiscard]] const vigine::graph::IEdgeData *data() const noexcept override
+    {
+        return nullptr;
+    }
+
+    void onGraphIdAssigned(
+        vigine::graph::NodeId nodeId,
+        vigine::graph::EdgeId edgeId) noexcept override
+    {
+        _id = edgeId;
+        (void)nodeId;
+    }
+
+  private:
+    vigine::graph::EdgeId _id{};
+    vigine::graph::NodeId _from{};
+    vigine::graph::NodeId _to{};
+};
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Construction / destruction.
+// ---------------------------------------------------------------------------
+
+EntityWorld::EntityWorld() = default;
+
+EntityWorld::~EntityWorld() = default;
+
+// ---------------------------------------------------------------------------
+// POD translation helpers. The @ref EntityId / @ref ComponentHandle
+// layouts are intentionally identical to @c vigine::graph::NodeId so the
+// translation is a plain field-for-field copy; INV-11 allows it here
+// because the conversion lives entirely inside the wrapper
+// implementation.
+// ---------------------------------------------------------------------------
+
+vigine::graph::NodeId EntityWorld::toNodeId(EntityId entity) noexcept
+{
+    return vigine::graph::NodeId{entity.index, entity.generation};
+}
+
+vigine::graph::NodeId EntityWorld::toNodeId(ComponentHandle handle) noexcept
+{
+    return vigine::graph::NodeId{handle.index, handle.generation};
+}
+
+EntityId EntityWorld::toEntityId(vigine::graph::NodeId node) noexcept
+{
+    return EntityId{node.index, node.generation};
+}
+
+ComponentHandle EntityWorld::toComponentHandle(vigine::graph::NodeId node) noexcept
+{
+    return ComponentHandle{node.index, node.generation};
+}
+
+// ---------------------------------------------------------------------------
+// Entity lifecycle.
+// ---------------------------------------------------------------------------
+
+EntityId EntityWorld::createEntity()
+{
+    // The base graph never returns an invalid generation from addNode, so
+    // the fresh @ref EntityId is always valid. Passing the node back as an
+    // @c INode unique_ptr follows the IdStamp handshake — the node
+    // captures the assigned id during insert.
+    auto                        node = std::make_unique<EntityNode>();
+    const vigine::graph::NodeId nid  = addNode(std::move(node));
+
+    {
+        std::unique_lock lock(_entitiesMutex);
+        _entities.push_back(nid);
+    }
+
+    return toEntityId(nid);
+}
+
+Result EntityWorld::removeEntity(EntityId entity)
+{
+    if (!entity.valid())
+    {
+        return Result(Result::Code::Error, "invalid entity id");
+    }
+
+    const auto nid = toNodeId(entity);
+    if (!query().hasNode(nid))
+    {
+        return Result(Result::Code::Error, "stale entity id");
+    }
+
+    // Cascade component removal first so the graph layer only has to
+    // clean up the entity node at the end. The underlying graph supports
+    // cascading removeNode internally; doing the walk here keeps the
+    // component ownership release in deterministic LIFO order.
+    const auto attachedEdges
+        = query().outEdgesOfKind(nid, vigine::ecs::edge_kind::Attached);
+    for (auto it = attachedEdges.rbegin(); it != attachedEdges.rend(); ++it)
+    {
+        const vigine::graph::IEdge *e = edge(*it);
+        if (e == nullptr)
+        {
+            continue;
+        }
+        const vigine::graph::NodeId componentNode = e->to();
+        // removeNode cascades the edge for us; calling it first on the
+        // component makes ownership release order deterministic.
+        (void)removeNode(componentNode);
+    }
+
+    Result graphResult = removeNode(nid);
+    if (!graphResult.isSuccess())
+    {
+        return graphResult;
+    }
+
+    // Erase the matching slot from the live-entity side-table. Multiple
+    // recycled slots with different generations can share an index; only
+    // the exact (index, generation) match is a dead duplicate of the
+    // caller's handle.
+    {
+        std::unique_lock lock(_entitiesMutex);
+        _entities.erase(
+            std::remove(_entities.begin(), _entities.end(), nid),
+            _entities.end());
+    }
+
+    return graphResult;
+}
+
+bool EntityWorld::hasEntity(EntityId entity) const noexcept
+{
+    if (!entity.valid())
+    {
+        return false;
+    }
+    const vigine::graph::INode *n = node(toNodeId(entity));
+    return n != nullptr && n->kind() == vigine::ecs::kind::Entity;
+}
+
+// ---------------------------------------------------------------------------
+// Component lifecycle.
+// ---------------------------------------------------------------------------
+
+ComponentHandle EntityWorld::attachComponent(
+    EntityId entity, std::unique_ptr<IComponent> component)
+{
+    if (!entity.valid() || component == nullptr)
+    {
+        return ComponentHandle{};
+    }
+
+    const vigine::graph::NodeId entityNode = toNodeId(entity);
+    if (!query().hasNode(entityNode))
+    {
+        return ComponentHandle{};
+    }
+
+    auto                        compNode = std::make_unique<ComponentNode>(std::move(component));
+    const vigine::graph::NodeId compId   = addNode(std::move(compNode));
+    if (!compId.valid())
+    {
+        return ComponentHandle{};
+    }
+
+    auto                        attachment = std::make_unique<AttachedEdge>(entityNode, compId);
+    const vigine::graph::EdgeId eid        = addEdge(std::move(attachment));
+    if (!eid.valid())
+    {
+        // Adding the edge failed — roll the component node back so the
+        // graph does not keep a dangling component with no entity link.
+        (void)removeNode(compId);
+        return ComponentHandle{};
+    }
+
+    return toComponentHandle(compId);
+}
+
+Result EntityWorld::detachComponent(EntityId entity, ComponentTypeId typeId)
+{
+    if (!entity.valid())
+    {
+        return Result(Result::Code::Error, "invalid entity id");
+    }
+
+    const vigine::graph::NodeId entityNode = toNodeId(entity);
+    if (!query().hasNode(entityNode))
+    {
+        return Result(Result::Code::Error, "stale entity id");
+    }
+
+    const auto attachedEdges
+        = query().outEdgesOfKind(entityNode, vigine::ecs::edge_kind::Attached);
+    for (vigine::graph::EdgeId eid : attachedEdges)
+    {
+        const vigine::graph::IEdge *e = edge(eid);
+        if (e == nullptr)
+        {
+            continue;
+        }
+        const vigine::graph::INode *target = node(e->to());
+        const auto                 *cn     = dynamic_cast<const ComponentNode *>(target);
+        if (cn == nullptr || cn->component() == nullptr)
+        {
+            continue;
+        }
+        if (cn->component()->componentTypeId() != typeId)
+        {
+            continue;
+        }
+        // removeNode cascades the @c Attached edge automatically.
+        return removeNode(e->to());
+    }
+    return Result(Result::Code::Error, "component not attached");
+}
+
+const IComponent *EntityWorld::findComponent(
+    EntityId entity, ComponentTypeId typeId) const
+{
+    if (!entity.valid())
+    {
+        return nullptr;
+    }
+
+    const vigine::graph::NodeId entityNode = toNodeId(entity);
+    if (!query().hasNode(entityNode))
+    {
+        return nullptr;
+    }
+
+    const auto attachedEdges
+        = query().outEdgesOfKind(entityNode, vigine::ecs::edge_kind::Attached);
+    for (vigine::graph::EdgeId eid : attachedEdges)
+    {
+        const vigine::graph::IEdge *e = edge(eid);
+        if (e == nullptr)
+        {
+            continue;
+        }
+        const vigine::graph::INode *target = node(e->to());
+        const auto                 *cn     = dynamic_cast<const ComponentNode *>(target);
+        if (cn == nullptr || cn->component() == nullptr)
+        {
+            continue;
+        }
+        if (cn->component()->componentTypeId() == typeId)
+        {
+            return cn->component();
+        }
+    }
+    return nullptr;
+}
+
+std::vector<const IComponent *> EntityWorld::componentsOf(EntityId entity) const
+{
+    std::vector<const IComponent *> out;
+    if (!entity.valid())
+    {
+        return out;
+    }
+
+    const vigine::graph::NodeId entityNode = toNodeId(entity);
+    if (!query().hasNode(entityNode))
+    {
+        return out;
+    }
+
+    const auto attachedEdges
+        = query().outEdgesOfKind(entityNode, vigine::ecs::edge_kind::Attached);
+    out.reserve(attachedEdges.size());
+    for (vigine::graph::EdgeId eid : attachedEdges)
+    {
+        const vigine::graph::IEdge *e = edge(eid);
+        if (e == nullptr)
+        {
+            continue;
+        }
+        const vigine::graph::INode *target = node(e->to());
+        const auto                 *cn     = dynamic_cast<const ComponentNode *>(target);
+        if (cn == nullptr || cn->component() == nullptr)
+        {
+            continue;
+        }
+        out.push_back(cn->component());
+    }
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// Bulk query.
+// ---------------------------------------------------------------------------
+
+std::vector<EntityId> EntityWorld::entitiesWith(ComponentTypeId typeId) const
+{
+    // Snapshot the live-entity list under the shared lock, then walk
+    // each entity's outgoing @c Attached edges without holding the
+    // local mutex. The graph's own shared_mutex guards every per-edge
+    // lookup, so concurrent attaches land under the graph's exclusive
+    // lock and finish before this walk observes them.
+    std::vector<vigine::graph::NodeId> snapshot;
+    {
+        std::shared_lock lock(_entitiesMutex);
+        snapshot = _entities;
+    }
+
+    std::vector<EntityId> out;
+    out.reserve(snapshot.size());
+    for (vigine::graph::NodeId entityNode : snapshot)
+    {
+        if (!query().hasNode(entityNode))
+        {
+            continue;
+        }
+        const auto attachedEdges
+            = query().outEdgesOfKind(entityNode, vigine::ecs::edge_kind::Attached);
+        bool matched = false;
+        for (vigine::graph::EdgeId eid : attachedEdges)
+        {
+            const vigine::graph::IEdge *e = edge(eid);
+            if (e == nullptr)
+            {
+                continue;
+            }
+            const vigine::graph::INode *target = node(e->to());
+            const auto                 *cn     = dynamic_cast<const ComponentNode *>(target);
+            if (cn == nullptr || cn->component() == nullptr)
+            {
+                continue;
+            }
+            if (cn->component()->componentTypeId() == typeId)
+            {
+                matched = true;
+                break;
+            }
+        }
+        if (matched)
+        {
+            out.push_back(toEntityId(entityNode));
+        }
+    }
+    return out;
+}
+
+} // namespace vigine::ecs

--- a/src/ecs/entityworld.h
+++ b/src/ecs/entityworld.h
@@ -1,0 +1,193 @@
+#pragma once
+
+#include <memory>
+#include <shared_mutex>
+#include <vector>
+
+#include "vigine/ecs/ecstypes.h"
+#include "vigine/ecs/iecs.h"
+#include "vigine/graph/abstractgraph.h"
+#include "vigine/graph/nodeid.h"
+#include "vigine/result.h"
+
+namespace vigine::ecs
+{
+/**
+ * @brief Internal graph specialisation that the ECS wrapper uses to
+ *        hold its entity-and-component storage.
+ *
+ * @ref EntityWorld is a concrete @c vigine::graph::AbstractGraph
+ * subtype that seals the inheritance chain for the ECS wrapper. It
+ * carries the translation between the ECS's own POD handles
+ * (@ref EntityId, @ref ComponentHandle) and the substrate's
+ * generational @c NodeId so every @ref IECS method can delegate a
+ * single call to it without letting substrate primitives leak through
+ * the public wrapper surface.
+ *
+ * This header lives under @c src/ecs on purpose: the INV-11 rule
+ * forbids @c vigine::graph types from surfacing in
+ * @c include/vigine/ecs. Only the wrapper implementation consumes the
+ * world; callers of @ref IECS / @ref AbstractECS see neither the
+ * world nor its graph base.
+ *
+ * Thread-safety inherits from @c AbstractGraph: every mutating entry
+ * point takes the graph's exclusive lock; reads take a shared lock.
+ * The wrapper layer does not add any additional synchronisation on
+ * top; every ECS-side access path funnels through the world.
+ *
+ * Node kinds used:
+ *   - @c vigine::ecs::kind::Entity for entity nodes.
+ *   - @c vigine::ecs::kind::Component for component nodes.
+ *
+ * Edge kinds used:
+ *   - @c vigine::ecs::edge_kind::Attached for the directed edge that
+ *     ties a component node back to its owning entity.
+ */
+class EntityWorld final : public vigine::graph::AbstractGraph
+{
+  public:
+    EntityWorld();
+    ~EntityWorld() override;
+
+    EntityWorld(const EntityWorld &)            = delete;
+    EntityWorld &operator=(const EntityWorld &) = delete;
+    EntityWorld(EntityWorld &&)                 = delete;
+    EntityWorld &operator=(EntityWorld &&)      = delete;
+
+    // Mutex protecting the private @c _entities list below. The
+    // underlying @c AbstractGraph already serialises access to its own
+    // storage with a reader-writer mutex; this second mutex is here
+    // because the wrapper keeps a small side-table of live entity ids
+    // so @ref entitiesWith can enumerate without probing the graph via
+    // fragile index math.
+
+    /**
+     * @brief Allocates a fresh entity node and returns the
+     *        corresponding @ref EntityId.
+     *
+     * The returned handle is always valid; the underlying graph never
+     * reports a generation of zero from @ref AbstractGraph::addNode.
+     */
+    [[nodiscard]] EntityId createEntity();
+
+    /**
+     * @brief Removes the entity node addressed by @p entity along
+     *        with every attached component node and its attachment
+     *        edge.
+     *
+     * Delegates to @ref AbstractGraph::removeNode for the entity
+     * itself; attached components are released first so the graph
+     * layer only has to clean up the entity slot. Idempotent: a stale
+     * handle reports an @ref Result::Code::Error status without
+     * side effects.
+     */
+    Result removeEntity(EntityId entity);
+
+    /**
+     * @brief Reports whether an entity node addressed by @p entity is
+     *        currently tracked.
+     */
+    [[nodiscard]] bool hasEntity(EntityId entity) const noexcept;
+
+    /**
+     * @brief Creates a component node wrapping @p component and
+     *        attaches it to the entity addressed by @p entity through
+     *        a directed @c Attached edge.
+     *
+     * Returns the fresh @ref ComponentHandle addressing the new
+     * component node. Returns a default-constructed (invalid) handle
+     * when @p component is null or @p entity is stale.
+     */
+    [[nodiscard]] ComponentHandle
+        attachComponent(EntityId entity, std::unique_ptr<IComponent> component);
+
+    /**
+     * @brief Releases the first component attached to @p entity whose
+     *        @ref IComponent::componentTypeId equals @p typeId.
+     *
+     * Removes both the component node and the @c Attached edge that
+     * tied it to the entity. Reports @ref Result::Code::Error when
+     * no matching component exists.
+     */
+    Result detachComponent(EntityId entity, ComponentTypeId typeId);
+
+    /**
+     * @brief Returns a non-owning view of the first component on
+     *        @p entity whose type id matches @p typeId, or @c nullptr
+     *        when no such component exists.
+     */
+    [[nodiscard]] const IComponent *
+        findComponent(EntityId entity, ComponentTypeId typeId) const;
+
+    /**
+     * @brief Returns non-owning views of every component currently
+     *        attached to @p entity.
+     */
+    [[nodiscard]] std::vector<const IComponent *>
+        componentsOf(EntityId entity) const;
+
+    /**
+     * @brief Returns every entity that currently carries at least one
+     *        component whose type id matches @p typeId.
+     */
+    [[nodiscard]] std::vector<EntityId>
+        entitiesWith(ComponentTypeId typeId) const;
+
+    /**
+     * @brief Translates an @ref EntityId to the substrate's
+     *        @c NodeId.
+     *
+     * Packaged as a free-standing @c static helper so the wrapper
+     * implementation can reach the substrate without needing further
+     * access to the graph's internals. The two POD types have the
+     * same layout; the helper exists for type-safety, not for
+     * arithmetic.
+     */
+    [[nodiscard]] static vigine::graph::NodeId toNodeId(EntityId entity) noexcept;
+
+    /**
+     * @brief Translates an @ref ComponentHandle to the substrate's
+     *        @c NodeId.
+     */
+    [[nodiscard]] static vigine::graph::NodeId toNodeId(ComponentHandle handle) noexcept;
+
+    /**
+     * @brief Translates a substrate @c NodeId back to an
+     *        @ref EntityId.
+     *
+     * Only the wrapper implementation calls this; callers of the
+     * public ECS API never see the substrate type.
+     */
+    [[nodiscard]] static EntityId toEntityId(vigine::graph::NodeId node) noexcept;
+
+    /**
+     * @brief Translates a substrate @c NodeId back to a
+     *        @ref ComponentHandle.
+     */
+    [[nodiscard]] static ComponentHandle
+        toComponentHandle(vigine::graph::NodeId node) noexcept;
+
+  private:
+    /**
+     * @brief Serialises access to the live-entity side-table below.
+     *
+     * The underlying @c AbstractGraph already locks its own storage;
+     * this mutex lives alongside so that the two pieces of state the
+     * wrapper mutates in concert (the graph slot and the entity id
+     * list) stay consistent with each other. Mutations take the
+     * exclusive lock; read-only scans (e.g. @ref entitiesWith) take
+     * the shared lock.
+     */
+    mutable std::shared_mutex _entitiesMutex;
+
+    /**
+     * @brief Live entity ids in creation order.
+     *
+     * Kept alongside the graph so that @ref entitiesWith can enumerate
+     * without probing the substrate via fragile index math. Mutated
+     * only by @ref createEntity (push) and @ref removeEntity (erase).
+     */
+    std::vector<vigine::graph::NodeId> _entities;
+};
+
+} // namespace vigine::ecs

--- a/src/ecs/factory.cpp
+++ b/src/ecs/factory.cpp
@@ -1,0 +1,19 @@
+#include "vigine/ecs/factory.h"
+
+#include <memory>
+
+#include "ecs/defaultecs.h"
+
+namespace vigine::ecs
+{
+
+std::unique_ptr<IECS> createECS()
+{
+    // The factory constructs the default concrete closer over
+    // AbstractECS. The internal entity world is allocated eagerly by
+    // the base class constructor, so the returned ECS is immediately
+    // ready to accept entities and components.
+    return std::make_unique<DefaultECS>();
+}
+
+} // namespace vigine::ecs


### PR DESCRIPTION
## Summary

Ships the Level-1 ECS wrapper over the graph substrate. Mirrors the shape of the service wrapper (#148):

- `IECS` pure-virtual surface: entity lifecycle, component attach/detach, bulk `entitiesWith` query.
- `AbstractECS` stateful base — private `std::unique_ptr<EntityWorld>`; composition keeps the substrate off the public header tree.
- `EntityWorld` — internal `vigine::graph::AbstractGraph` specialisation living under `src/ecs/`. Translates `EntityId` / `ComponentHandle` ↔ substrate ids; keeps a small live-entity side-table so `entitiesWith` is correct without walking the whole graph.
- `DefaultECS` + `createECS()` — minimal concrete closer returning `std::unique_ptr<IECS>` (FF-1).
- `EntityId` / `ComponentHandle` — own generational PODs in `include/vigine/ecs/ecstypes.h` per UD-8 retroactive fix; explicitly not aliases.
- `IComponent` — pure-virtual root for attached components, reports `ComponentTypeId` (opaque `uint32_t`).
- `IComponentStore` — thin view over the four component-lifecycle methods for systems that only need attachment, not entity lifecycle.

Uses `vigine::ecs::kind::Entity` / `Component` + `edge_kind::Attached` from the existing `include/vigine/ecs/kind.h` (R.1.2.1, already on main).

## Scope notes

- Legacy render-ECS headers (`entity.h`, `abstractsystem.h`, `componentmanager.h`, etc.) are untouched. Deprecating / migrating them is deferred to a follow-up leaf.
- New public headers reference no graph primitive types (`NodeId` / `EdgeId` / `IGraph` / ...). Verified by grep.
- No templates in any new public header.

## Test plan

- [x] `cmake --build build --target vigine --config Debug` — clean.
- [x] `cmake --build build --target vigine --config Release` — clean.
- [x] `grep -rE "NodeId|EdgeId|IGraph|INode|IEdge|EdgeData|TraverseMode|IGraphVisitor|IGraphQuery" include/vigine/ecs/{iecs,abstractecs,icomponentstore,ecstypes,factory}.h` — empty.
- [x] `grep -rn "using EntityId" include/` — empty.
- [x] `python scripts/check_no_templates.py` — 0 violations.
- [x] `python scripts/check_graph_purity.py` — 0 violations.
- [x] `python scripts/check_naming_convention.py` — no ECS violations (two pre-existing payload/threading violations unrelated to this leaf).
- [ ] Smoke test + migration of the legacy render ECS land in follow-up leaves.

Closes #113