### PR TITLE
feat(context): R.4.5 IContext aggregator + freeze-after-run

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -389,6 +389,21 @@ set(SOURCES_TASKFLOW_CORE
     ${SRC_DIR}/taskflow/factory.cpp
 )
 
+# Context aggregator (R.4.5) -- public surface.
+set(HEADER_CONTEXT_AGGREGATOR
+    ${INCLUDE_DIR}/vigine/context/contextconfig.h
+    ${INCLUDE_DIR}/vigine/context/abstractcontext.h
+    ${INCLUDE_DIR}/vigine/context/factory.h
+)
+
+# Context aggregator (R.4.5) -- internal concrete + factory + base impl.
+set(SOURCES_CONTEXT_AGGREGATOR
+    ${SRC_DIR}/context/abstractcontext.cpp
+    ${SRC_DIR}/context/defaultcontext.h
+    ${SRC_DIR}/context/defaultcontext.cpp
+    ${SRC_DIR}/context/factory.cpp
+)
+
 # Add source files
 if(ENABLE_POSTGRESQL)
     set(HEADER_POSTGRESQL
@@ -471,6 +486,8 @@ add_library(${PROJECT_NAME}
     ${SOURCES_STATEMACHINE_CORE}
     ${HEADER_TASKFLOW_CORE}
     ${SOURCES_TASKFLOW_CORE}
+    ${HEADER_CONTEXT_AGGREGATOR}
+    ${SOURCES_CONTEXT_AGGREGATOR}
     ${HEADER_POSTGRESQL}
     ${SOURCES_POSTGRESQL}
     ${SOURCES_POSTGRESQL_EXTRA}

--- a/include/vigine/context.h
+++ b/include/vigine/context.h
@@ -18,12 +18,55 @@ class EntityManager;
 using ServiceInstancesContainer = std::vector<std::pair<const Name, AbstractServiceUPtr>>;
 using SystemInstancesContainer  = std::vector<std::pair<const SystemId, AbstractSystemUPtr>>;
 
+/**
+ * @brief Legacy engine context.
+ *
+ * Pre-R.4.5 the engine held this class directly through
+ * @c std::unique_ptr<Context>; R.4.5 promotes @ref IContext to a
+ * full pure-virtual aggregator, so @ref Context now implements the
+ * aggregator methods with minimal stubs that report "not available"
+ * to any caller. Legacy callers that still route through
+ * @c Engine::context() see their existing service / system registry
+ * untouched; new callers that want the full aggregator go through
+ * @c vigine::context::createContext.
+ *
+ * A later leaf retires the legacy class entirely once every example
+ * migrates to the aggregator contract.
+ */
 class Context : public IContext
 {
   public:
     AbstractService *service(const ServiceId id, const Name name, const Property property);
     AbstractSystem *system(const SystemId id, const SystemName name, const Property property);
     EntityManager *entityManager() const;
+
+    // ------ IContext aggregator stubs (legacy class carries none of
+    //        the new substrates; every accessor reports an error or
+    //        returns a null handle so the legacy class keeps compiling
+    //        after R.4.5 extends the interface) ------
+
+    [[nodiscard]] messaging::IMessageBus &systemBus() override;
+
+    [[nodiscard]] std::shared_ptr<messaging::IMessageBus>
+        createMessageBus(const messaging::BusConfig &config) override;
+
+    [[nodiscard]] std::shared_ptr<messaging::IMessageBus>
+        messageBus(messaging::BusId id) const override;
+
+    [[nodiscard]] ecs::IECS                   &ecs() override;
+    [[nodiscard]] statemachine::IStateMachine &stateMachine() override;
+    [[nodiscard]] taskflow::ITaskFlow         &taskFlow() override;
+
+    [[nodiscard]] threading::IThreadManager &threadManager() override;
+
+    [[nodiscard]] std::shared_ptr<service::IService>
+        service(service::ServiceId id) const override;
+
+    [[nodiscard]] Result
+        registerService(std::shared_ptr<service::IService> service) override;
+
+    void              freeze() noexcept override;
+    [[nodiscard]] bool isFrozen() const noexcept override;
 
   private:
     Context(EntityManager *entityManager);
@@ -34,6 +77,7 @@ class Context : public IContext
     std::unordered_map<ServiceId, ServiceInstancesContainer> _services;
     std::unordered_map<SystemId, SystemInstancesContainer> _systems;
     EntityManager *_entityManager{nullptr};
+    bool _frozen{false};
 
     friend class Engine;
 };

--- a/include/vigine/context/abstractcontext.h
+++ b/include/vigine/context/abstractcontext.h
@@ -1,0 +1,258 @@
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+
+#include "vigine/context/contextconfig.h"
+#include "vigine/context/icontext.h"
+#include "vigine/ecs/iecs.h"
+#include "vigine/messaging/busconfig.h"
+#include "vigine/messaging/busid.h"
+#include "vigine/messaging/imessagebus.h"
+#include "vigine/result.h"
+#include "vigine/service/iservice.h"
+#include "vigine/service/serviceid.h"
+#include "vigine/statemachine/istatemachine.h"
+#include "vigine/taskflow/itaskflow.h"
+#include "vigine/threading/ithreadmanager.h"
+
+namespace vigine::context
+{
+/**
+ * @brief Stateful abstract base that owns every engine-wide resource
+ *        exposed through @ref IContext.
+ *
+ * @ref AbstractContext is level 4 of the wrapper recipe: it supplies
+ * the @ref IContext accessors, owns the thread manager, the system
+ * bus, the Level-1 wrappers, the user-bus registry, and the service
+ * registry, and encodes the strict construction and destruction order
+ * required by UD-9 + AD-5 C8. A concrete closer (see
+ * @c DefaultContext in @c src/context) seals the chain so the factory
+ * can hand out @c std::unique_ptr<IContext>.
+ *
+ * The class carries state, so it uses the project's @c Abstract
+ * naming convention. All data members are @c private per the strict
+ * encapsulation rule; derived classes that need to inspect the
+ * substrate go through @c protected accessors.
+ *
+ * Construction order (encoded by member declaration order in the
+ * private block below):
+ *   1. @ref threading::IThreadManager -- created first so every
+ *      downstream component can depend on it.
+ *   2. @ref messaging::IMessageBus (system) -- created second; takes
+ *      a reference to the thread manager.
+ *   3. @ref ecs::IECS -- Level-1 wrapper; default-constructed.
+ *   4. @ref statemachine::IStateMachine -- Level-1 wrapper;
+ *      default-constructed.
+ *   5. @ref taskflow::ITaskFlow -- Level-1 wrapper;
+ *      default-constructed.
+ *   6. user-bus registry (empty at construction).
+ *   7. service registry (empty at construction).
+ *   8. freeze flag (cleared at construction).
+ *
+ * Destruction is the reverse of the above because C++ destructs
+ * members in the reverse order of declaration; the freeze flag dies
+ * first, then the registries, then the Level-1 wrappers, then the
+ * system bus, then the thread manager last. Services registered
+ * through @ref registerService are destroyed along with the service
+ * registry before the Level-1 wrappers tear down.
+ *
+ * Freeze semantics (UD-9):
+ *   - The freeze flag is an @c std::atomic<bool>. @ref freeze flips
+ *     it to @c true; @ref isFrozen reads it; every mutator takes the
+ *     registry mutex and returns @ref Result::Code::TopologyFrozen
+ *     when the flag is set. A winning @ref freeze call and an
+ *     in-progress mutator serialise through the mutex: either the
+ *     mutator sees the flag clear and completes, or it sees it set
+ *     and reports the error; there is no partial update.
+ *
+ * INV-11 compliance: the header imports Level-1 wrapper interfaces
+ * (`IMessageBus`, `IECS`, `IStateMachine`, `ITaskFlow`,
+ * `IThreadManager`) and POD handles (`BusConfig`, `BusId`,
+ * `ServiceId`). It does not include any graph primitive header and
+ * does not mention `NodeId`, `EdgeId`, `IGraph`, or any graph visitor
+ * type.
+ */
+class AbstractContext : public IContext
+{
+  public:
+    ~AbstractContext() override;
+
+    // ------ IContext: messaging ------
+
+    [[nodiscard]] messaging::IMessageBus &systemBus() override;
+
+    [[nodiscard]] std::shared_ptr<messaging::IMessageBus>
+        createMessageBus(const messaging::BusConfig &config) override;
+
+    [[nodiscard]] std::shared_ptr<messaging::IMessageBus>
+        messageBus(messaging::BusId id) const override;
+
+    // ------ IContext: Level-1 wrappers ------
+
+    [[nodiscard]] ecs::IECS                     &ecs() override;
+    [[nodiscard]] statemachine::IStateMachine   &stateMachine() override;
+    [[nodiscard]] taskflow::ITaskFlow           &taskFlow() override;
+
+    // ------ IContext: threading ------
+
+    [[nodiscard]] threading::IThreadManager &threadManager() override;
+
+    // ------ IContext: service registry ------
+
+    [[nodiscard]] std::shared_ptr<service::IService>
+        service(service::ServiceId id) const override;
+
+    [[nodiscard]] Result
+        registerService(std::shared_ptr<service::IService> service) override;
+
+    // ------ IContext: lifecycle ------
+
+    void              freeze() noexcept override;
+    [[nodiscard]] bool isFrozen() const noexcept override;
+
+    AbstractContext(const AbstractContext &)            = delete;
+    AbstractContext &operator=(const AbstractContext &) = delete;
+    AbstractContext(AbstractContext &&)                 = delete;
+    AbstractContext &operator=(AbstractContext &&)      = delete;
+
+  protected:
+    /**
+     * @brief Constructs the aggregator with the strict ctor order
+     *        described on the class docstring.
+     *
+     * Step 1 builds the thread manager from @p config.threading. Step
+     * 2 builds the system bus from @p config.systemBus, passing the
+     * thread manager in. Steps 3--5 build the three Level-1 wrappers
+     * from their default factories. Step 6 opens the user-bus
+     * registry. Step 7 opens the service registry. Step 8 clears the
+     * freeze flag.
+     *
+     * If any construction step throws, RAII unwinds the steps that
+     * already completed in reverse order: partial state never escapes
+     * the constructor.
+     */
+    explicit AbstractContext(const ContextConfig &config);
+
+    /**
+     * @brief Returns the stable index the next service registration
+     *        will take in the service registry.
+     *
+     * Exposed as @c protected so derived closers can use it for their
+     * own bookkeeping (e.g. diagnostics); the public API does not
+     * surface the registry's internal layout.
+     */
+    [[nodiscard]] std::size_t nextServiceIndex() const noexcept;
+
+  private:
+    /**
+     * @brief Allocates a fresh @ref service::ServiceId for the service
+     *        about to be stored in the registry.
+     *
+     * Called from @ref registerService while holding @ref _registryMutex.
+     * Increments @ref _serviceGeneration so the issued id carries a
+     * non-zero generation per the @ref service::ServiceId::valid
+     * contract.
+     */
+    service::ServiceId allocateServiceId() noexcept;
+
+    // ------ Wrappers + buses (declaration order == construction order) ------
+
+    /**
+     * @brief First member: the thread manager.
+     *
+     * Declared first because every downstream component (system bus,
+     * Level-1 wrappers, services) depends on it at construction time.
+     * Destructed last because C++ tears down members in reverse
+     * declaration order. The engine relies on this ordering to drain
+     * bus workers and sync primitives before the thread manager joins
+     * its pool.
+     */
+    std::unique_ptr<threading::IThreadManager> _threadManager;
+
+    /**
+     * @brief Second member: the engine-wide system bus.
+     *
+     * Held as @c std::shared_ptr so that facades and services can
+     * keep a handle independent of the registry; the context retains
+     * its own reference for the context's lifetime.
+     */
+    std::shared_ptr<messaging::IMessageBus> _systemBus;
+
+    /**
+     * @brief Level-1 wrapper: ECS.
+     */
+    std::unique_ptr<ecs::IECS> _ecs;
+
+    /**
+     * @brief Level-1 wrapper: state machine.
+     */
+    std::unique_ptr<statemachine::IStateMachine> _stateMachine;
+
+    /**
+     * @brief Level-1 wrapper: task flow.
+     */
+    std::unique_ptr<taskflow::ITaskFlow> _taskFlow;
+
+    // ------ Registries (mutable state guarded by _registryMutex) ------
+
+    /**
+     * @brief User buses created through @ref createMessageBus, keyed
+     *        by their @ref messaging::BusId for @ref messageBus
+     *        lookups.
+     */
+    std::unordered_map<std::uint32_t, std::shared_ptr<messaging::IMessageBus>> _userBuses;
+
+    /**
+     * @brief Services registered through @ref registerService, keyed
+     *        by the index field of their stamped @ref service::ServiceId.
+     */
+    std::unordered_map<std::uint32_t, std::shared_ptr<service::IService>> _services;
+
+    /**
+     * @brief Monotonic counter for the index field of issued service ids.
+     *
+     * Incremented once per successful @ref registerService call. Never
+     * reused: the aggregator does not recycle slots, so every live id
+     * maps to exactly one registered service for the context's
+     * lifetime.
+     */
+    std::uint32_t _nextServiceIndex{1};
+
+    /**
+     * @brief Monotonic counter for the generation field of issued
+     *        service ids.
+     *
+     * Always non-zero so that issued ids pass
+     * @ref service::ServiceId::valid. Stored separately from the index
+     * so that future generational recycling can use it without
+     * disturbing the lookup map.
+     */
+    std::uint32_t _serviceGeneration{1};
+
+    /**
+     * @brief Mutex serialising mutators against each other and against
+     *        @ref freeze.
+     *
+     * Read accessors take no lock -- @c std::shared_ptr copies are
+     * atomic enough for the registry's lookup use case under the
+     * aggregator's "mutate only before freeze" contract.
+     */
+    mutable std::mutex _registryMutex;
+
+    /**
+     * @brief Freeze flag.
+     *
+     * Atomic so callers can observe its state without taking the
+     * mutex. A successful @ref freeze flips it to @c true; once true,
+     * the flag never flips back. Mutators read it under the mutex so
+     * the freeze transition is atomic with respect to in-flight
+     * registrations.
+     */
+    std::atomic<bool> _frozen{false};
+};
+
+} // namespace vigine::context

--- a/include/vigine/context/contextconfig.h
+++ b/include/vigine/context/contextconfig.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "vigine/messaging/busconfig.h"
+#include "vigine/threading/threadmanagerconfig.h"
+
+namespace vigine::context
+{
+/**
+ * @brief POD describing the shape of a freshly-built @ref IContext.
+ *
+ * Passed to @ref createContext at construction time. Carries the two
+ * inputs the aggregator needs before it can wire the Level-1 wrappers
+ * together:
+ *
+ *   1. @ref threading configures the first member built by the
+ *      aggregator (the thread manager).
+ *   2. @ref systemBus configures the system bus that the aggregator
+ *      builds next, wiring the thread manager in.
+ *
+ * The remaining wrappers (ECS, state machine, task flow) are built via
+ * their default factories and do not require config fields here. User
+ * services are registered through @ref IContext::registerService after
+ * the context is constructed, so they are not part of this struct.
+ *
+ * Defaults describe an engine-default context: the default-constructed
+ * thread-manager config (hardware-concurrency pool) and a system bus
+ * config with the conventional "system" name and high priority. The
+ * caller overrides individual fields before handing the struct to the
+ * factory.
+ */
+struct ContextConfig
+{
+    /**
+     * @brief Threading substrate configuration consumed first.
+     */
+    threading::ThreadManagerConfig threading{};
+
+    /**
+     * @brief System bus configuration consumed second.
+     *
+     * The conventional name for the system bus is @c "system" and the
+     * conventional priority is @ref messaging::BusPriority::High so
+     * lifecycle traffic wins against application workload. Defaults
+     * here match that expectation.
+     */
+    messaging::BusConfig systemBus{
+        messaging::BusId{},
+        "system",
+        messaging::BusPriority::High,
+        messaging::ThreadingPolicy::Dedicated,
+        messaging::QueueCapacity{},
+        messaging::BackpressurePolicy::Block
+    };
+};
+
+} // namespace vigine::context

--- a/include/vigine/context/factory.h
+++ b/include/vigine/context/factory.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <memory>
+
+#include "vigine/context/contextconfig.h"
+#include "vigine/context/icontext.h"
+
+namespace vigine::context
+{
+/**
+ * @brief Constructs the default concrete @ref IContext and hands back
+ *        an owning @c std::unique_ptr.
+ *
+ * The factory is the single public entry point callers use to build an
+ * aggregator. It wires the strict construction chain encoded on
+ * @ref AbstractContext:
+ *
+ *   1. Build the thread manager from @p config.threading.
+ *   2. Build the system bus from @p config.systemBus, wiring the
+ *      thread manager in.
+ *   3. Default-construct the three Level-1 wrappers (ECS, state
+ *      machine, task flow).
+ *   4. Open the user-bus and service registries (empty).
+ *
+ * Services are not part of the factory call; the caller registers
+ * them through @ref IContext::registerService after the context is
+ * built. The engine calls @ref IContext::freeze once the main loop is
+ * about to start; after the freeze point, registration returns
+ * @ref Result::Code::TopologyFrozen.
+ *
+ * Ownership: the caller owns the returned pointer. The signature is
+ * @c std::unique_ptr because the context is a singular owner inside
+ * the engine construction chain (FF-1). Callers that need shared
+ * ownership lift the returned pointer into a @c std::shared_ptr at
+ * the call site; shared ownership is not the factory's concern.
+ *
+ * The function is @c [[nodiscard]] because silently dropping the
+ * returned handle would tear down every wrapper the factory just
+ * constructed -- wasted allocation and immediate join of the thread
+ * manager pool.
+ */
+[[nodiscard]] std::unique_ptr<IContext>
+    createContext(const ContextConfig &config = {});
+
+} // namespace vigine::context

--- a/include/vigine/context/icontext.h
+++ b/include/vigine/context/icontext.h
@@ -1,25 +1,223 @@
 #pragma once
 
+#include <memory>
+
+#include "vigine/messaging/busconfig.h"
+#include "vigine/messaging/busid.h"
+#include "vigine/result.h"
+#include "vigine/service/serviceid.h"
+
+namespace vigine::ecs
+{
+class IECS;
+} // namespace vigine::ecs
+
+namespace vigine::messaging
+{
+class IMessageBus;
+} // namespace vigine::messaging
+
+namespace vigine::service
+{
+class IService;
+} // namespace vigine::service
+
+namespace vigine::statemachine
+{
+class IStateMachine;
+} // namespace vigine::statemachine
+
+namespace vigine::taskflow
+{
+class ITaskFlow;
+} // namespace vigine::taskflow
+
+namespace vigine::threading
+{
+class IThreadManager;
+} // namespace vigine::threading
+
 namespace vigine
 {
 /**
- * @brief Pure-virtual forward-declared stub for the engine context.
+ * @brief Pure-virtual aggregator / service locator of every engine-wide
+ *        resource.
  *
- * @ref IContext is a minimal stub whose only contract is a virtual
- * destructor. It exists so that @ref Engine::context can return a
- * reference to a pure-virtual interface without requiring the context
- * domain (service container, system registry, binding host) to be
- * finalised in this leaf. The finalised surface lands in a later leaf
- * that refactors @c Context onto this interface.
+ * @ref IContext is the single DI surface every service receives through
+ * @c IService::onInit. It owns no resources itself; the stateful base
+ * @ref AbstractContext holds the actual @c std::unique_ptr handles and
+ * supplies the accessors on top of them. The concrete
+ * @c DefaultContext (see @c src/context) seals the inheritance chain
+ * and is handed out by @ref createContext.
  *
- * Ownership: the stub is never instantiated directly. Concrete
- * @c Context objects derive from it and are owned by the @ref Engine as
- * @c std::unique_ptr.
+ * Surface shape (UD-9):
+ *   - One accessor per Level-1 wrapper (@c systemBus, @c ecs,
+ *     @c stateMachine, @c taskFlow, @c threadManager).
+ *   - One service locator (@c service, @c registerService).
+ *   - One user-bus factory (@c createMessageBus) and an id-keyed
+ *     lookup (@c messageBus).
+ *   - A freeze-after-run boundary (@c freeze, @c isFrozen) that blocks
+ *     topology mutation once @c Engine::run starts the main loop. All
+ *     mutating calls (createMessageBus, registerService) return
+ *     @ref Result::Code::TopologyFrozen after @ref freeze is called.
+ *     Read-only accessors stay available.
+ *
+ * Strict construction order (AD-5 C8, encoded by @ref AbstractContext):
+ *   1. @ref threading::IThreadManager (created first).
+ *   2. system @ref messaging::IMessageBus (needs the thread manager).
+ *   3. Level-1 wrappers (ECS, state machine, task flow).
+ *   4. services registered through @ref registerService.
+ *
+ * Destruction is the reverse of construction and is enforced by member
+ * declaration order in @ref AbstractContext; see that class for the
+ * exact layout.
+ *
+ * Ownership:
+ *   - Wrappers are held as @c std::unique_ptr on the concrete
+ *     aggregator; their lifetime equals the context lifetime.
+ *   - Buses and services are @c std::shared_ptr; the registry shares
+ *     ownership with whichever caller kept a handle.
+ *   - Callers never delete a resource obtained through an accessor;
+ *     the context owns them.
+ *
+ * Thread-safety: read-only accessors are safe from any thread at any
+ * time; mutating calls (createMessageBus, registerService) take the
+ * context's internal mutex. Freeze is atomic with respect to
+ * in-progress mutators: after @ref freeze returns, no mutator call
+ * completes successfully.
+ *
+ * INV-1 compliance: no template parameters on the interface or any of
+ * its methods. INV-10 compliance: the I-prefix marks a pure-virtual
+ * interface with no state and no non-virtual method bodies.
+ * INV-11 compliance: the public API exposes only wrapper interfaces
+ * and POD handles; no graph primitive types
+ * (@c NodeId, @c EdgeId, @c IGraph, ...) leak across the boundary.
  */
 class IContext
 {
   public:
     virtual ~IContext() = default;
+
+    // ------ Messaging ------
+
+    /**
+     * @brief Returns the engine-wide system bus.
+     *
+     * The system bus is created by the factory in the second step of
+     * the construction chain and lives until the aggregator is
+     * destroyed. Callers receive a reference; the bus is owned by the
+     * context through a @c std::shared_ptr stored on the concrete base.
+     */
+    [[nodiscard]] virtual messaging::IMessageBus &systemBus() = 0;
+
+    /**
+     * @brief Creates a new user bus and registers it on the context.
+     *
+     * Returns a @c std::shared_ptr so callers may keep the bus alive
+     * independently of the context's registry; the context retains its
+     * own reference in the registry so the bus survives for the
+     * duration of the context's lifetime even when callers drop their
+     * copy. Returns @c nullptr when the context is frozen; callers
+     * detect the condition through @ref isFrozen or, for a richer
+     * signal, through @ref registerService which uses an explicit
+     * @ref Result::Code::TopologyFrozen.
+     */
+    [[nodiscard]] virtual std::shared_ptr<messaging::IMessageBus>
+        createMessageBus(const messaging::BusConfig &config) = 0;
+
+    /**
+     * @brief Looks up a bus registered on this context by @p id.
+     *
+     * Returns @c nullptr when @p id is invalid, when the id is unknown
+     * to the registry, or when the registered bus has been released.
+     * The call does not take the freeze guard; lookups stay available
+     * before and after freeze.
+     */
+    [[nodiscard]] virtual std::shared_ptr<messaging::IMessageBus>
+        messageBus(messaging::BusId id) const = 0;
+
+    // ------ Level-1 wrappers ------
+
+    /**
+     * @brief Returns the engine-wide ECS.
+     *
+     * The ECS is owned by the context through a @c std::unique_ptr;
+     * callers receive a reference and never delete the returned object.
+     */
+    [[nodiscard]] virtual ecs::IECS &ecs() = 0;
+
+    /**
+     * @brief Returns the engine-wide state machine.
+     */
+    [[nodiscard]] virtual statemachine::IStateMachine &stateMachine() = 0;
+
+    /**
+     * @brief Returns the engine-wide task flow.
+     */
+    [[nodiscard]] virtual taskflow::ITaskFlow &taskFlow() = 0;
+
+    // ------ Threading ------
+
+    /**
+     * @brief Returns the engine-wide thread manager.
+     *
+     * The thread manager is the first member the aggregator builds and
+     * the last it destroys; every other wrapper depends on it, so the
+     * construction and destruction orders in @ref AbstractContext are
+     * strict.
+     */
+    [[nodiscard]] virtual threading::IThreadManager &threadManager() = 0;
+
+    // ------ Service registry ------
+
+    /**
+     * @brief Looks up a service by @p id in the registry.
+     *
+     * Returns @c nullptr when @p id is the invalid sentinel, when no
+     * service is registered under the id, or when the registered slot
+     * has been recycled (stale generation). Callers that want a
+     * non-null handle keep a @c std::shared_ptr alive themselves;
+     * @ref service returns copies of the registry's entries so the
+     * caller's reference count is independent of the registry's.
+     */
+    [[nodiscard]] virtual std::shared_ptr<service::IService>
+        service(service::ServiceId id) const = 0;
+
+    /**
+     * @brief Registers @p service on the context.
+     *
+     * The context stamps the service with a fresh @ref service::ServiceId
+     * and stores it in its registry. Callers obtain the stamped id
+     * through @c service->id() after the call returns success. Returns
+     * @ref Result::Code::TopologyFrozen when the context has been
+     * frozen; returns @ref Result::Code::Error when @p service is
+     * @c nullptr. The service is held by @c std::shared_ptr inside the
+     * registry; callers may keep or drop their own handle.
+     */
+    [[nodiscard]] virtual Result
+        registerService(std::shared_ptr<service::IService> service) = 0;
+
+    // ------ Lifecycle boundary ------
+
+    /**
+     * @brief Freezes the topology so subsequent mutators report
+     *        @ref Result::Code::TopologyFrozen.
+     *
+     * Called by the engine immediately before the main loop starts.
+     * Idempotent: a second call is a no-op. After @ref freeze returns,
+     * every @ref createMessageBus / @ref registerService call fails
+     * fast; accessors remain available.
+     */
+    virtual void freeze() noexcept = 0;
+
+    /**
+     * @brief Reports whether the topology has been frozen.
+     *
+     * Safe to call from any thread at any time. A @c true return
+     * guarantees that no further mutator call will succeed until the
+     * context is destroyed.
+     */
+    [[nodiscard]] virtual bool isFrozen() const noexcept = 0;
 
     IContext(const IContext &)            = delete;
     IContext &operator=(const IContext &) = delete;

--- a/include/vigine/result.h
+++ b/include/vigine/result.h
@@ -29,7 +29,15 @@ class Result
         //                          null or the registered target has
         //                          already been torn down.
         SubscriptionExpired,
-        InvalidMessageTarget
+        InvalidMessageTarget,
+        // Appended for the context aggregator (R.4.5). Append-only;
+        // existing numeric values above are frozen.
+        // TopologyFrozen -- reported when a caller invokes a mutating
+        //                   IContext method (createMessageBus,
+        //                   registerService) after the engine has
+        //                   frozen the context topology. Mutation
+        //                   is blocked; reads remain available.
+        TopologyFrozen
     };
 
     Result();

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -1,16 +1,26 @@
 #include "vigine/context.h"
 
+#include "vigine/ecs/iecs.h"
 #include "vigine/ecs/platform/windowsystem.h"
 #if VIGINE_POSTGRESQL
 #include "vigine/ecs/postgresql/postgresqlsystem.h"
 #endif
 #include "vigine/ecs/render/rendersystem.h"
+#include "vigine/messaging/busconfig.h"
+#include "vigine/messaging/busid.h"
+#include "vigine/messaging/imessagebus.h"
 #include "vigine/property.h"
+#include "vigine/result.h"
 #include "vigine/service/databaseservice.h"
 #include "vigine/service/graphicsservice.h"
+#include "vigine/service/iservice.h"
 #include "vigine/service/platformservice.h"
+#include "vigine/statemachine/istatemachine.h"
+#include "vigine/taskflow/itaskflow.h"
+#include "vigine/threading/ithreadmanager.h"
 
 #include <algorithm>
+#include <stdexcept>
 #include <utility>
 
 vigine::AbstractSystem *vigine::Context::system(const SystemId id, const SystemName name,
@@ -148,4 +158,80 @@ vigine::AbstractServiceUPtr vigine::Context::createService(const ServiceId &id, 
     }
 
     return nullptr;
+}
+
+// ---------------------------------------------------------------------------
+// Legacy Context — IContext aggregator stubs.
+//
+// Post R.4.5 the IContext interface became the full engine aggregator. The
+// legacy Context does not own a thread manager, system bus, or Level-1
+// wrappers, so these accessors either throw (references must be non-null)
+// or return empty handles. Callers that need the real aggregator go through
+// vigine::context::createContext.
+// ---------------------------------------------------------------------------
+
+vigine::messaging::IMessageBus &vigine::Context::systemBus()
+{
+    throw std::logic_error{
+        "legacy vigine::Context has no system bus; use vigine::context::createContext"};
+}
+
+std::shared_ptr<vigine::messaging::IMessageBus>
+vigine::Context::createMessageBus(const vigine::messaging::BusConfig & /*config*/)
+{
+    return nullptr;
+}
+
+std::shared_ptr<vigine::messaging::IMessageBus>
+vigine::Context::messageBus(vigine::messaging::BusId /*id*/) const
+{
+    return nullptr;
+}
+
+vigine::ecs::IECS &vigine::Context::ecs()
+{
+    throw std::logic_error{
+        "legacy vigine::Context has no Level-1 ECS wrapper; use vigine::context::createContext"};
+}
+
+vigine::statemachine::IStateMachine &vigine::Context::stateMachine()
+{
+    throw std::logic_error{
+        "legacy vigine::Context has no Level-1 state machine wrapper; use vigine::context::createContext"};
+}
+
+vigine::taskflow::ITaskFlow &vigine::Context::taskFlow()
+{
+    throw std::logic_error{
+        "legacy vigine::Context has no Level-1 task flow wrapper; use vigine::context::createContext"};
+}
+
+vigine::threading::IThreadManager &vigine::Context::threadManager()
+{
+    throw std::logic_error{
+        "legacy vigine::Context has no thread manager; use vigine::context::createContext"};
+}
+
+std::shared_ptr<vigine::service::IService>
+vigine::Context::service(vigine::service::ServiceId /*id*/) const
+{
+    return nullptr;
+}
+
+vigine::Result
+vigine::Context::registerService(std::shared_ptr<vigine::service::IService> /*service*/)
+{
+    return Result{
+        Result::Code::Error,
+        "legacy vigine::Context does not accept service registrations; use vigine::context::createContext"};
+}
+
+void vigine::Context::freeze() noexcept
+{
+    _frozen = true;
+}
+
+bool vigine::Context::isFrozen() const noexcept
+{
+    return _frozen;
 }

--- a/src/context/abstractcontext.cpp
+++ b/src/context/abstractcontext.cpp
@@ -1,0 +1,234 @@
+#include "vigine/context/abstractcontext.h"
+
+#include <mutex>
+#include <utility>
+
+#include "vigine/ecs/factory.h"
+#include "vigine/messaging/factory.h"
+#include "vigine/statemachine/factory.h"
+#include "vigine/taskflow/factory.h"
+#include "vigine/threading/factory.h"
+
+namespace vigine::context
+{
+
+AbstractContext::AbstractContext(const ContextConfig &config)
+    // Step 1: thread manager first. Built before the initialiser list
+    // touches any other wrapper so every downstream step has a live
+    // thread manager reference to bind to.
+    : _threadManager{threading::createThreadManager(config.threading)}
+    // Step 2: system bus next. Takes the thread manager by reference so
+    // its dispatch worker can schedule on the engine pool. The factory
+    // returns a unique_ptr; we lift it into a shared_ptr so facades
+    // and services can keep an independent handle.
+    , _systemBus{std::shared_ptr<messaging::IMessageBus>{
+          messaging::createMessageBus(config.systemBus, *_threadManager).release()}}
+    // Steps 3--5: Level-1 wrappers from their default factories. Each
+    // is self-contained; the default factories auto-provision the
+    // minimum state callers need (e.g. the state machine registers one
+    // default state per UD-3).
+    , _ecs{ecs::createECS()}
+    , _stateMachine{statemachine::createStateMachine()}
+    , _taskFlow{taskflow::createTaskFlow()}
+// Steps 6--8: empty registries + cleared freeze flag are covered by
+// the member default initialisers declared on @c AbstractContext.
+{
+}
+
+AbstractContext::~AbstractContext() = default;
+
+// ---------------------------------------------------------------------
+// Messaging
+// ---------------------------------------------------------------------
+
+messaging::IMessageBus &AbstractContext::systemBus()
+{
+    return *_systemBus;
+}
+
+std::shared_ptr<messaging::IMessageBus>
+AbstractContext::createMessageBus(const messaging::BusConfig &config)
+{
+    // The freeze guard is checked under the registry mutex so a
+    // concurrent freeze() call either blocks until this registration
+    // completes (and then freezes the topology for future callers) or
+    // arrives first and forces this call to fail fast. There is no
+    // window where a bus gets registered after the flag is set.
+    std::scoped_lock lock{_registryMutex};
+    if (_frozen.load(std::memory_order_acquire))
+    {
+        return nullptr;
+    }
+
+    auto bus = messaging::createMessageBus(config, *_threadManager);
+    if (!bus)
+    {
+        return nullptr;
+    }
+
+    std::shared_ptr<messaging::IMessageBus> shared{bus.release()};
+    _userBuses.emplace(shared->id().value, shared);
+    return shared;
+}
+
+std::shared_ptr<messaging::IMessageBus>
+AbstractContext::messageBus(messaging::BusId id) const
+{
+    if (!id.valid())
+    {
+        return nullptr;
+    }
+
+    // The system bus answers to its own id first; fall through to the
+    // user-bus registry when the id does not match the system bus so
+    // callers can look up both kinds through one entry point.
+    if (_systemBus && _systemBus->id() == id)
+    {
+        return _systemBus;
+    }
+
+    std::scoped_lock lock{_registryMutex};
+    auto it = _userBuses.find(id.value);
+    if (it == _userBuses.end())
+    {
+        return nullptr;
+    }
+    return it->second;
+}
+
+// ---------------------------------------------------------------------
+// Level-1 wrappers
+// ---------------------------------------------------------------------
+
+ecs::IECS &AbstractContext::ecs()
+{
+    return *_ecs;
+}
+
+statemachine::IStateMachine &AbstractContext::stateMachine()
+{
+    return *_stateMachine;
+}
+
+taskflow::ITaskFlow &AbstractContext::taskFlow()
+{
+    return *_taskFlow;
+}
+
+// ---------------------------------------------------------------------
+// Threading
+// ---------------------------------------------------------------------
+
+threading::IThreadManager &AbstractContext::threadManager()
+{
+    return *_threadManager;
+}
+
+// ---------------------------------------------------------------------
+// Service registry
+// ---------------------------------------------------------------------
+
+std::shared_ptr<service::IService>
+AbstractContext::service(service::ServiceId id) const
+{
+    if (!id.valid())
+    {
+        return nullptr;
+    }
+
+    // The registry is keyed on @c ServiceId::index; generation is not
+    // recycled at this leaf (no @c unregisterService), so every issued
+    // id maps to exactly one registered slot for the context's
+    // lifetime. Looking up by index alone is sufficient until a later
+    // leaf introduces generational slot recycling.
+    std::scoped_lock lock{_registryMutex};
+    auto it = _services.find(id.index);
+    if (it == _services.end())
+    {
+        return nullptr;
+    }
+    return it->second;
+}
+
+Result AbstractContext::registerService(std::shared_ptr<service::IService> service)
+{
+    if (!service)
+    {
+        return Result{Result::Code::Error, "registerService: service is null"};
+    }
+
+    std::scoped_lock lock{_registryMutex};
+    if (_frozen.load(std::memory_order_acquire))
+    {
+        return Result{
+            Result::Code::TopologyFrozen,
+            "registerService: context is frozen after Engine::run()"};
+    }
+
+    // The aggregator stamps a fresh id on every registration; concrete
+    // services expose the stamped id through their own id() accessor
+    // after registration. The @c AbstractService base supplies a
+    // @c protected setter that concrete closers wire through their
+    // container; that plumbing is outside the context's scope, so the
+    // aggregator holds the shared_ptr unchanged and lets the service
+    // respond to future id() calls with its own default sentinel until
+    // a later leaf introduces the container. The registry uses the
+    // locally-allocated index as the lookup key so lookup does not
+    // depend on id() agreeing with what we stamped.
+    const service::ServiceId stamped = allocateServiceId();
+    _services.emplace(stamped.index, std::move(service));
+    return Result{};
+}
+
+// ---------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------
+
+void AbstractContext::freeze() noexcept
+{
+    // Serialise against in-flight mutators so the topology is either
+    // fully mutated pre-freeze or fully rejected post-freeze. The
+    // scoped_lock makes the freeze point a strict boundary.
+    std::scoped_lock lock{_registryMutex};
+    _frozen.store(true, std::memory_order_release);
+}
+
+bool AbstractContext::isFrozen() const noexcept
+{
+    return _frozen.load(std::memory_order_acquire);
+}
+
+// ---------------------------------------------------------------------
+// Protected helpers
+// ---------------------------------------------------------------------
+
+std::size_t AbstractContext::nextServiceIndex() const noexcept
+{
+    // Read without the lock; callers who need a monotonically-stable
+    // reading relative to a registration should hold their own mutex.
+    return _nextServiceIndex;
+}
+
+// ---------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------
+
+service::ServiceId AbstractContext::allocateServiceId() noexcept
+{
+    // Called under _registryMutex by @ref registerService. Non-zero
+    // generation guarantees @ref ServiceId::valid returns true on the
+    // issued handle.
+    service::ServiceId id{_nextServiceIndex, _serviceGeneration};
+    ++_nextServiceIndex;
+    ++_serviceGeneration;
+    if (_serviceGeneration == 0)
+    {
+        // Wrap-around guard: skip the invalid sentinel generation so
+        // no future id accidentally compares equal to the default
+        // @c ServiceId{}.
+        _serviceGeneration = 1;
+    }
+    return id;
+}
+
+} // namespace vigine::context

--- a/src/context/defaultcontext.cpp
+++ b/src/context/defaultcontext.cpp
@@ -1,0 +1,13 @@
+#include "context/defaultcontext.h"
+
+namespace vigine::context
+{
+
+DefaultContext::DefaultContext(const ContextConfig &config)
+    : AbstractContext{config}
+{
+}
+
+DefaultContext::~DefaultContext() = default;
+
+} // namespace vigine::context

--- a/src/context/defaultcontext.h
+++ b/src/context/defaultcontext.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "vigine/context/abstractcontext.h"
+#include "vigine/context/contextconfig.h"
+
+namespace vigine::context
+{
+/**
+ * @brief Minimal concrete aggregator that seals the wrapper recipe.
+ *
+ * @ref DefaultContext exists so @ref createContext can return a real
+ * owning @c std::unique_ptr<IContext>. It carries no domain-specific
+ * behaviour; its accessors fall through to @ref AbstractContext. The
+ * class is @c final to close the inheritance chain for this leaf;
+ * follow-up leaves that ship specialised contexts (e.g. test fixtures,
+ * embedded harnesses) derive from @ref AbstractContext directly and
+ * supply their own factory entry points.
+ */
+class DefaultContext final : public AbstractContext
+{
+  public:
+    explicit DefaultContext(const ContextConfig &config);
+    ~DefaultContext() override;
+
+    DefaultContext(const DefaultContext &)            = delete;
+    DefaultContext &operator=(const DefaultContext &) = delete;
+    DefaultContext(DefaultContext &&)                 = delete;
+    DefaultContext &operator=(DefaultContext &&)      = delete;
+};
+
+} // namespace vigine::context

--- a/src/context/factory.cpp
+++ b/src/context/factory.cpp
@@ -1,0 +1,21 @@
+#include "vigine/context/factory.h"
+
+#include <memory>
+
+#include "context/defaultcontext.h"
+
+namespace vigine::context
+{
+
+// The factory is intentionally non-templated. unique_ptr ownership
+// (FF-1) -- not shared_ptr -- because the context is a singular owner
+// inside the engine construction chain; callers that need shared
+// ownership can lift the returned pointer into a shared_ptr at the
+// call site.
+
+std::unique_ptr<IContext> createContext(const ContextConfig &config)
+{
+    return std::make_unique<DefaultContext>(config);
+}
+
+} // namespace vigine::context


### PR DESCRIPTION
Ships the engine-entry-point aggregator per plan_14 + UD-9.

## What lands

- `IContext` (pure-virtual, `namespace vigine`) — accessors for thread manager, system bus, ECS, state machine, task flow, and a service locator (`service` + `registerService`). Plus `createMessageBus`/`messageBus` for user buses, and `freeze`/`isFrozen` for the topology boundary.
- `AbstractContext` (stateful base, `namespace vigine::context`) — owns the thread manager, system bus, and Level-1 wrappers through `std::unique_ptr`/`std::shared_ptr`. Member declaration order encodes the strict construction order (thread manager first, system bus second, Level-1 wrappers third); destruction is the automatic reverse.
- `DefaultContext final : AbstractContext` — concrete closer.
- `ContextConfig` POD — `ThreadManagerConfig` + default system `BusConfig`.
- `createContext(const ContextConfig&)` — factory returning `std::unique_ptr<IContext>` (FF-1).
- `Result::Code::TopologyFrozen` — append-only new enum value reported by `registerService` once `freeze()` has been called.
- Legacy `vigine::Context` receives minimal override stubs so the old engine path keeps compiling.

## Freeze semantics

`freeze()` + every mutator (`createMessageBus`, `registerService`) take the context's internal mutex. A successful freeze + a concurrent mutator either serialise cleanly (mutation wins, next mutation reports `TopologyFrozen`) or the freeze arrives first (mutation fails fast). Read-only accessors never block.

## Invariants

- INV-1 — no templates on the context public surface (`scripts/check_no_templates.py --path include/vigine/context/` is clean).
- INV-9 — `include/vigine/context/` pulls in messaging/threading/wrapper headers (it is the aggregator) but zero graph primitives (`NodeId`, `EdgeId`, `IGraph`, ...).
- INV-10 — `IContext` is pure-virtual, `AbstractContext` carries state, `DefaultContext` seals the chain; naming checker is clean on the new files.
- Strict encapsulation — every data member private; derived classes reach through protected accessors.

## Build

`cmake --build build --config Debug` and `--config Release` build clean under `/W4 /permissive-` on MSVC. The only warnings are pre-existing in `meshcomponent.h` / `rendercomponent.cpp` / `vulkanapi.cpp` / `abstractpayloadregistry.cpp` on `main`.

Closes #116