### PR TITLE
R.4.3: Ship IStateMachine + AbstractStateMachine + StateTopology

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -351,6 +351,24 @@ set(SOURCES_ECS_CORE
     ${SRC_DIR}/ecs/factory.cpp
 )
 
+# Level-1 state machine wrapper (R.4.3) -- public surface.
+set(HEADER_STATEMACHINE_CORE
+    ${INCLUDE_DIR}/vigine/statemachine/stateid.h
+    ${INCLUDE_DIR}/vigine/statemachine/routemode.h
+    ${INCLUDE_DIR}/vigine/statemachine/abstractstatemachine.h
+    ${INCLUDE_DIR}/vigine/statemachine/factory.h
+)
+
+# Level-1 state machine wrapper (R.4.3) -- internal state topology + base impl.
+set(SOURCES_STATEMACHINE_CORE
+    ${SRC_DIR}/statemachine/statetopology.h
+    ${SRC_DIR}/statemachine/statetopology.cpp
+    ${SRC_DIR}/statemachine/abstractstatemachine.cpp
+    ${SRC_DIR}/statemachine/defaultstatemachine.h
+    ${SRC_DIR}/statemachine/defaultstatemachine.cpp
+    ${SRC_DIR}/statemachine/factory.cpp
+)
+
 # Add source files
 if(ENABLE_POSTGRESQL)
     set(HEADER_POSTGRESQL
@@ -429,6 +447,8 @@ add_library(${PROJECT_NAME}
     ${SOURCES_SERVICE}
     ${HEADER_ECS_CORE}
     ${SOURCES_ECS_CORE}
+    ${HEADER_STATEMACHINE_CORE}
+    ${SOURCES_STATEMACHINE_CORE}
     ${HEADER_POSTGRESQL}
     ${SOURCES_POSTGRESQL}
     ${SOURCES_POSTGRESQL_EXTRA}

--- a/include/vigine/statemachine/abstractstatemachine.h
+++ b/include/vigine/statemachine/abstractstatemachine.h
@@ -1,0 +1,184 @@
+#pragma once
+
+#include <memory>
+
+#include "vigine/result.h"
+#include "vigine/statemachine/istatemachine.h"
+#include "vigine/statemachine/routemode.h"
+#include "vigine/statemachine/stateid.h"
+
+namespace vigine::statemachine
+{
+// Forward declaration only. The concrete StateTopology type is a
+// substrate-primitive specialisation defined under @c src/statemachine
+// and is never exposed in the public header tree — see INV-11,
+// wrapper encapsulation.
+class StateTopology;
+
+/**
+ * @brief Stateful abstract base that every concrete state machine
+ *        derives from.
+ *
+ * @ref AbstractStateMachine is level 4 of the wrapper recipe the
+ * engine's Level-1 subsystem wrappers follow. It carries the state
+ * every concrete state machine shares — a private handle to the
+ * internal state topology, the currently active @ref StateId, and the
+ * selected @ref RouteMode — and supplies default implementations of
+ * every @ref IStateMachine method so a minimal concrete state
+ * machine only needs to seal the inheritance chain. The internal
+ * state topology specialises the graph substrate and translates
+ * between @ref StateId and the substrate's own identifier types
+ * inside its implementation.
+ *
+ * The class carries state, so it follows the project's @c Abstract
+ * naming convention rather than the @c I pure-virtual prefix. The
+ * base is abstract in the logical sense; its default constructor
+ * wires up a fresh internal state topology and auto-provisions the
+ * default state per UD-3 so every concrete state machine has a live
+ * substrate and a valid @ref current state as soon as it is
+ * constructed.
+ *
+ * Composition, not inheritance:
+ *   - @ref AbstractStateMachine HAS-A private
+ *     @c std::unique_ptr<StateTopology>. It does @b not inherit from
+ *     the substrate primitive at the wrapper level. The internal
+ *     state topology is the only place where substrate primitives
+ *     enter the state machine stack, and it lives strictly under
+ *     @c src/statemachine. This keeps the public header tree free of
+ *     substrate types (INV-11) and makes the "a state machine IS NOT
+ *     a substrate graph" relationship explicit.
+ *
+ * Default-state auto-provisioning (UD-3):
+ *   - The constructor registers one default state and selects it as
+ *     the initial (and current) state. A caller that never registers
+ *     its own states still sees a valid @ref current id. A caller
+ *     that registers its own states freely overrides the initial
+ *     selection with @ref setInitial and the current selection with
+ *     @ref transition.
+ *   - The default state id is stored as a private member so the
+ *     concrete closer can expose it through an internal helper if it
+ *     ever needs to (the public API does not surface it separately).
+ *
+ * Routing (UD-3):
+ *   - @ref routeMode defaults to @ref RouteMode::Bubble. The value
+ *     is stored as a private member; a later leaf that wires the
+ *     machine to the message bus reads the stored value when it
+ *     resolves where a given event goes.
+ *
+ * Strict encapsulation:
+ *   - All data members are @c private. Derived state machine classes
+ *     reach internal state through @c protected accessors; the
+ *     single getter returns a reference to the state topology so
+ *     concrete derivatives can extend the default implementation
+ *     without re-exporting the substrate on their own public surface.
+ *
+ * Thread-safety: the base inherits the state topology's thread-safety
+ * policy (reader-writer mutex on the substrate primitive). Callers
+ * may query and mutate concurrently; each mutation takes the
+ * exclusive lock while each query takes a shared lock. The wrapper
+ * layer does not add further synchronisation — every state-machine
+ * access path funnels through the topology.
+ */
+class AbstractStateMachine : public IStateMachine
+{
+  public:
+    ~AbstractStateMachine() override;
+
+    // ------ IStateMachine: state registration ------
+
+    [[nodiscard]] StateId addState() override;
+    [[nodiscard]] bool    hasState(StateId state) const noexcept override;
+
+    // ------ IStateMachine: hierarchy ------
+
+    Result                addChildState(StateId parent, StateId child) override;
+    [[nodiscard]] StateId parent(StateId state) const override;
+    [[nodiscard]] bool    isAncestorOf(StateId ancestor, StateId descendant) const override;
+
+    // ------ IStateMachine: initial / current ------
+
+    Result                setInitial(StateId state) override;
+    Result                transition(StateId state) override;
+    [[nodiscard]] StateId current() const noexcept override;
+
+    // ------ IStateMachine: routing ------
+
+    [[nodiscard]] RouteMode routeMode() const noexcept override;
+    void                    setRouteMode(RouteMode mode) noexcept override;
+
+    AbstractStateMachine(const AbstractStateMachine &)            = delete;
+    AbstractStateMachine &operator=(const AbstractStateMachine &) = delete;
+    AbstractStateMachine(AbstractStateMachine &&)                 = delete;
+    AbstractStateMachine &operator=(AbstractStateMachine &&)      = delete;
+
+  protected:
+    AbstractStateMachine();
+
+    /**
+     * @brief Returns a mutable reference to the internal state
+     *        topology.
+     *
+     * Exposed as @c protected so that follow-up concrete state
+     * machine classes can add their own specialised cache or
+     * traversal on top of the default implementation without
+     * re-exporting the substrate on the public surface. The
+     * reference is stable for the lifetime of the
+     * @ref AbstractStateMachine instance.
+     */
+    [[nodiscard]] StateTopology       &topology() noexcept;
+    [[nodiscard]] const StateTopology &topology() const noexcept;
+
+    /**
+     * @brief Returns the id of the default state registered during
+     *        construction.
+     *
+     * Exposed as @c protected so derived closers that want to query
+     * or expose the default state (e.g. for diagnostics) can reach
+     * it without walking the topology themselves. The public API
+     * does not surface the default id separately because callers
+     * who register their own states use @ref setInitial /
+     * @ref transition instead.
+     */
+    [[nodiscard]] StateId defaultState() const noexcept;
+
+  private:
+    /**
+     * @brief Owns the internal state topology.
+     *
+     * The topology is a substrate-primitive specialisation defined
+     * under @c src/statemachine; forward-declaring it here keeps the
+     * substrate out of the public header tree. Held through a
+     * @c std::unique_ptr so the topology's full definition does not
+     * have to leak through this header.
+     */
+    std::unique_ptr<StateTopology> _topology;
+
+    /**
+     * @brief Id of the default state registered during construction.
+     *
+     * Stored so the base can report it through @ref defaultState
+     * without re-querying the topology. Never invalid after
+     * construction completes; cleared only when the machine is
+     * destroyed.
+     */
+    StateId _defaultState{};
+
+    /**
+     * @brief Id of the currently active state.
+     *
+     * Initialised to @ref _defaultState during construction so the
+     * machine has a valid @ref current immediately. Updated by
+     * @ref setInitial and @ref transition.
+     */
+    StateId _current{};
+
+    /**
+     * @brief Selected hierarchical routing mode.
+     *
+     * Defaults to @ref RouteMode::Bubble per UD-3. Updated by
+     * @ref setRouteMode; read by @ref routeMode.
+     */
+    RouteMode _routeMode{RouteMode::Bubble};
+};
+
+} // namespace vigine::statemachine

--- a/include/vigine/statemachine/factory.h
+++ b/include/vigine/statemachine/factory.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <memory>
+
+#include "vigine/statemachine/istatemachine.h"
+
+namespace vigine::statemachine
+{
+/**
+ * @brief Constructs the default concrete state machine and hands back
+ *        an owning @c std::unique_ptr<IStateMachine>.
+ *
+ * The factory is the single public entry point callers use to
+ * instantiate a state machine in this leaf. The returned object is
+ * the minimal concrete closer over @ref AbstractStateMachine; it
+ * carries no domain-specific behaviour of its own and exists so the
+ * wrapper primitive can be exercised, linked, and tested in
+ * isolation.
+ *
+ * Ownership: the caller owns the returned pointer. Callers that need
+ * shared ownership wrap the result in a @c std::shared_ptr at the
+ * call site; shared ownership is not the factory's concern. This
+ * mirrors the shape used by the ECS factory
+ * (@ref vigine::ecs::createECS), the service factory
+ * (@ref vigine::service::createService), the thread manager factory
+ * (@ref vigine::threading::createThreadManager), the payload registry
+ * factory, and the message bus factory
+ * (@ref vigine::messaging::createMessageBus).
+ *
+ * Lifetime: the returned machine is self-contained. The internal
+ * state topology is constructed eagerly during the factory call and
+ * the default state is auto-provisioned per UD-3, so the returned
+ * machine has a valid @ref IStateMachine::current id immediately
+ * without any further caller action.
+ *
+ * The function is @c [[nodiscard]] because silently dropping the
+ * returned handle would leak the allocation and leave the caller
+ * with nothing — the motivation for the @ref FF-1 factory rule.
+ */
+[[nodiscard]] std::unique_ptr<IStateMachine> createStateMachine();
+
+} // namespace vigine::statemachine

--- a/include/vigine/statemachine/istatemachine.h
+++ b/include/vigine/statemachine/istatemachine.h
@@ -1,20 +1,27 @@
 #pragma once
 
+#include "vigine/result.h"
+#include "vigine/statemachine/routemode.h"
+#include "vigine/statemachine/stateid.h"
+
 namespace vigine
 {
 /**
- * @brief Pure-virtual forward-declared stub for the state-machine surface.
+ * @brief Pure-virtual forward-declared stub for the legacy state-machine
+ *        surface.
  *
  * @ref IStateMachine is a minimal stub whose only contract is a virtual
  * destructor. It exists so that @ref Engine::state can return a
- * reference to a pure-virtual interface without requiring the
- * state-machine domain to be finalised in this leaf. The finalised
- * surface -- transitions, state lookup, tick semantics, and so on --
- * lands in a later leaf that refactors @c StateMachine onto this
- * interface.
+ * reference to a pure-virtual interface without requiring the legacy
+ * @c StateMachine (declared in @c include/vigine/statemachine.h) to
+ * migrate onto the new wrapper surface in this leaf. The richer
+ * wrapper surface — state registration, hierarchical routing, and so
+ * on — lives under @c vigine::statemachine::IStateMachine in the
+ * nested namespace block below; a later leaf moves the legacy
+ * @c StateMachine onto that surface and retires this stub.
  *
- * Ownership: this type is never instantiated directly. Concrete
- * @c StateMachine objects derive from it and are owned by the
+ * Ownership: this type is never instantiated directly. The concrete
+ * legacy @c StateMachine object derives from it and is owned by the
  * @ref Engine as @c std::unique_ptr.
  */
 class IStateMachine
@@ -32,3 +39,195 @@ class IStateMachine
 };
 
 } // namespace vigine
+
+namespace vigine::statemachine
+{
+/**
+ * @brief Pure-virtual Level-1 wrapper surface for the state machine.
+ *
+ * @ref IStateMachine is the user-facing contract over the state
+ * machine substrate: it registers states, wires hierarchical
+ * parent/child relationships, picks the initial state, changes the
+ * currently active state, and walks the hierarchy. The interface
+ * knows nothing about the underlying graph storage; substrate
+ * primitive types never appear in the public API per INV-11. The
+ * stateful base @ref AbstractStateMachine carries an opaque internal
+ * state topology through a private @c std::unique_ptr so the
+ * substrate stays hidden from consumers of this header.
+ *
+ * Ownership and lifetime:
+ *   - Concrete state machines are constructed through the
+ *     non-template factory in @ref factory.h and handed back as
+ *     @c std::unique_ptr<IStateMachine>. The caller owns the returned
+ *     pointer.
+ *   - States are value handles (@ref StateId); the machine never
+ *     hands out raw pointers to its internal state slots. Registering
+ *     a state yields its generational @ref StateId; the handle stays
+ *     stable until the machine is destroyed.
+ *   - The machine auto-provisions one default state in its
+ *     constructor per UD-3: callers that register no states still
+ *     observe a valid @ref current state and a valid initial state.
+ *     Callers that register their own states freely override the
+ *     initial selection with @ref setInitial.
+ *
+ * Routing model (UD-3):
+ *   - @ref routeMode reports the hierarchical routing strategy the
+ *     machine uses when a later leaf wires it to the message bus.
+ *     @ref RouteMode::Bubble is the default: events that the active
+ *     child state does not handle bubble up the @c ChildOf parent
+ *     chain until a handler consumes them or the root is reached.
+ *     Flat FSM users select @ref RouteMode::Direct to keep the legacy
+ *     behaviour.
+ *
+ * Thread-safety: the contract does not fix one. The default
+ * implementation inherits the substrate's reader-writer policy; the
+ * concrete machine exposed through @c createStateMachine serialises
+ * mutations with the same @c std::shared_mutex the underlying graph
+ * uses. Concurrent queries are safe with each other; concurrent
+ * mutations take the exclusive lock.
+ *
+ * INV-1 compliance: the surface uses no template parameters. INV-10
+ * compliance: the name carries the @c I prefix for a pure-virtual
+ * interface. INV-11 compliance: the public API mentions only state
+ * machine domain handles (@ref StateId, @ref RouteMode, @ref Result);
+ * no graph primitive types cross the boundary.
+ */
+class IStateMachine
+{
+  public:
+    virtual ~IStateMachine() = default;
+
+    // ------ State registration ------
+
+    /**
+     * @brief Allocates a fresh state slot and returns its generational
+     *        handle.
+     *
+     * The returned handle is always valid. Every subsequent query
+     * (@ref hasState, @ref parent, @ref isAncestorOf, @ref current)
+     * accepts the returned id; recycled slots carry a bumped
+     * generation so stale handles fail safely.
+     */
+    [[nodiscard]] virtual StateId addState() = 0;
+
+    /**
+     * @brief Reports whether the state machine currently tracks the
+     *        state addressed by @p state.
+     *
+     * Useful for pre-flight checks in callers that want to skip
+     * silently rather than error out when a state has been removed by
+     * another path between ticks.
+     */
+    [[nodiscard]] virtual bool hasState(StateId state) const noexcept = 0;
+
+    // ------ Hierarchy ------
+
+    /**
+     * @brief Wires @p child under @p parent in the hierarchical
+     *        topology.
+     *
+     * Both states must have been registered beforehand. Adding the
+     * edge records a directed @c ChildOf relationship that
+     * @ref parent and @ref isAncestorOf query later. Reports
+     * @ref Result::Code::Error when either state is stale or when the
+     * edge would introduce a cycle.
+     *
+     * Multiple children under the same parent are allowed; that is
+     * how the machine models parallel sub-states when a later leaf
+     * adds FanOut routing.
+     */
+    virtual Result addChildState(StateId parent, StateId child) = 0;
+
+    /**
+     * @brief Returns the parent of @p state or a default-constructed
+     *        invalid @ref StateId when @p state is a root.
+     *
+     * Roots of the hierarchy (states without a @c ChildOf edge
+     * pointing at them) report an invalid parent. The call is
+     * @c const and takes the reader lock only; concurrent callers do
+     * not serialise on one another.
+     */
+    [[nodiscard]] virtual StateId parent(StateId state) const = 0;
+
+    /**
+     * @brief Returns @c true when @p ancestor lies somewhere on the
+     *        parent chain of @p descendant.
+     *
+     * The relation is strict: a state is @b not its own ancestor. An
+     * invalid @p ancestor or @p descendant always returns @c false.
+     * The walk is O(depth); callers that need repeated ancestor
+     * checks for the same state cache the result.
+     */
+    [[nodiscard]] virtual bool isAncestorOf(StateId ancestor, StateId descendant) const = 0;
+
+    // ------ Initial / current state ------
+
+    /**
+     * @brief Selects the initial (and currently active) state.
+     *
+     * The referenced state must have been registered through
+     * @ref addState. Reports @ref Result::Code::Error when @p state
+     * is stale; on success the next @ref current call returns
+     * @p state.
+     *
+     * Per UD-3 every concrete machine auto-provisions one default
+     * state in its constructor and selects it as the initial; callers
+     * are free to override the selection with this call before they
+     * start dispatching events.
+     */
+    virtual Result setInitial(StateId state) = 0;
+
+    /**
+     * @brief Transitions the machine to @p state as the new current
+     *        state.
+     *
+     * The referenced state must have been registered. Reports
+     * @ref Result::Code::Error when @p state is stale; on success the
+     * next @ref current call returns @p state. The call does not
+     * invoke enter/exit hooks by itself — those live on the state
+     * base class that a later leaf adds; the wrapper only tracks
+     * which state id is the active one.
+     */
+    virtual Result transition(StateId state) = 0;
+
+    /**
+     * @brief Returns the currently active state.
+     *
+     * Every concrete machine reports a valid id after construction
+     * because the constructor auto-provisions the default state per
+     * UD-3. A caller that never registers its own states still sees
+     * the default state as the current one.
+     */
+    [[nodiscard]] virtual StateId current() const noexcept = 0;
+
+    // ------ Routing ------
+
+    /**
+     * @brief Returns the hierarchical routing mode the machine uses.
+     *
+     * Defaults to @ref RouteMode::Bubble per UD-3. A later leaf that
+     * wires the machine to the message bus consumes this value when
+     * it resolves where an event goes; the wrapper in this leaf only
+     * stores the closed enum so callers can inspect the chosen
+     * strategy ahead of time.
+     */
+    [[nodiscard]] virtual RouteMode routeMode() const noexcept = 0;
+
+    /**
+     * @brief Replaces the hierarchical routing mode.
+     *
+     * Accepts any value of the closed @ref RouteMode enum; subsequent
+     * @ref routeMode calls return the newly selected value.
+     */
+    virtual void setRouteMode(RouteMode mode) noexcept = 0;
+
+    IStateMachine(const IStateMachine &)            = delete;
+    IStateMachine &operator=(const IStateMachine &) = delete;
+    IStateMachine(IStateMachine &&)                 = delete;
+    IStateMachine &operator=(IStateMachine &&)      = delete;
+
+  protected:
+    IStateMachine() = default;
+};
+
+} // namespace vigine::statemachine

--- a/include/vigine/statemachine/routemode.h
+++ b/include/vigine/statemachine/routemode.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <cstdint>
+
+namespace vigine::statemachine
+{
+/**
+ * @brief Closed enumeration of the routing strategies an
+ *        @ref IStateMachine uses when it resolves where an event goes
+ *        inside a hierarchical state machine.
+ *
+ * The three values are the minimal set user decision UD-3 pinned for
+ * hierarchical state machines:
+ *
+ *   - @c Direct    — deliver the event only to the current active
+ *                    state. The traditional flat-FSM behaviour.
+ *   - @c Bubble    — when the current (possibly child) state does not
+ *                    handle the event, walk the parent chain via the
+ *                    ChildOf edge of the internal topology until a
+ *                    handler returns @c Handled or the root is
+ *                    reached. Classical UML-statechart semantics.
+ *   - @c Broadcast — deliver the event to every registered state
+ *                    regardless of the hierarchy. Reserved for
+ *                    cross-cutting diagnostic or shutdown signals.
+ *
+ * The enum is deliberately closed: adding a new mode is an API break
+ * that requires an architect review per INV-1. The underlying type is
+ * fixed at @c std::uint8_t so the enum is cheap to pass by value and
+ * so its layout is portable across the messaging bus that eventually
+ * consumes these values.
+ *
+ * @note The state machine wrapper ships its own @ref RouteMode rather
+ *       than reusing the messaging core's @c vigine::messaging::RouteMode
+ *       because the state-machine surface only needs the subset of
+ *       modes that apply to hierarchical routing; letting every
+ *       messaging mode leak through would widen the wrapper's
+ *       contract beyond what UD-3 sanctions.
+ */
+enum class RouteMode : std::uint8_t
+{
+    Direct    = 1,
+    Bubble    = 2,
+    Broadcast = 3,
+};
+
+} // namespace vigine::statemachine

--- a/include/vigine/statemachine/stateid.h
+++ b/include/vigine/statemachine/stateid.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <compare>
+#include <cstdint>
+
+namespace vigine::statemachine
+{
+/**
+ * @brief Generational identifier for a state managed by an
+ *        @ref IStateMachine.
+ *
+ * @ref StateId is a POD value type owned by the state machine wrapper.
+ * It is deliberately its own struct rather than an alias over the
+ * substrate primitive's identifier type so the public state machine
+ * surface never mentions substrate primitive types (INV-11 — wrapper
+ * encapsulation). The wrapper layer translates between @c StateId and
+ * the substrate-side identifiers exclusively inside
+ * @c src/statemachine; callers of the @ref IStateMachine API never
+ * need to know the substrate exists.
+ *
+ * The @c index field addresses a slot in the internal state topology;
+ * the @c generation field is incremented whenever that slot is recycled
+ * so a lookup with a stale handle fails safely rather than returning a
+ * different state. A default-constructed @ref StateId (@c generation
+ * @c == @c 0) is the invalid sentinel and reports @ref valid as
+ * @c false.
+ *
+ * The pair is small (8 bytes), trivially copyable, and safe to pass by
+ * value across thread boundaries.
+ *
+ * @note The layout is intentionally structurally identical to the
+ *       substrate's own generational identifier. The translation
+ *       lives exclusively inside the wrapper implementation —
+ *       keeping substrate types out of the public header tree is
+ *       the whole point of the separate type.
+ */
+struct StateId
+{
+    std::uint32_t index{0};
+    std::uint32_t generation{0};
+
+    /**
+     * @brief Reports whether the id addresses a slot that was live at
+     *        construction time.
+     *
+     * A @c true return only means the generation is non-zero. The
+     * underlying state topology may still have invalidated the slot
+     * since; the authoritative check is an @ref IStateMachine lookup.
+     */
+    [[nodiscard]] constexpr bool valid() const noexcept { return generation != 0; }
+
+    friend constexpr auto operator<=>(const StateId &, const StateId &) = default;
+    friend constexpr bool operator==(const StateId &, const StateId &)  = default;
+};
+
+} // namespace vigine::statemachine

--- a/src/statemachine/abstractstatemachine.cpp
+++ b/src/statemachine/abstractstatemachine.cpp
@@ -1,0 +1,133 @@
+#include "vigine/statemachine/abstractstatemachine.h"
+
+#include <memory>
+
+#include "statemachine/statetopology.h"
+#include "vigine/result.h"
+#include "vigine/statemachine/routemode.h"
+#include "vigine/statemachine/stateid.h"
+
+namespace vigine::statemachine
+{
+
+// ---------------------------------------------------------------------------
+// Construction / destruction.
+//
+// The constructor wires up the internal topology, auto-provisions the
+// default state per UD-3, and selects it as both the default and the
+// current state so @ref current immediately returns a valid id even when
+// the caller never registers any state of their own.
+// ---------------------------------------------------------------------------
+
+AbstractStateMachine::AbstractStateMachine()
+    : _topology{std::make_unique<StateTopology>()}
+{
+    _defaultState = _topology->addState();
+    _current      = _defaultState;
+}
+
+AbstractStateMachine::~AbstractStateMachine() = default;
+
+// ---------------------------------------------------------------------------
+// Protected accessors — the derived classes reach the internal topology
+// through these so the substrate stays invisible on the wrapper's
+// public surface.
+// ---------------------------------------------------------------------------
+
+StateTopology &AbstractStateMachine::topology() noexcept
+{
+    return *_topology;
+}
+
+const StateTopology &AbstractStateMachine::topology() const noexcept
+{
+    return *_topology;
+}
+
+StateId AbstractStateMachine::defaultState() const noexcept
+{
+    return _defaultState;
+}
+
+// ---------------------------------------------------------------------------
+// IStateMachine: state registration. Each delegation is a one-liner; the
+// topology does the substrate translation so the wrapper stays thin.
+// ---------------------------------------------------------------------------
+
+StateId AbstractStateMachine::addState()
+{
+    return _topology->addState();
+}
+
+bool AbstractStateMachine::hasState(StateId state) const noexcept
+{
+    return _topology->hasState(state);
+}
+
+// ---------------------------------------------------------------------------
+// IStateMachine: hierarchy.
+// ---------------------------------------------------------------------------
+
+Result AbstractStateMachine::addChildState(StateId parent, StateId child)
+{
+    return _topology->addChildEdge(parent, child);
+}
+
+StateId AbstractStateMachine::parent(StateId state) const
+{
+    return _topology->parentOf(state);
+}
+
+bool AbstractStateMachine::isAncestorOf(StateId ancestor, StateId descendant) const
+{
+    return _topology->isAncestorOf(ancestor, descendant);
+}
+
+// ---------------------------------------------------------------------------
+// IStateMachine: initial / current. The base enforces that the target
+// state is registered before it updates @c _current; callers that pass a
+// stale id observe an @ref Result::Code::Error and no state change.
+// ---------------------------------------------------------------------------
+
+Result AbstractStateMachine::setInitial(StateId state)
+{
+    if (!_topology->hasState(state))
+    {
+        return Result(Result::Code::Error, "initial state not registered");
+    }
+    _current = state;
+    return Result();
+}
+
+Result AbstractStateMachine::transition(StateId state)
+{
+    if (!_topology->hasState(state))
+    {
+        return Result(Result::Code::Error, "transition target not registered");
+    }
+    _current = state;
+    return Result();
+}
+
+StateId AbstractStateMachine::current() const noexcept
+{
+    return _current;
+}
+
+// ---------------------------------------------------------------------------
+// IStateMachine: routing. UD-3 fixes @ref RouteMode::Bubble as the
+// default; the base stores the selection and a later leaf that wires
+// the machine to the message bus reads it back.
+// ---------------------------------------------------------------------------
+
+RouteMode AbstractStateMachine::routeMode() const noexcept
+{
+    return _routeMode;
+}
+
+void AbstractStateMachine::setRouteMode(RouteMode mode) noexcept
+{
+    _routeMode = mode;
+}
+
+} // namespace vigine::statemachine

--- a/src/statemachine/defaultstatemachine.cpp
+++ b/src/statemachine/defaultstatemachine.cpp
@@ -1,0 +1,10 @@
+#include "statemachine/defaultstatemachine.h"
+
+namespace vigine::statemachine
+{
+
+DefaultStateMachine::DefaultStateMachine() = default;
+
+DefaultStateMachine::~DefaultStateMachine() = default;
+
+} // namespace vigine::statemachine

--- a/src/statemachine/defaultstatemachine.h
+++ b/src/statemachine/defaultstatemachine.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "vigine/statemachine/abstractstatemachine.h"
+
+namespace vigine::statemachine
+{
+/**
+ * @brief Minimal concrete state machine that seals the wrapper recipe.
+ *
+ * @ref DefaultStateMachine exists so @ref createStateMachine can
+ * return a real owning @c std::unique_ptr<IStateMachine>. It carries
+ * no domain-specific behaviour; every @ref IStateMachine method
+ * falls through to @ref AbstractStateMachine, which in turn
+ * delegates to the internal state topology and applies the UD-3
+ * default-state and bubble-routing behaviours.
+ *
+ * The class is @c final to close the inheritance chain for this
+ * leaf; follow-up leaves that specialise the state machine with
+ * their own caches or indices define their own concrete classes and
+ * their own factory entry points and do not derive from
+ * @ref DefaultStateMachine.
+ */
+class DefaultStateMachine final : public AbstractStateMachine
+{
+  public:
+    DefaultStateMachine();
+    ~DefaultStateMachine() override;
+
+    DefaultStateMachine(const DefaultStateMachine &)            = delete;
+    DefaultStateMachine &operator=(const DefaultStateMachine &) = delete;
+    DefaultStateMachine(DefaultStateMachine &&)                 = delete;
+    DefaultStateMachine &operator=(DefaultStateMachine &&)      = delete;
+};
+
+} // namespace vigine::statemachine

--- a/src/statemachine/factory.cpp
+++ b/src/statemachine/factory.cpp
@@ -1,0 +1,20 @@
+#include "vigine/statemachine/factory.h"
+
+#include <memory>
+
+#include "statemachine/defaultstatemachine.h"
+
+namespace vigine::statemachine
+{
+
+std::unique_ptr<IStateMachine> createStateMachine()
+{
+    // The factory constructs the default concrete closer over
+    // AbstractStateMachine. The internal state topology is allocated
+    // eagerly by the base class constructor, which also auto-provisions
+    // the default state per UD-3, so the returned machine is immediately
+    // ready to answer @ref IStateMachine::current with a valid id.
+    return std::make_unique<DefaultStateMachine>();
+}
+
+} // namespace vigine::statemachine

--- a/src/statemachine/statetopology.cpp
+++ b/src/statemachine/statetopology.cpp
@@ -1,0 +1,264 @@
+#include "statemachine/statetopology.h"
+
+#include <cstddef>
+#include <memory>
+
+#include "vigine/fsm/kind.h"
+#include "vigine/graph/abstractgraph.h"
+#include "vigine/graph/edgeid.h"
+#include "vigine/graph/iedge.h"
+#include "vigine/graph/igraphquery.h"
+#include "vigine/graph/inode.h"
+#include "vigine/graph/kind.h"
+#include "vigine/graph/nodeid.h"
+#include "vigine/result.h"
+#include "vigine/statemachine/stateid.h"
+
+namespace vigine::statemachine
+{
+
+// ---------------------------------------------------------------------------
+// Private helper nodes / edges. These types live entirely inside the
+// translation unit — the wrapper's public header never mentions them, so
+// they are free to refer to substrate types directly without breaching
+// INV-11.
+// ---------------------------------------------------------------------------
+
+namespace
+{
+
+/**
+ * @brief State vertex stored inside the specialised state topology.
+ *
+ * Carries only the @c vigine::fsm::kind::State tag and cooperates
+ * with @c AbstractGraph::IdStamp so the assigned generational id
+ * flows back to @c id() without a round-trip through the graph.
+ */
+class StateNode final
+    : public vigine::graph::INode
+    , public vigine::graph::AbstractGraph::IdStamp
+{
+  public:
+    StateNode() = default;
+
+    [[nodiscard]] vigine::graph::NodeId id() const noexcept override { return _id; }
+    [[nodiscard]] vigine::graph::NodeKind kind() const noexcept override
+    {
+        return vigine::fsm::kind::State;
+    }
+
+    void onGraphIdAssigned(
+        vigine::graph::NodeId nodeId,
+        vigine::graph::EdgeId edgeId) noexcept override
+    {
+        _id = nodeId;
+        (void)edgeId;
+    }
+
+  private:
+    vigine::graph::NodeId _id{};
+};
+
+/**
+ * @brief Directed @c ChildOf edge from a child state to its parent.
+ *
+ * Carries no payload — the hierarchy itself is the semantic. The
+ * direction is child->parent so the natural query at dispatch time
+ * (walk the parent chain from the active state) matches
+ * @c outEdgesOfKind on the child vertex.
+ */
+class ChildOfEdge final
+    : public vigine::graph::IEdge
+    , public vigine::graph::AbstractGraph::IdStamp
+{
+  public:
+    ChildOfEdge(vigine::graph::NodeId from, vigine::graph::NodeId to) noexcept
+        : _from{from}, _to{to}
+    {
+    }
+
+    [[nodiscard]] vigine::graph::EdgeId id() const noexcept override { return _id; }
+    [[nodiscard]] vigine::graph::EdgeKind kind() const noexcept override
+    {
+        return vigine::fsm::edge_kind::ChildOf;
+    }
+    [[nodiscard]] vigine::graph::NodeId from() const noexcept override { return _from; }
+    [[nodiscard]] vigine::graph::NodeId to() const noexcept override { return _to; }
+    [[nodiscard]] const vigine::graph::IEdgeData *data() const noexcept override
+    {
+        return nullptr;
+    }
+
+    void onGraphIdAssigned(
+        vigine::graph::NodeId nodeId,
+        vigine::graph::EdgeId edgeId) noexcept override
+    {
+        _id = edgeId;
+        (void)nodeId;
+    }
+
+  private:
+    vigine::graph::EdgeId _id{};
+    vigine::graph::NodeId _from{};
+    vigine::graph::NodeId _to{};
+};
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Construction / destruction.
+// ---------------------------------------------------------------------------
+
+StateTopology::StateTopology() = default;
+
+StateTopology::~StateTopology() = default;
+
+// ---------------------------------------------------------------------------
+// POD translation helpers. The @ref StateId layout is intentionally
+// identical to @c vigine::graph::NodeId so the translation is a plain
+// field-for-field copy; INV-11 allows it here because the conversion
+// lives entirely inside the wrapper implementation.
+// ---------------------------------------------------------------------------
+
+vigine::graph::NodeId StateTopology::toNodeId(StateId state) noexcept
+{
+    return vigine::graph::NodeId{state.index, state.generation};
+}
+
+StateId StateTopology::toStateId(vigine::graph::NodeId node) noexcept
+{
+    return StateId{node.index, node.generation};
+}
+
+// ---------------------------------------------------------------------------
+// State lifecycle.
+// ---------------------------------------------------------------------------
+
+StateId StateTopology::addState()
+{
+    // The base graph never returns an invalid generation from addNode, so
+    // the fresh @ref StateId is always valid. Passing the node back as an
+    // @c INode unique_ptr follows the IdStamp handshake — the node captures
+    // the assigned id during insert.
+    auto                        node = std::make_unique<StateNode>();
+    const vigine::graph::NodeId nid  = addNode(std::move(node));
+    return toStateId(nid);
+}
+
+bool StateTopology::hasState(StateId state) const noexcept
+{
+    if (!state.valid())
+    {
+        return false;
+    }
+    const vigine::graph::INode *n = node(toNodeId(state));
+    return n != nullptr && n->kind() == vigine::fsm::kind::State;
+}
+
+// ---------------------------------------------------------------------------
+// Hierarchy.
+// ---------------------------------------------------------------------------
+
+Result StateTopology::addChildEdge(StateId parent, StateId child)
+{
+    if (!parent.valid() || !child.valid())
+    {
+        return Result(Result::Code::Error, "invalid state id");
+    }
+    if (parent == child)
+    {
+        return Result(Result::Code::Error, "state cannot be its own parent");
+    }
+
+    const vigine::graph::NodeId parentNode = toNodeId(parent);
+    const vigine::graph::NodeId childNode  = toNodeId(child);
+
+    if (!query().hasNode(parentNode))
+    {
+        return Result(Result::Code::Error, "parent state not registered");
+    }
+    if (!query().hasNode(childNode))
+    {
+        return Result(Result::Code::Error, "child state not registered");
+    }
+
+    // Reject a registration that would introduce a cycle. Because the
+    // edge direction is child->parent, a cycle appears if @p child is
+    // already an ancestor of @p parent. The ancestor walk below is O(depth)
+    // and bounded by @ref kMaxHierarchyDepth, so the check is cheap.
+    if (isAncestorOf(child, parent))
+    {
+        return Result(Result::Code::Error, "child-of edge would introduce a cycle");
+    }
+
+    // Reject multi-parent registrations: a state with two outgoing
+    // @c ChildOf edges is ambiguous for bubble traversal. The wrapper
+    // keeps the single-parent invariant explicit at registration time.
+    const auto existingParents
+        = query().outEdgesOfKind(childNode, vigine::fsm::edge_kind::ChildOf);
+    if (!existingParents.empty())
+    {
+        return Result(Result::Code::Error, "child already has a parent");
+    }
+
+    auto                        edgePtr = std::make_unique<ChildOfEdge>(childNode, parentNode);
+    const vigine::graph::EdgeId eid     = addEdge(std::move(edgePtr));
+    if (!eid.valid())
+    {
+        return Result(Result::Code::Error, "failed to add child-of edge");
+    }
+    return Result();
+}
+
+StateId StateTopology::parentOf(StateId state) const
+{
+    if (!state.valid())
+    {
+        return StateId{};
+    }
+    const vigine::graph::NodeId nid = toNodeId(state);
+    if (!query().hasNode(nid))
+    {
+        return StateId{};
+    }
+
+    const auto parents = query().outEdgesOfKind(nid, vigine::fsm::edge_kind::ChildOf);
+    if (parents.empty())
+    {
+        return StateId{};
+    }
+    const vigine::graph::IEdge *e = edge(parents.front());
+    if (e == nullptr)
+    {
+        return StateId{};
+    }
+    return toStateId(e->to());
+}
+
+bool StateTopology::isAncestorOf(StateId ancestor, StateId descendant) const
+{
+    if (!ancestor.valid() || !descendant.valid())
+    {
+        return false;
+    }
+
+    // Walk the parent chain from @p descendant upward. Stop at the root
+    // (no further parent), when we find @p ancestor, or when the walk
+    // exceeds the defensive depth cap.
+    StateId cursor = parentOf(descendant);
+    for (std::size_t depth = 0; depth < kMaxHierarchyDepth; ++depth)
+    {
+        if (!cursor.valid())
+        {
+            return false;
+        }
+        if (cursor == ancestor)
+        {
+            return true;
+        }
+        cursor = parentOf(cursor);
+    }
+    return false;
+}
+
+} // namespace vigine::statemachine

--- a/src/statemachine/statetopology.h
+++ b/src/statemachine/statetopology.h
@@ -1,0 +1,152 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "vigine/graph/abstractgraph.h"
+#include "vigine/graph/nodeid.h"
+#include "vigine/result.h"
+#include "vigine/statemachine/stateid.h"
+
+namespace vigine::statemachine
+{
+/**
+ * @brief Internal graph specialisation that the state machine wrapper
+ *        uses to hold its state-and-hierarchy storage.
+ *
+ * @ref StateTopology is a concrete @c vigine::graph::AbstractGraph
+ * subtype that seals the inheritance chain for the state machine
+ * wrapper. It carries the translation between the wrapper's own POD
+ * handle (@ref StateId) and the substrate's generational @c NodeId
+ * so every @ref IStateMachine method can delegate a single call to
+ * it without letting substrate primitives leak through the public
+ * wrapper surface.
+ *
+ * This header lives under @c src/statemachine on purpose: the INV-11
+ * rule forbids @c vigine::graph types from surfacing in
+ * @c include/vigine/statemachine. Only the wrapper implementation
+ * consumes the topology; callers of @ref IStateMachine /
+ * @ref AbstractStateMachine see neither the topology nor its graph
+ * base.
+ *
+ * Thread-safety inherits from @c AbstractGraph: every mutating entry
+ * point takes the graph's exclusive lock; reads take a shared lock.
+ * The wrapper layer does not add any additional synchronisation on
+ * top; every state-machine-side access path funnels through the
+ * topology.
+ *
+ * Node kinds used:
+ *   - @c vigine::fsm::kind::State for state nodes (from
+ *     @c include/vigine/fsm/kind.h).
+ *
+ * Edge kinds used:
+ *   - @c vigine::fsm::edge_kind::ChildOf for the directed edge that
+ *     ties a child state back to its parent (bubble traversal).
+ *   - @c vigine::fsm::edge_kind::Transition is reserved for a later
+ *     leaf that wires the machine to the message bus; this leaf
+ *     only maintains the hierarchy.
+ */
+class StateTopology final : public vigine::graph::AbstractGraph
+{
+  public:
+    StateTopology();
+    ~StateTopology() override;
+
+    StateTopology(const StateTopology &)            = delete;
+    StateTopology &operator=(const StateTopology &) = delete;
+    StateTopology(StateTopology &&)                 = delete;
+    StateTopology &operator=(StateTopology &&)      = delete;
+
+    // ------ State lifecycle ------
+
+    /**
+     * @brief Allocates a fresh state node and returns the
+     *        corresponding @ref StateId.
+     *
+     * The returned handle is always valid; the underlying graph
+     * never reports a generation of zero from
+     * @ref AbstractGraph::addNode.
+     */
+    [[nodiscard]] StateId addState();
+
+    /**
+     * @brief Reports whether a state node addressed by @p state is
+     *        currently tracked.
+     */
+    [[nodiscard]] bool hasState(StateId state) const noexcept;
+
+    // ------ Hierarchy ------
+
+    /**
+     * @brief Creates a directed @c ChildOf edge from @p child to
+     *        @p parent.
+     *
+     * Reports @ref Result::Code::Error when either state is stale,
+     * when the pair is identical, or when the edge would introduce
+     * a cycle (i.e. @p child is already an ancestor of @p parent).
+     * The edge direction is child->parent because the natural query
+     * at dispatch time is "who is the parent of the current state?"
+     * and that matches @c outEdgesOfKind on the child.
+     */
+    Result addChildEdge(StateId parent, StateId child);
+
+    /**
+     * @brief Returns the parent of @p state, or a default-constructed
+     *        invalid @ref StateId when @p state is a root.
+     *
+     * A state with more than one outgoing @c ChildOf edge is ill-
+     * formed (the wrapper rejects multi-parent registrations in
+     * @ref addChildEdge), so the walk only needs to look at the
+     * first matching edge.
+     */
+    [[nodiscard]] StateId parentOf(StateId state) const;
+
+    /**
+     * @brief Returns @c true when @p ancestor sits on the parent
+     *        chain of @p descendant.
+     *
+     * The relation is strict: a state is never its own ancestor. An
+     * invalid @p ancestor or @p descendant always returns @c false.
+     * The walk depth is capped by @ref kMaxHierarchyDepth as a
+     * defensive safeguard against accidental cycles; the cap is far
+     * above any realistic HSM depth.
+     */
+    [[nodiscard]] bool isAncestorOf(StateId ancestor, StateId descendant) const;
+
+    // ------ POD translation helpers ------
+
+    /**
+     * @brief Translates a @ref StateId to the substrate's
+     *        @c NodeId.
+     *
+     * Packaged as a free-standing @c static helper so the wrapper
+     * implementation can reach the substrate without needing further
+     * access to the graph's internals. The two POD types have the
+     * same layout; the helper exists for type-safety, not for
+     * arithmetic.
+     */
+    [[nodiscard]] static vigine::graph::NodeId toNodeId(StateId state) noexcept;
+
+    /**
+     * @brief Translates a substrate @c NodeId back to a
+     *        @ref StateId.
+     *
+     * Only the wrapper implementation calls this; callers of the
+     * public state machine API never see the substrate type.
+     */
+    [[nodiscard]] static StateId toStateId(vigine::graph::NodeId node) noexcept;
+
+  private:
+    /**
+     * @brief Maximum depth the ancestor walk traverses before
+     *        bailing out.
+     *
+     * The cap protects against accidental cycles the wrapper's
+     * @ref addChildEdge validation somehow missed. Any realistic HSM
+     * sits far below this depth; the cap mostly exists so a bug in
+     * @ref addChildEdge cannot hang the caller.
+     */
+    static constexpr std::size_t kMaxHierarchyDepth = 1024;
+};
+
+} // namespace vigine::statemachine


### PR DESCRIPTION
Third Level-1 wrapper over the graph substrate. Mirrors the recipe
R.4.1 (service, PR #148) and R.4.2 (ecs, PR #149) opened just before
it.

## What lands

Public surface under `include/vigine/statemachine/`:

- `stateid.h` — own generational `StateId` POD (INV-11).
- `routemode.h` — closed `RouteMode` enum `{ Direct, Bubble, Broadcast }` per UD-3.
- `istatemachine.h` — new `vigine::statemachine::IStateMachine`
  (state registration, hierarchy, initial / current, routing). The
  existing minimal legacy stub `vigine::IStateMachine` in the same
  header is kept so the legacy monolithic `StateMachine` keeps
  compiling.
- `abstractstatemachine.h` — `AbstractStateMachine : public IStateMachine`
  with private `std::unique_ptr<StateTopology>` composition (not
  inheritance); the substrate stays hidden.
- `factory.h` — `[[nodiscard]] std::unique_ptr<IStateMachine> createStateMachine();`.

Internals under `src/statemachine/`:

- `statetopology.{h,cpp}` — specialised `AbstractGraph` using
  `vigine::fsm::kind::State` and `vigine::fsm::edge_kind::ChildOf`.
  Carries the `StateId <-> NodeId` translation so INV-11 stays sealed
  in the public surface.
- `abstractstatemachine.cpp` — base impl. Ctor auto-provisions the
  default state per UD-3 and makes it the current state.
- `defaultstatemachine.{h,cpp}` — minimal concrete closer.
- `factory.cpp`.

The legacy `include/vigine/statemachine.h` is untouched.

## Verification

- `cmake --build build --target vigine --config Debug` — clean.
- `cmake --build build --target vigine --config Release` — clean.
- `python scripts/check_naming_convention.py --path include/vigine/statemachine/` — 0 violations.
- `python scripts/check_no_templates.py --path include/vigine/statemachine/` — 0 violations.
- `python scripts/check_graph_purity.py --path include/vigine/graph/` — 0 violations.
- `grep -rE 'NodeId|EdgeId|IGraph|INode|IEdge|EdgeData|TraverseMode|IGraphVisitor|IGraphQuery' include/vigine/statemachine/` — no matches (INV-11).

Closes #114