### PR TITLE
R.4.4: Ship ITaskFlow + AbstractTaskFlow + TaskOrchestrator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -369,6 +369,26 @@ set(SOURCES_STATEMACHINE_CORE
     ${SRC_DIR}/statemachine/factory.cpp
 )
 
+# Level-1 task flow wrapper (R.4.4) -- public surface.
+set(HEADER_TASKFLOW_CORE
+    ${INCLUDE_DIR}/vigine/taskflow/taskid.h
+    ${INCLUDE_DIR}/vigine/taskflow/resultcode.h
+    ${INCLUDE_DIR}/vigine/taskflow/routemode.h
+    ${INCLUDE_DIR}/vigine/taskflow/itaskflow.h
+    ${INCLUDE_DIR}/vigine/taskflow/abstracttaskflow.h
+    ${INCLUDE_DIR}/vigine/taskflow/factory.h
+)
+
+# Level-1 task flow wrapper (R.4.4) -- internal orchestrator + base impl.
+set(SOURCES_TASKFLOW_CORE
+    ${SRC_DIR}/taskflow/taskorchestrator.h
+    ${SRC_DIR}/taskflow/taskorchestrator.cpp
+    ${SRC_DIR}/taskflow/abstracttaskflow.cpp
+    ${SRC_DIR}/taskflow/defaulttaskflow.h
+    ${SRC_DIR}/taskflow/defaulttaskflow.cpp
+    ${SRC_DIR}/taskflow/factory.cpp
+)
+
 # Add source files
 if(ENABLE_POSTGRESQL)
     set(HEADER_POSTGRESQL
@@ -449,6 +469,8 @@ add_library(${PROJECT_NAME}
     ${SOURCES_ECS_CORE}
     ${HEADER_STATEMACHINE_CORE}
     ${SOURCES_STATEMACHINE_CORE}
+    ${HEADER_TASKFLOW_CORE}
+    ${SOURCES_TASKFLOW_CORE}
     ${HEADER_POSTGRESQL}
     ${SOURCES_POSTGRESQL}
     ${SOURCES_POSTGRESQL_EXTRA}

--- a/include/vigine/taskflow/abstracttaskflow.h
+++ b/include/vigine/taskflow/abstracttaskflow.h
@@ -1,0 +1,175 @@
+#pragma once
+
+#include <memory>
+
+#include "vigine/result.h"
+#include "vigine/taskflow/itaskflow.h"
+#include "vigine/taskflow/resultcode.h"
+#include "vigine/taskflow/routemode.h"
+#include "vigine/taskflow/taskid.h"
+
+namespace vigine::taskflow
+{
+// Forward declaration only. The concrete TaskOrchestrator type is a
+// substrate-primitive specialisation defined under @c src/taskflow and
+// is never exposed in the public header tree — see INV-11, wrapper
+// encapsulation.
+class TaskOrchestrator;
+
+/**
+ * @brief Stateful abstract base that every concrete task flow derives
+ *        from.
+ *
+ * @ref AbstractTaskFlow is level 4 of the wrapper recipe the engine's
+ * Level-1 subsystem wrappers follow. It carries the state every
+ * concrete task flow shares — a private handle to the internal task
+ * orchestrator and the currently active @ref TaskId — and supplies
+ * default implementations of every @ref ITaskFlow method so a minimal
+ * concrete task flow only needs to seal the inheritance chain. The
+ * internal task orchestrator specialises the graph substrate and
+ * translates between @ref TaskId and the substrate's own identifier
+ * types inside its implementation.
+ *
+ * The class carries state, so it follows the project's @c Abstract
+ * naming convention rather than the @c I pure-virtual prefix. The
+ * base is abstract in the logical sense; its default constructor
+ * wires up a fresh internal task orchestrator and auto-provisions the
+ * default task per UD-3 so every concrete task flow has a live
+ * substrate and a valid @ref current task as soon as it is
+ * constructed.
+ *
+ * Composition, not inheritance:
+ *   - @ref AbstractTaskFlow HAS-A private
+ *     @c std::unique_ptr<TaskOrchestrator>. It does @b not inherit
+ *     from the substrate primitive at the wrapper level. The
+ *     internal task orchestrator is the only place where substrate
+ *     primitives enter the task flow stack, and it lives strictly
+ *     under @c src/taskflow. This keeps the public header tree free
+ *     of substrate types (INV-11) and makes the "a task flow IS NOT
+ *     a substrate graph" relationship explicit.
+ *
+ * Default-task auto-provisioning (UD-3):
+ *   - The constructor registers one default task and selects it as
+ *     the start (and current) task. A caller that never registers
+ *     its own tasks still sees a valid @ref current id. A caller
+ *     that registers its own tasks freely overrides the selection
+ *     with @ref enqueue.
+ *   - The default task id is stored as a private member so the
+ *     concrete closer can expose it through an internal helper if it
+ *     ever needs to (the public API does not surface it separately).
+ *
+ * Routing (UD-3):
+ *   - The default @ref RouteMode for transitions registered through
+ *     the short overload of @ref onResult is @ref RouteMode::FirstMatch,
+ *     matching the back-compat behaviour of the legacy task flow.
+ *     Callers opt into @ref RouteMode::FanOut or @ref RouteMode::Chain
+ *     per transition through the explicit-mode overload.
+ *   - Per @c (source, ResultCode) pair the orchestrator stores a
+ *     single @ref RouteMode; re-registrations with a conflicting
+ *     mode report @ref Result::Code::Error so callers cannot
+ *     accidentally mix routing semantics for the same pair.
+ *
+ * Strict encapsulation:
+ *   - All data members are @c private. Derived task flow classes
+ *     reach internal state through @c protected accessors; the
+ *     single getter returns a reference to the task orchestrator so
+ *     concrete derivatives can extend the default implementation
+ *     without re-exporting the substrate on their own public surface.
+ *
+ * Thread-safety: the base inherits the task orchestrator's
+ * thread-safety policy (reader-writer mutex on the substrate
+ * primitive). Callers may query and mutate concurrently; each
+ * mutation takes the exclusive lock while each query takes a shared
+ * lock. The wrapper layer does not add further synchronisation —
+ * every task-flow access path funnels through the orchestrator.
+ */
+class AbstractTaskFlow : public ITaskFlow
+{
+  public:
+    ~AbstractTaskFlow() override;
+
+    // ------ ITaskFlow: task registration ------
+
+    [[nodiscard]] TaskId addTask() override;
+    [[nodiscard]] bool   hasTask(TaskId task) const noexcept override;
+
+    // ------ ITaskFlow: transitions ------
+
+    Result onResult(TaskId source, ResultCode code, TaskId next) override;
+    Result onResult(
+        TaskId    source,
+        ResultCode code,
+        TaskId    next,
+        RouteMode mode) override;
+
+    // ------ ITaskFlow: flow control ------
+
+    Result               enqueue(TaskId start) override;
+    [[nodiscard]] TaskId current() const noexcept override;
+
+    AbstractTaskFlow(const AbstractTaskFlow &)            = delete;
+    AbstractTaskFlow &operator=(const AbstractTaskFlow &) = delete;
+    AbstractTaskFlow(AbstractTaskFlow &&)                 = delete;
+    AbstractTaskFlow &operator=(AbstractTaskFlow &&)      = delete;
+
+  protected:
+    AbstractTaskFlow();
+
+    /**
+     * @brief Returns a mutable reference to the internal task
+     *        orchestrator.
+     *
+     * Exposed as @c protected so that follow-up concrete task flow
+     * classes can add their own specialised cache or traversal on top
+     * of the default implementation without re-exporting the
+     * substrate on the public surface. The reference is stable for
+     * the lifetime of the @ref AbstractTaskFlow instance.
+     */
+    [[nodiscard]] TaskOrchestrator       &orchestrator() noexcept;
+    [[nodiscard]] const TaskOrchestrator &orchestrator() const noexcept;
+
+    /**
+     * @brief Returns the id of the default task registered during
+     *        construction.
+     *
+     * Exposed as @c protected so derived closers that want to query
+     * or expose the default task (e.g. for diagnostics) can reach it
+     * without walking the orchestrator themselves. The public API
+     * does not surface the default id separately because callers who
+     * register their own tasks use @ref enqueue instead.
+     */
+    [[nodiscard]] TaskId defaultTask() const noexcept;
+
+  private:
+    /**
+     * @brief Owns the internal task orchestrator.
+     *
+     * The orchestrator is a substrate-primitive specialisation
+     * defined under @c src/taskflow; forward-declaring it here keeps
+     * the substrate out of the public header tree. Held through a
+     * @c std::unique_ptr so the orchestrator's full definition does
+     * not have to leak through this header.
+     */
+    std::unique_ptr<TaskOrchestrator> _orchestrator;
+
+    /**
+     * @brief Id of the default task registered during construction.
+     *
+     * Stored so the base can report it through @ref defaultTask
+     * without re-querying the orchestrator. Never invalid after
+     * construction completes; cleared only when the flow is
+     * destroyed.
+     */
+    TaskId _defaultTask{};
+
+    /**
+     * @brief Id of the currently active task.
+     *
+     * Initialised to @ref _defaultTask during construction so the
+     * flow has a valid @ref current immediately. Updated by
+     * @ref enqueue.
+     */
+    TaskId _current{};
+};
+
+} // namespace vigine::taskflow

--- a/include/vigine/taskflow/factory.h
+++ b/include/vigine/taskflow/factory.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <memory>
+
+#include "vigine/taskflow/itaskflow.h"
+
+namespace vigine::taskflow
+{
+/**
+ * @brief Constructs the default concrete task flow and hands back an
+ *        owning @c std::unique_ptr<ITaskFlow>.
+ *
+ * The factory is the single public entry point callers use to
+ * instantiate a task flow in this leaf. The returned object is the
+ * minimal concrete closer over @ref AbstractTaskFlow; it carries no
+ * domain-specific behaviour of its own and exists so the wrapper
+ * primitive can be exercised, linked, and tested in isolation.
+ *
+ * Ownership: the caller owns the returned pointer. Callers that need
+ * shared ownership wrap the result in a @c std::shared_ptr at the
+ * call site; shared ownership is not the factory's concern. This
+ * mirrors the shape used by the ECS factory
+ * (@ref vigine::ecs::createECS), the service factory
+ * (@ref vigine::service::createService), the state machine factory
+ * (@ref vigine::statemachine::createStateMachine), the thread manager
+ * factory (@ref vigine::threading::createThreadManager), the payload
+ * registry factory, and the message bus factory
+ * (@ref vigine::messaging::createMessageBus).
+ *
+ * Lifetime: the returned flow is self-contained. The internal task
+ * orchestrator is constructed eagerly during the factory call and
+ * the default task is auto-provisioned per UD-3, so the returned
+ * flow has a valid @ref ITaskFlow::current id immediately without
+ * any further caller action.
+ *
+ * The function is @c [[nodiscard]] because silently dropping the
+ * returned handle would leak the allocation and leave the caller
+ * with nothing — the motivation for the @ref FF-1 factory rule.
+ */
+[[nodiscard]] std::unique_ptr<ITaskFlow> createTaskFlow();
+
+} // namespace vigine::taskflow

--- a/include/vigine/taskflow/itaskflow.h
+++ b/include/vigine/taskflow/itaskflow.h
@@ -1,0 +1,208 @@
+#pragma once
+
+#include "vigine/result.h"
+#include "vigine/taskflow/resultcode.h"
+#include "vigine/taskflow/routemode.h"
+#include "vigine/taskflow/taskid.h"
+
+namespace vigine
+{
+/**
+ * @brief Pure-virtual forward-declared stub for the legacy task flow
+ *        surface.
+ *
+ * @ref ITaskFlow is a minimal stub whose only contract is a virtual
+ * destructor. It exists so that callers that want a stable reference
+ * to "some task flow" can hold a pointer to a pure-virtual interface
+ * without requiring the legacy @c TaskFlow (declared in
+ * @c include/vigine/taskflow.h) to migrate onto the new wrapper
+ * surface in this leaf. The richer wrapper surface — task
+ * registration, result-code transitions, and so on — lives under
+ * @c vigine::taskflow::ITaskFlow in the nested namespace block below;
+ * a later leaf moves the legacy @c TaskFlow onto that surface and
+ * retires this stub.
+ *
+ * Ownership: this type is never instantiated directly. The concrete
+ * legacy @c TaskFlow object derives from it when that migration
+ * eventually lands; for now the stub carries no users on its own.
+ */
+class ITaskFlow
+{
+  public:
+    virtual ~ITaskFlow() = default;
+
+    ITaskFlow(const ITaskFlow &)            = delete;
+    ITaskFlow &operator=(const ITaskFlow &) = delete;
+    ITaskFlow(ITaskFlow &&)                 = delete;
+    ITaskFlow &operator=(ITaskFlow &&)      = delete;
+
+  protected:
+    ITaskFlow() = default;
+};
+
+} // namespace vigine
+
+namespace vigine::taskflow
+{
+/**
+ * @brief Pure-virtual Level-1 wrapper surface for the task flow.
+ *
+ * @ref ITaskFlow is the user-facing contract over the task flow
+ * substrate: it registers tasks, wires result-code-driven transitions
+ * between them, picks the starting task, advances the flow, and
+ * reports which task is currently active. The interface knows nothing
+ * about the underlying graph storage; substrate primitive types never
+ * appear in the public API per INV-11. The stateful base
+ * @ref AbstractTaskFlow carries an opaque internal task orchestrator
+ * through a private @c std::unique_ptr so the substrate stays hidden
+ * from consumers of this header.
+ *
+ * Ownership and lifetime:
+ *   - Concrete task flows are constructed through the non-template
+ *     factory in @ref factory.h and handed back as
+ *     @c std::unique_ptr<ITaskFlow>. The caller owns the returned
+ *     pointer.
+ *   - Tasks are opaque slots addressed by @ref TaskId value handles;
+ *     the flow never hands out raw pointers to its internal task
+ *     slots. Registering a task yields its generational @ref TaskId;
+ *     the handle stays stable until the flow is destroyed. User
+ *     logic for the task is not part of this leaf — tasks are plain
+ *     containers whose behaviour is wired through a later leaf that
+ *     attaches work callbacks to @ref TaskId handles.
+ *
+ * Routing model (UD-3):
+ *   - Sync transitions fire when a completed task reports a
+ *     @ref ResultCode. The flow looks up the list of next tasks
+ *     registered via @ref onResult against the @c (source, resultCode)
+ *     pair and advances according to the transition's @ref RouteMode.
+ *   - @ref RouteMode::FirstMatch is the default. Callers pass
+ *     @ref RouteMode::FanOut to register a transition that lets every
+ *     next task registered for the same pair run, or
+ *     @ref RouteMode::Chain to register a transition that pipelines
+ *     through every registered target sequentially.
+ *   - Async routing via signals lands in a later leaf that wires the
+ *     flow to the messaging bus. This leaf only models the sync path
+ *     so the wrapper primitive can be exercised in isolation.
+ *
+ * Thread-safety: the contract does not fix one. The default
+ * implementation inherits the substrate's reader-writer policy; the
+ * concrete flow exposed through @c createTaskFlow serialises
+ * mutations with the same @c std::shared_mutex the underlying graph
+ * uses. Concurrent queries are safe with each other; concurrent
+ * mutations take the exclusive lock.
+ *
+ * INV-1 compliance: the surface uses no template parameters. INV-10
+ * compliance: the name carries the @c I prefix for a pure-virtual
+ * interface. INV-11 compliance: the public API mentions only task
+ * flow domain handles (@ref TaskId, @ref ResultCode, @ref RouteMode,
+ * @ref Result); no graph primitive types cross the boundary.
+ */
+class ITaskFlow
+{
+  public:
+    virtual ~ITaskFlow() = default;
+
+    // ------ Task registration ------
+
+    /**
+     * @brief Allocates a fresh task slot and returns its generational
+     *        handle.
+     *
+     * The returned handle is always valid. Every subsequent query
+     * (@ref hasTask, @ref current) and every transition registration
+     * accepts the returned id; recycled slots carry a bumped
+     * generation so stale handles fail safely.
+     */
+    [[nodiscard]] virtual TaskId addTask() = 0;
+
+    /**
+     * @brief Reports whether the task flow currently tracks the task
+     *        addressed by @p task.
+     *
+     * Useful for pre-flight checks in callers that want to skip
+     * silently rather than error out when a task has been removed by
+     * another path between ticks.
+     */
+    [[nodiscard]] virtual bool hasTask(TaskId task) const noexcept = 0;
+
+    // ------ Transitions ------
+
+    /**
+     * @brief Registers a transition: when @p source completes with
+     *        @p code the flow advances to @p next.
+     *
+     * Shorthand for @ref onResult with @ref RouteMode::FirstMatch —
+     * the UD-3 default. Multiple calls with the same
+     * @c (source, code) pair stack up in registration order; the
+     * default @c FirstMatch mode routes to the first registered
+     * target and ignores the rest.
+     *
+     * Both @p source and @p next must have been registered via
+     * @ref addTask beforehand. Reports @ref Result::Code::Error when
+     * either id is stale or when the source id is the same as the
+     * next id (a task cannot transition directly to itself through
+     * a zero-length transition — callers that need a loop wire it
+     * through an explicit intermediate task).
+     */
+    virtual Result onResult(TaskId source, ResultCode code, TaskId next) = 0;
+
+    /**
+     * @brief Registers a transition with an explicit routing mode.
+     *
+     * Use this overload to opt into @ref RouteMode::FanOut (every
+     * target registered against the pair runs independently) or
+     * @ref RouteMode::Chain (registered targets run sequentially as
+     * a pipeline). Multiple registrations with the same
+     * @c (source, code) pair must agree on the @ref RouteMode; the
+     * wrapper reports @ref Result::Code::Error on a conflicting
+     * re-registration so the routing contract stays unambiguous.
+     *
+     * Both @p source and @p next must have been registered via
+     * @ref addTask beforehand. Reports @ref Result::Code::Error when
+     * either id is stale, when the source id is the same as the next
+     * id, or when the re-registration conflicts with the already-
+     * stored @ref RouteMode for that pair.
+     */
+    virtual Result onResult(
+        TaskId    source,
+        ResultCode code,
+        TaskId    next,
+        RouteMode mode) = 0;
+
+    // ------ Flow control ------
+
+    /**
+     * @brief Marks @p start as the task the flow begins with.
+     *
+     * The referenced task must have been registered through
+     * @ref addTask. Reports @ref Result::Code::Error when @p start is
+     * stale; on success the next @ref current call returns @p start.
+     *
+     * The flow auto-provisions a default start task in its
+     * constructor per UD-3, so callers that never register their own
+     * tasks still observe a valid @ref current id. Callers that
+     * register their own tasks freely override the selection with
+     * this call before they begin driving the flow.
+     */
+    virtual Result enqueue(TaskId start) = 0;
+
+    /**
+     * @brief Returns the task the flow currently considers active.
+     *
+     * Every concrete flow reports a valid id after construction
+     * because the constructor auto-provisions the default task per
+     * UD-3. A caller that never registers its own tasks still sees
+     * the default task as the current one.
+     */
+    [[nodiscard]] virtual TaskId current() const noexcept = 0;
+
+    ITaskFlow(const ITaskFlow &)            = delete;
+    ITaskFlow &operator=(const ITaskFlow &) = delete;
+    ITaskFlow(ITaskFlow &&)                 = delete;
+    ITaskFlow &operator=(ITaskFlow &&)      = delete;
+
+  protected:
+    ITaskFlow() = default;
+};
+
+} // namespace vigine::taskflow

--- a/include/vigine/taskflow/resultcode.h
+++ b/include/vigine/taskflow/resultcode.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <cstdint>
+
+namespace vigine::taskflow
+{
+/**
+ * @brief Closed enumeration of the outcome codes a task reports back
+ *        to its task flow when it finishes executing.
+ *
+ * User decision UD-3 fixed the minimal set of outcome codes the task
+ * flow wrapper needs to route synchronously. The four values are the
+ * smallest set that covers both the back-compat path (@c Success vs.
+ * @c Error matching the legacy @c Result::Code shape) and the two UD-3
+ * extensions callers rely on when they wire up non-trivial flows:
+ *
+ *   - @c Success  — the task completed successfully. The task flow
+ *                   routes to whichever next task is registered
+ *                   against @c Success from this source.
+ *   - @c Error    — the task failed. The task flow routes to whichever
+ *                   next task is registered against @c Error from this
+ *                   source, or halts the flow when no route is
+ *                   registered.
+ *   - @c Deferred — the task declined to route synchronously and will
+ *                   signal the next transition asynchronously later.
+ *                   The wrapper in this leaf only stores the outcome
+ *                   code; the signal-driven routing that consumes
+ *                   @c Deferred lands with the facade wiring in a
+ *                   later leaf.
+ *   - @c Skip     — the task chose to skip routing for this outcome.
+ *                   The task flow neither advances nor reports an
+ *                   error; the caller typically uses @c Skip to short-
+ *                   circuit a branch without aborting the flow.
+ *
+ * The enum is deliberately closed: adding a new code is an API break
+ * that requires an architect review per INV-1. The underlying type is
+ * fixed at @c std::uint8_t so the enum is cheap to pass by value and
+ * so its layout is portable across the messaging bus that eventually
+ * consumes these values.
+ *
+ * @note The task flow wrapper ships its own @ref ResultCode rather
+ *       than reusing the engine's @c vigine::Result::Code because the
+ *       flow surface only needs the four outcomes above; widening the
+ *       surface to the general @c Result::Code set would pull in
+ *       codes (e.g. @c DuplicatePayloadId, @c SubscriptionExpired)
+ *       that have no meaning inside a task transition and would
+ *       obscure the routing contract callers rely on.
+ */
+enum class ResultCode : std::uint8_t
+{
+    Success  = 1,
+    Error    = 2,
+    Deferred = 3,
+    Skip     = 4,
+};
+
+} // namespace vigine::taskflow

--- a/include/vigine/taskflow/routemode.h
+++ b/include/vigine/taskflow/routemode.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <cstdint>
+
+namespace vigine::taskflow
+{
+/**
+ * @brief Closed enumeration of the routing strategies an
+ *        @ref ITaskFlow uses when it resolves which next task runs
+ *        after a completed task reports a given @ref ResultCode.
+ *
+ * The three values are the minimal set user decision UD-3 pinned for
+ * task flow transitions:
+ *
+ *   - @c FirstMatch — deliver to the first next task registered for
+ *                     this @c (source, resultCode) pair. Later
+ *                     registrations with the same pair are ignored
+ *                     during routing. The back-compatible default
+ *                     that matches the legacy task flow behaviour.
+ *   - @c FanOut     — deliver to every next task registered for this
+ *                     @c (source, resultCode) pair. Callers opt in
+ *                     per registration; each matching target runs
+ *                     independently.
+ *   - @c Chain      — deliver sequentially through every next task
+ *                     registered for this @c (source, resultCode)
+ *                     pair, one after another, forming a pipeline.
+ *                     The next task in the chain starts when the
+ *                     current one finishes with @c Success.
+ *
+ * The enum is deliberately closed: adding a new mode is an API break
+ * that requires an architect review per INV-1. The underlying type is
+ * fixed at @c std::uint8_t so the enum is cheap to pass by value and
+ * so its layout is portable across the messaging bus that eventually
+ * consumes these values.
+ *
+ * @note The task flow wrapper ships its own @ref RouteMode rather
+ *       than reusing the messaging core's @c vigine::messaging::RouteMode
+ *       because the task-flow surface only needs the three modes that
+ *       apply to task transitions; letting every messaging mode
+ *       (@c Bubble, @c Broadcast) leak through would widen the
+ *       wrapper's contract beyond what UD-3 sanctions.
+ */
+enum class RouteMode : std::uint8_t
+{
+    FirstMatch = 1,
+    FanOut     = 2,
+    Chain      = 3,
+};
+
+} // namespace vigine::taskflow

--- a/include/vigine/taskflow/taskid.h
+++ b/include/vigine/taskflow/taskid.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <compare>
+#include <cstdint>
+
+namespace vigine::taskflow
+{
+/**
+ * @brief Generational identifier for a task managed by an
+ *        @ref ITaskFlow.
+ *
+ * @ref TaskId is a POD value type owned by the task flow wrapper. It is
+ * deliberately its own struct rather than an alias over the substrate
+ * primitive's identifier type so the public task flow surface never
+ * mentions substrate primitive types (INV-11 — wrapper encapsulation).
+ * The wrapper layer translates between @c TaskId and the substrate-side
+ * identifiers exclusively inside @c src/taskflow; callers of the
+ * @ref ITaskFlow API never need to know the substrate exists.
+ *
+ * The @c index field addresses a slot in the internal task orchestrator;
+ * the @c generation field is incremented whenever that slot is recycled
+ * so a lookup with a stale handle fails safely rather than returning a
+ * different task. A default-constructed @ref TaskId (@c generation
+ * @c == @c 0) is the invalid sentinel and reports @ref valid as
+ * @c false.
+ *
+ * The pair is small (8 bytes), trivially copyable, and safe to pass by
+ * value across thread boundaries.
+ *
+ * @note The layout is intentionally structurally identical to the
+ *       substrate's own generational identifier. The translation
+ *       lives exclusively inside the wrapper implementation —
+ *       keeping substrate types out of the public header tree is
+ *       the whole point of the separate type.
+ */
+struct TaskId
+{
+    std::uint32_t index{0};
+    std::uint32_t generation{0};
+
+    /**
+     * @brief Reports whether the id addresses a slot that was live at
+     *        construction time.
+     *
+     * A @c true return only means the generation is non-zero. The
+     * underlying task orchestrator may still have invalidated the slot
+     * since; the authoritative check is an @ref ITaskFlow lookup.
+     */
+    [[nodiscard]] constexpr bool valid() const noexcept { return generation != 0; }
+
+    friend constexpr auto operator<=>(const TaskId &, const TaskId &) = default;
+    friend constexpr bool operator==(const TaskId &, const TaskId &)  = default;
+};
+
+} // namespace vigine::taskflow

--- a/src/taskflow/abstracttaskflow.cpp
+++ b/src/taskflow/abstracttaskflow.cpp
@@ -1,0 +1,110 @@
+#include "vigine/taskflow/abstracttaskflow.h"
+
+#include <memory>
+
+#include "taskflow/taskorchestrator.h"
+#include "vigine/result.h"
+#include "vigine/taskflow/resultcode.h"
+#include "vigine/taskflow/routemode.h"
+#include "vigine/taskflow/taskid.h"
+
+namespace vigine::taskflow
+{
+
+// ---------------------------------------------------------------------------
+// Construction / destruction.
+//
+// The constructor wires up the internal orchestrator, auto-provisions the
+// default task per UD-3, and selects it as both the default and the
+// current task so @ref current immediately returns a valid id even when
+// the caller never registers any task of their own.
+// ---------------------------------------------------------------------------
+
+AbstractTaskFlow::AbstractTaskFlow()
+    : _orchestrator{std::make_unique<TaskOrchestrator>()}
+{
+    _defaultTask = _orchestrator->addTask();
+    _current     = _defaultTask;
+}
+
+AbstractTaskFlow::~AbstractTaskFlow() = default;
+
+// ---------------------------------------------------------------------------
+// Protected accessors — the derived classes reach the internal orchestrator
+// through these so the substrate stays invisible on the wrapper's
+// public surface.
+// ---------------------------------------------------------------------------
+
+TaskOrchestrator &AbstractTaskFlow::orchestrator() noexcept
+{
+    return *_orchestrator;
+}
+
+const TaskOrchestrator &AbstractTaskFlow::orchestrator() const noexcept
+{
+    return *_orchestrator;
+}
+
+TaskId AbstractTaskFlow::defaultTask() const noexcept
+{
+    return _defaultTask;
+}
+
+// ---------------------------------------------------------------------------
+// ITaskFlow: task registration. Each delegation is a one-liner; the
+// orchestrator does the substrate translation so the wrapper stays thin.
+// ---------------------------------------------------------------------------
+
+TaskId AbstractTaskFlow::addTask()
+{
+    return _orchestrator->addTask();
+}
+
+bool AbstractTaskFlow::hasTask(TaskId task) const noexcept
+{
+    return _orchestrator->hasTask(task);
+}
+
+// ---------------------------------------------------------------------------
+// ITaskFlow: transitions. The short overload routes through the explicit-
+// mode overload with the UD-3 default @ref RouteMode::FirstMatch; the
+// explicit-mode overload forwards straight to the orchestrator, which
+// enforces the "one @ref RouteMode per pair" invariant.
+// ---------------------------------------------------------------------------
+
+Result AbstractTaskFlow::onResult(TaskId source, ResultCode code, TaskId next)
+{
+    return onResult(source, code, next, RouteMode::FirstMatch);
+}
+
+Result AbstractTaskFlow::onResult(
+    TaskId    source,
+    ResultCode code,
+    TaskId    next,
+    RouteMode mode)
+{
+    return _orchestrator->addTransition(source, code, next, mode);
+}
+
+// ---------------------------------------------------------------------------
+// ITaskFlow: flow control. The base enforces that the start task is
+// registered before it updates @c _current; callers that pass a stale id
+// observe an @ref Result::Code::Error and no state change.
+// ---------------------------------------------------------------------------
+
+Result AbstractTaskFlow::enqueue(TaskId start)
+{
+    if (!_orchestrator->hasTask(start))
+    {
+        return Result(Result::Code::Error, "start task not registered");
+    }
+    _current = start;
+    return Result();
+}
+
+TaskId AbstractTaskFlow::current() const noexcept
+{
+    return _current;
+}
+
+} // namespace vigine::taskflow

--- a/src/taskflow/defaulttaskflow.cpp
+++ b/src/taskflow/defaulttaskflow.cpp
@@ -1,0 +1,10 @@
+#include "taskflow/defaulttaskflow.h"
+
+namespace vigine::taskflow
+{
+
+DefaultTaskFlow::DefaultTaskFlow() = default;
+
+DefaultTaskFlow::~DefaultTaskFlow() = default;
+
+} // namespace vigine::taskflow

--- a/src/taskflow/defaulttaskflow.h
+++ b/src/taskflow/defaulttaskflow.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "vigine/taskflow/abstracttaskflow.h"
+
+namespace vigine::taskflow
+{
+/**
+ * @brief Minimal concrete task flow that seals the wrapper recipe.
+ *
+ * @ref DefaultTaskFlow exists so @ref createTaskFlow can return a real
+ * owning @c std::unique_ptr<ITaskFlow>. It carries no domain-specific
+ * behaviour; every @ref ITaskFlow method falls through to
+ * @ref AbstractTaskFlow, which in turn delegates to the internal task
+ * orchestrator and applies the UD-3 default-task and FirstMatch-routing
+ * behaviours.
+ *
+ * The class is @c final to close the inheritance chain for this leaf;
+ * follow-up leaves that specialise the task flow with their own caches
+ * or indices define their own concrete classes and their own factory
+ * entry points and do not derive from @ref DefaultTaskFlow.
+ */
+class DefaultTaskFlow final : public AbstractTaskFlow
+{
+  public:
+    DefaultTaskFlow();
+    ~DefaultTaskFlow() override;
+
+    DefaultTaskFlow(const DefaultTaskFlow &)            = delete;
+    DefaultTaskFlow &operator=(const DefaultTaskFlow &) = delete;
+    DefaultTaskFlow(DefaultTaskFlow &&)                 = delete;
+    DefaultTaskFlow &operator=(DefaultTaskFlow &&)      = delete;
+};
+
+} // namespace vigine::taskflow

--- a/src/taskflow/factory.cpp
+++ b/src/taskflow/factory.cpp
@@ -1,0 +1,20 @@
+#include "vigine/taskflow/factory.h"
+
+#include <memory>
+
+#include "taskflow/defaulttaskflow.h"
+
+namespace vigine::taskflow
+{
+
+std::unique_ptr<ITaskFlow> createTaskFlow()
+{
+    // The factory constructs the default concrete closer over
+    // AbstractTaskFlow. The internal task orchestrator is allocated
+    // eagerly by the base class constructor, which also auto-provisions
+    // the default task per UD-3, so the returned flow is immediately
+    // ready to answer @ref ITaskFlow::current with a valid id.
+    return std::make_unique<DefaultTaskFlow>();
+}
+
+} // namespace vigine::taskflow

--- a/src/taskflow/taskorchestrator.cpp
+++ b/src/taskflow/taskorchestrator.cpp
@@ -1,0 +1,302 @@
+#include "taskflow/taskorchestrator.h"
+
+#include <cstdint>
+#include <memory>
+
+#include "vigine/graph/abstractgraph.h"
+#include "vigine/graph/edgeid.h"
+#include "vigine/graph/iedge.h"
+#include "vigine/graph/iedgedata.h"
+#include "vigine/graph/igraphquery.h"
+#include "vigine/graph/inode.h"
+#include "vigine/graph/kind.h"
+#include "vigine/graph/nodeid.h"
+#include "vigine/result.h"
+#include "vigine/taskflow/kind.h"
+#include "vigine/taskflow/resultcode.h"
+#include "vigine/taskflow/routemode.h"
+#include "vigine/taskflow/taskid.h"
+
+namespace vigine::taskflow
+{
+
+// ---------------------------------------------------------------------------
+// Private helper nodes / edges. These types live entirely inside the
+// translation unit — the wrapper's public header never mentions them, so
+// they are free to refer to substrate types directly without breaching
+// INV-11.
+// ---------------------------------------------------------------------------
+
+namespace
+{
+
+/**
+ * @brief Stable runtime identifier for the @ref TransitionData payload
+ *        attached to every transition edge.
+ *
+ * The constant lives in the anonymous namespace so no other translation
+ * unit can accidentally collide with it. The value is arbitrary within
+ * the space of @c std::uint32_t; the only contract is that every
+ * transition edge reports exactly this value from its
+ * @ref vigine::graph::IEdgeData::dataTypeId override.
+ */
+inline constexpr std::uint32_t kTransitionDataTypeId = 0x74665452U; // "tfTR"
+
+/**
+ * @brief Task vertex stored inside the specialised task orchestrator.
+ *
+ * Carries only the @c vigine::taskflow::kind::Task tag and cooperates
+ * with @c AbstractGraph::IdStamp so the assigned generational id
+ * flows back to @c id() without a round-trip through the graph.
+ */
+class TaskNode final
+    : public vigine::graph::INode
+    , public vigine::graph::AbstractGraph::IdStamp
+{
+  public:
+    TaskNode() = default;
+
+    [[nodiscard]] vigine::graph::NodeId id() const noexcept override { return _id; }
+    [[nodiscard]] vigine::graph::NodeKind kind() const noexcept override
+    {
+        return vigine::taskflow::kind::Task;
+    }
+
+    void onGraphIdAssigned(
+        vigine::graph::NodeId nodeId,
+        vigine::graph::EdgeId edgeId) noexcept override
+    {
+        _id = nodeId;
+        (void)edgeId;
+    }
+
+  private:
+    vigine::graph::NodeId _id{};
+};
+
+/**
+ * @brief Payload attached to a transition edge.
+ *
+ * Carries the @ref ResultCode that triggers the transition and the
+ * @ref RouteMode that determines how the wrapper dispatches when
+ * several edges share the same @c (source, code) pair. The payload is
+ * immutable after construction; the orchestrator inspects it during
+ * registration to enforce the "one @ref RouteMode per pair"
+ * invariant.
+ */
+class TransitionData final : public vigine::graph::IEdgeData
+{
+  public:
+    TransitionData(ResultCode code, RouteMode mode) noexcept
+        : _code{code}, _mode{mode}
+    {
+    }
+
+    [[nodiscard]] std::uint32_t dataTypeId() const noexcept override
+    {
+        return kTransitionDataTypeId;
+    }
+
+    [[nodiscard]] ResultCode code() const noexcept { return _code; }
+    [[nodiscard]] RouteMode  mode() const noexcept { return _mode; }
+
+  private:
+    ResultCode _code;
+    RouteMode  _mode;
+};
+
+/**
+ * @brief Directed transition edge from a source task to a registered
+ *        next task.
+ *
+ * Owns its @ref TransitionData payload and exposes it through the
+ * base class's @c data() hook so the wrapper implementation can read
+ * the @ref ResultCode and @ref RouteMode back during queries.
+ */
+class TransitionEdge final
+    : public vigine::graph::IEdge
+    , public vigine::graph::AbstractGraph::IdStamp
+{
+  public:
+    TransitionEdge(
+        vigine::graph::NodeId from,
+        vigine::graph::NodeId to,
+        ResultCode            code,
+        RouteMode             mode) noexcept
+        : _from{from}
+        , _to{to}
+        , _data{code, mode}
+    {
+    }
+
+    [[nodiscard]] vigine::graph::EdgeId id() const noexcept override { return _id; }
+    [[nodiscard]] vigine::graph::EdgeKind kind() const noexcept override
+    {
+        return vigine::taskflow::edge_kind::Transition;
+    }
+    [[nodiscard]] vigine::graph::NodeId from() const noexcept override { return _from; }
+    [[nodiscard]] vigine::graph::NodeId to() const noexcept override { return _to; }
+    [[nodiscard]] const vigine::graph::IEdgeData *data() const noexcept override
+    {
+        return &_data;
+    }
+
+    void onGraphIdAssigned(
+        vigine::graph::NodeId nodeId,
+        vigine::graph::EdgeId edgeId) noexcept override
+    {
+        _id = edgeId;
+        (void)nodeId;
+    }
+
+  private:
+    vigine::graph::EdgeId _id{};
+    vigine::graph::NodeId _from{};
+    vigine::graph::NodeId _to{};
+    TransitionData        _data;
+};
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Construction / destruction.
+// ---------------------------------------------------------------------------
+
+TaskOrchestrator::TaskOrchestrator() = default;
+
+TaskOrchestrator::~TaskOrchestrator() = default;
+
+// ---------------------------------------------------------------------------
+// POD translation helpers. The @ref TaskId layout is intentionally
+// identical to @c vigine::graph::NodeId so the translation is a plain
+// field-for-field copy; INV-11 allows it here because the conversion
+// lives entirely inside the wrapper implementation.
+// ---------------------------------------------------------------------------
+
+vigine::graph::NodeId TaskOrchestrator::toNodeId(TaskId task) noexcept
+{
+    return vigine::graph::NodeId{task.index, task.generation};
+}
+
+TaskId TaskOrchestrator::toTaskId(vigine::graph::NodeId node) noexcept
+{
+    return TaskId{node.index, node.generation};
+}
+
+// ---------------------------------------------------------------------------
+// Task lifecycle.
+// ---------------------------------------------------------------------------
+
+TaskId TaskOrchestrator::addTask()
+{
+    // The base graph never returns an invalid generation from addNode, so
+    // the fresh @ref TaskId is always valid. Passing the node back as an
+    // @c INode unique_ptr follows the IdStamp handshake — the node captures
+    // the assigned id during insert.
+    auto                        node = std::make_unique<TaskNode>();
+    const vigine::graph::NodeId nid  = addNode(std::move(node));
+    return toTaskId(nid);
+}
+
+bool TaskOrchestrator::hasTask(TaskId task) const noexcept
+{
+    if (!task.valid())
+    {
+        return false;
+    }
+    const vigine::graph::INode *n = node(toNodeId(task));
+    return n != nullptr && n->kind() == vigine::taskflow::kind::Task;
+}
+
+// ---------------------------------------------------------------------------
+// Transitions.
+// ---------------------------------------------------------------------------
+
+RouteMode TaskOrchestrator::storedModeFor(
+    TaskId     source,
+    ResultCode code,
+    RouteMode  fallback) const
+{
+    const vigine::graph::NodeId srcNode = toNodeId(source);
+    if (!query().hasNode(srcNode))
+    {
+        return fallback;
+    }
+
+    // Walk the outgoing transition edges of @p source and pick the first
+    // edge that carries the matching @ref ResultCode. That edge's stored
+    // @ref RouteMode is the canonical mode for the pair; later
+    // registrations for the same pair must repeat it.
+    const auto edges
+        = query().outEdgesOfKind(srcNode, vigine::taskflow::edge_kind::Transition);
+    for (const auto eid : edges)
+    {
+        const vigine::graph::IEdge *e = edge(eid);
+        if (e == nullptr)
+        {
+            continue;
+        }
+        const vigine::graph::IEdgeData *d = e->data();
+        if (d == nullptr || d->dataTypeId() != kTransitionDataTypeId)
+        {
+            continue;
+        }
+        const auto *td = static_cast<const TransitionData *>(d);
+        if (td->code() == code)
+        {
+            return td->mode();
+        }
+    }
+    return fallback;
+}
+
+Result TaskOrchestrator::addTransition(
+    TaskId    source,
+    ResultCode code,
+    TaskId    next,
+    RouteMode mode)
+{
+    if (!source.valid() || !next.valid())
+    {
+        return Result(Result::Code::Error, "invalid task id");
+    }
+    if (source == next)
+    {
+        return Result(Result::Code::Error, "task cannot transition to itself");
+    }
+
+    const vigine::graph::NodeId srcNode  = toNodeId(source);
+    const vigine::graph::NodeId nextNode = toNodeId(next);
+
+    if (!query().hasNode(srcNode))
+    {
+        return Result(Result::Code::Error, "source task not registered");
+    }
+    if (!query().hasNode(nextNode))
+    {
+        return Result(Result::Code::Error, "next task not registered");
+    }
+
+    // Enforce the "one @ref RouteMode per (source, code) pair" invariant.
+    // The first registration locks the mode; every subsequent registration
+    // for the same pair must repeat the same mode or the wrapper rejects
+    // it so routing stays unambiguous.
+    const RouteMode stored = storedModeFor(source, code, mode);
+    if (stored != mode)
+    {
+        return Result(
+            Result::Code::Error,
+            "conflicting RouteMode for (source, code) pair");
+    }
+
+    auto edgePtr
+        = std::make_unique<TransitionEdge>(srcNode, nextNode, code, mode);
+    const vigine::graph::EdgeId eid = addEdge(std::move(edgePtr));
+    if (!eid.valid())
+    {
+        return Result(Result::Code::Error, "failed to add transition edge");
+    }
+    return Result();
+}
+
+} // namespace vigine::taskflow

--- a/src/taskflow/taskorchestrator.h
+++ b/src/taskflow/taskorchestrator.h
@@ -1,0 +1,140 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "vigine/graph/abstractgraph.h"
+#include "vigine/graph/edgeid.h"
+#include "vigine/graph/nodeid.h"
+#include "vigine/result.h"
+#include "vigine/taskflow/resultcode.h"
+#include "vigine/taskflow/routemode.h"
+#include "vigine/taskflow/taskid.h"
+
+namespace vigine::taskflow
+{
+/**
+ * @brief Internal graph specialisation that the task flow wrapper uses
+ *        to hold its tasks and their transitions.
+ *
+ * @ref TaskOrchestrator is a concrete @c vigine::graph::AbstractGraph
+ * subtype that seals the inheritance chain for the task flow wrapper.
+ * It carries the translation between the wrapper's own POD handle
+ * (@ref TaskId) and the substrate's generational @c NodeId so every
+ * @ref ITaskFlow method can delegate a single call to it without
+ * letting substrate primitives leak through the public wrapper
+ * surface.
+ *
+ * This header lives under @c src/taskflow on purpose: the INV-11 rule
+ * forbids @c vigine::graph types from surfacing in
+ * @c include/vigine/taskflow. Only the wrapper implementation
+ * consumes the orchestrator; callers of @ref ITaskFlow /
+ * @ref AbstractTaskFlow see neither the orchestrator nor its graph
+ * base.
+ *
+ * Thread-safety inherits from @c AbstractGraph: every mutating entry
+ * point takes the graph's exclusive lock; reads take a shared lock.
+ * The wrapper layer does not add any additional synchronisation on
+ * top; every task-flow-side access path funnels through the
+ * orchestrator.
+ *
+ * Node kinds used:
+ *   - @c vigine::taskflow::kind::Task for task nodes (from
+ *     @c include/vigine/taskflow/kind.h).
+ *
+ * Edge kinds used:
+ *   - @c vigine::taskflow::edge_kind::Transition for the directed
+ *     edge from a source task to its registered next task. The edge
+ *     carries the @ref ResultCode that triggers the transition and
+ *     the @ref RouteMode that determines how the wrapper walks the
+ *     edges registered against the same
+ *     @c (source, resultCode) pair.
+ */
+class TaskOrchestrator final : public vigine::graph::AbstractGraph
+{
+  public:
+    TaskOrchestrator();
+    ~TaskOrchestrator() override;
+
+    TaskOrchestrator(const TaskOrchestrator &)            = delete;
+    TaskOrchestrator &operator=(const TaskOrchestrator &) = delete;
+    TaskOrchestrator(TaskOrchestrator &&)                 = delete;
+    TaskOrchestrator &operator=(TaskOrchestrator &&)      = delete;
+
+    // ------ Task lifecycle ------
+
+    /**
+     * @brief Allocates a fresh task node and returns the corresponding
+     *        @ref TaskId.
+     *
+     * The returned handle is always valid; the underlying graph never
+     * returns an invalid generation from
+     * @ref vigine::graph::AbstractGraph::addNode.
+     */
+    [[nodiscard]] TaskId addTask();
+
+    /**
+     * @brief Reports whether a task node addressed by @p task is
+     *        currently tracked.
+     */
+    [[nodiscard]] bool hasTask(TaskId task) const noexcept;
+
+    // ------ Transitions ------
+
+    /**
+     * @brief Creates a directed transition edge from @p source to
+     *        @p next triggered by @p code and routed with @p mode.
+     *
+     * Reports @ref Result::Code::Error when either task is stale,
+     * when @p source equals @p next (a task cannot transition
+     * directly to itself), or when a conflicting @ref RouteMode has
+     * already been stored for the @c (source, code) pair — the first
+     * registration locks the routing mode for the pair.
+     */
+    Result addTransition(
+        TaskId    source,
+        ResultCode code,
+        TaskId    next,
+        RouteMode mode);
+
+    // ------ POD translation helpers ------
+
+    /**
+     * @brief Translates a @ref TaskId to the substrate's
+     *        @c NodeId.
+     *
+     * Packaged as a free-standing @c static helper so the wrapper
+     * implementation can reach the substrate without needing further
+     * access to the graph's internals. The two POD types have the
+     * same layout; the helper exists for type-safety, not for
+     * arithmetic.
+     */
+    [[nodiscard]] static vigine::graph::NodeId toNodeId(TaskId task) noexcept;
+
+    /**
+     * @brief Translates a substrate @c NodeId back to a
+     *        @ref TaskId.
+     *
+     * Only the wrapper implementation calls this; callers of the
+     * public task flow API never see the substrate type.
+     */
+    [[nodiscard]] static TaskId toTaskId(vigine::graph::NodeId node) noexcept;
+
+  private:
+    /**
+     * @brief Reports the @ref RouteMode already stored for the
+     *        @c (source, code) pair, or the default @p fallback
+     *        when no edge is yet registered.
+     *
+     * Used by @ref addTransition to enforce the "one @ref RouteMode
+     * per pair" invariant: the first registration fixes the mode;
+     * every subsequent registration for the same pair must repeat
+     * the same mode.
+     */
+    [[nodiscard]] RouteMode storedModeFor(
+        TaskId     source,
+        ResultCode code,
+        RouteMode  fallback) const;
+};
+
+} // namespace vigine::taskflow


### PR DESCRIPTION
Fourth and final Level-1 wrapper following the same recipe as R.4.1 (service), R.4.2 (ecs), R.4.3 (statemachine).

## Public surface (`include/vigine/taskflow/`)

- `taskid.h` -- own generational POD; never a `NodeId` alias.
- `resultcode.h` -- closed enum `{Success, Error, Deferred, Skip}` per UD-3.
- `routemode.h` -- closed enum `{FirstMatch, FanOut, Chain}`; default `FirstMatch`.
- `itaskflow.h` -- pure-virtual `ITaskFlow`: `addTask`, `hasTask`, `onResult` (short + explicit-mode), `enqueue`, `current`.
- `abstracttaskflow.h` -- stateful base, private `std::unique_ptr<TaskOrchestrator>` composition (forward-declared here, defined in `src/taskflow/`).
- `factory.h` -- `[[nodiscard]] std::unique_ptr<ITaskFlow> createTaskFlow();`.

## Internals (`src/taskflow/`)

- `taskorchestrator.{h,cpp}` -- `final : public AbstractGraph`; owns the `TaskId <-> NodeId` translation. Transition edges carry an `IEdgeData` payload storing `ResultCode` + `RouteMode`; one `RouteMode` is locked per `(source, code)` pair on first registration.
- `abstracttaskflow.cpp` -- thin delegation; auto-provisions the default task in the constructor per UD-3.
- `defaulttaskflow.{h,cpp}` -- minimal `final` closer.
- `factory.cpp` -- single `make_unique<DefaultTaskFlow>()`.

## Invariants

- INV-1 (no templates in public headers) -- verified with `check_no_templates.py`.
- INV-10 (`I` / `Abstract` prefix convention) -- verified with `check_naming_convention.py`.
- INV-11 (no graph types in wrapper public API).
- Legacy `include/vigine/taskflow.h` left untouched.

## Build

- Debug + Release both compile warnings-clean under `/W4 /permissive-`.

Closes #115