### PR TITLE
build(ci): add check_wrapper_encapsulation.py static checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,20 @@ jobs:
       - name: Run check_naming_convention
         run: python scripts/check_naming_convention.py --root .
 
+  wrapper-encapsulation:
+    name: Wrapper encapsulation check (INV-11)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run check_wrapper_encapsulation
+        run: python scripts/check_wrapper_encapsulation.py --root .
+
   unit-tests-scripts:
     name: Script unit tests
     runs-on: ubuntu-latest
@@ -54,6 +68,9 @@ jobs:
 
       - name: Run test_check_naming_convention
         run: pytest test/scripts/test_check_naming_convention.py -q
+
+      - name: Run test_check_wrapper_encapsulation
+        run: pytest test/scripts/test_check_wrapper_encapsulation.py -q
 
   # Three-OS build matrix. Every cell runs a Debug and a Release build
   # under the project baseline (CMake 3.25, C++23, Vulkan 1.3). vcpkg

--- a/include/vigine/ecs/kind.h
+++ b/include/vigine/ecs/kind.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <vigine/graph/kind.h>
+#include <vigine/graph/kind.h>  // INV-11 EXEMPTION: kind.h maps wrapper constants onto graph substrate ranges
 
 // wrapper-kind-waiver: engine-concept kind constants in a wrapper subspace.
 
@@ -15,8 +15,8 @@ namespace vigine::ecs
  */
 namespace kind
 {
-inline constexpr vigine::graph::NodeKind Entity = 32;
-inline constexpr vigine::graph::NodeKind Component = 33;
+inline constexpr vigine::graph::NodeKind Entity = 32;    // INV-11 EXEMPTION: kind constant mapping
+inline constexpr vigine::graph::NodeKind Component = 33; // INV-11 EXEMPTION: kind constant mapping
 } // namespace kind
 
 /**
@@ -26,7 +26,7 @@ inline constexpr vigine::graph::NodeKind Component = 33;
  */
 namespace edge_kind
 {
-inline constexpr vigine::graph::EdgeKind Attached = 32;
+inline constexpr vigine::graph::EdgeKind Attached = 32;  // INV-11 EXEMPTION: kind constant mapping
 } // namespace edge_kind
 
 } // namespace vigine::ecs

--- a/include/vigine/messaging/abstractmessagebus.h
+++ b/include/vigine/messaging/abstractmessagebus.h
@@ -11,7 +11,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include "vigine/graph/abstractgraph.h"
+#include "vigine/graph/abstractgraph.h"  // INV-11 EXEMPTION: AbstractMessageBus inherits graph substrate for internal routing
 #include "vigine/messaging/busconfig.h"
 #include "vigine/messaging/busid.h"
 #include "vigine/messaging/connectionid.h"
@@ -81,7 +81,7 @@ class DefaultBusControlBlock;
  */
 class AbstractMessageBus
     : public IMessageBus
-    , protected vigine::graph::AbstractGraph
+    , protected vigine::graph::AbstractGraph  // INV-11 EXEMPTION: routing substrate is an internal implementation detail
 {
   public:
     ~AbstractMessageBus() override;

--- a/include/vigine/messaging/kind.h
+++ b/include/vigine/messaging/kind.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <vigine/graph/kind.h>
+#include <vigine/graph/kind.h>  // INV-11 EXEMPTION: kind.h maps wrapper constants onto graph substrate ranges
 
 // wrapper-kind-waiver: engine-concept kind constants in a wrapper subspace.
 
@@ -15,8 +15,8 @@ namespace vigine::messaging
  */
 namespace kind
 {
-inline constexpr vigine::graph::NodeKind Target = 16;
-inline constexpr vigine::graph::NodeKind Subscription = 17;
+inline constexpr vigine::graph::NodeKind Target = 16;       // INV-11 EXEMPTION: kind constant mapping
+inline constexpr vigine::graph::NodeKind Subscription = 17; // INV-11 EXEMPTION: kind constant mapping
 } // namespace kind
 
 /**
@@ -26,7 +26,7 @@ inline constexpr vigine::graph::NodeKind Subscription = 17;
  */
 namespace edge_kind
 {
-inline constexpr vigine::graph::EdgeKind Subscription = 16;
+inline constexpr vigine::graph::EdgeKind Subscription = 16; // INV-11 EXEMPTION: kind constant mapping
 } // namespace edge_kind
 
 } // namespace vigine::messaging

--- a/include/vigine/taskflow/kind.h
+++ b/include/vigine/taskflow/kind.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <vigine/graph/kind.h>
+#include <vigine/graph/kind.h>  // INV-11 EXEMPTION: kind.h maps wrapper constants onto graph substrate ranges
 
 // wrapper-kind-waiver: engine-concept kind constants in a wrapper subspace.
 
@@ -15,7 +15,7 @@ namespace vigine::taskflow
  */
 namespace kind
 {
-inline constexpr vigine::graph::NodeKind Task = 64;
+inline constexpr vigine::graph::NodeKind Task = 64;       // INV-11 EXEMPTION: kind constant mapping
 } // namespace kind
 
 /**
@@ -25,7 +25,7 @@ inline constexpr vigine::graph::NodeKind Task = 64;
  */
 namespace edge_kind
 {
-inline constexpr vigine::graph::EdgeKind Transition = 64;
+inline constexpr vigine::graph::EdgeKind Transition = 64; // INV-11 EXEMPTION: kind constant mapping
 } // namespace edge_kind
 
 } // namespace vigine::taskflow

--- a/scripts/check_wrapper_encapsulation.py
+++ b/scripts/check_wrapper_encapsulation.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""check_wrapper_encapsulation.py -- Static checker for wrapper encapsulation (INV-11).
+
+Scans public wrapper headers under include/vigine/<domain>/ and fails
+when any header references graph-substrate types or namespaces.  Two
+modes are available:
+
+  --mode wrapper (default)
+      Checks Level-1 wrapper headers.  Forbidden tokens are the core
+      graph primitive names and namespace qualifiers.
+
+  --mode facade
+      Extends the forbidden list with Level-2 facade-specific tokens
+      that must never bleed through into facade public headers.
+
+Exit codes:
+  0 -- all scanned files clean.
+  1 -- at least one violation found (or a required path was not found).
+
+Waiver: a line containing ``// INV-11 EXEMPTION:`` is skipped without
+error.  For class-scoped waivers place the marker on the class
+declaration line; the checker skips that entire class body including
+nested types.
+
+Standard-library Python only; no third-party runtime dependencies.
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+WAIVER_MARKER = "// INV-11 EXEMPTION:"
+
+# Default scan roots relative to repo root -- one entry per wrapper domain.
+DEFAULT_WRAPPER_PATHS: list[str] = [
+    "include/vigine/service",
+    "include/vigine/ecs",
+    "include/vigine/statemachine",
+    "include/vigine/taskflow",
+    "include/vigine/context",
+    "include/vigine/messaging",
+    "include/vigine/payload",
+    "include/vigine/threading",
+]
+
+# File extensions treated as C++ headers.
+EXTENSIONS: frozenset[str] = frozenset({".h", ".hpp", ".hxx"})
+
+# ---------------------------------------------------------------------------
+# Forbidden token lists
+# ---------------------------------------------------------------------------
+
+# Level-1 wrapper forbidden identifiers (word-boundary match).
+_WRAPPER_IDENTIFIERS: list[str] = [
+    "NodeId",
+    "EdgeId",
+    "IGraph",
+    "INode",
+    "IEdge",
+    "IEdgeData",
+    "IGraphVisitor",
+    "IGraphQuery",
+    "AbstractGraph",
+    "EdgeData",
+    "TraverseMode",
+]
+
+# Substring tokens for Level-1 (namespace qualifiers and include paths).
+_WRAPPER_SUBSTRINGS: list[str] = [
+    "vigine::graph::",
+    "<vigine/graph/",
+]
+
+# Additional identifiers forbidden in Level-2 facade headers.
+_FACADE_EXTRA_IDENTIFIERS: list[str] = [
+    "IBusControlBlock",
+    "IConnectionToken",
+]
+
+# Additional substring tokens for Level-2 facades.
+_FACADE_EXTRA_SUBSTRINGS: list[str] = [
+    "vigine::graph::kind::",
+]
+
+# ---------------------------------------------------------------------------
+# Pattern builders
+# ---------------------------------------------------------------------------
+
+# Matches lines that are entirely within a comment block.
+_BLOCK_COMMENT_LINE = re.compile(r"^\s*/?\*")
+_LINE_COMMENT       = re.compile(r"^\s*//")
+
+# Matches the opening of a class/struct definition (not a forward decl).
+_CLASS_OPEN_RE = re.compile(r"^\s*(?:class|struct)\s+(\w+)")
+
+
+def _is_comment_line(line: str) -> bool:
+    """Return True when the line starts with a comment marker."""
+    return bool(_BLOCK_COMMENT_LINE.match(line) or _LINE_COMMENT.match(line))
+
+
+def _build_patterns(
+    identifiers: list[str],
+    substrings: list[str],
+) -> list[tuple[str, re.Pattern]]:
+    """Return (token, compiled_pattern) pairs for all forbidden tokens."""
+    pairs: list[tuple[str, re.Pattern]] = []
+    for token in identifiers:
+        pairs.append((token, re.compile(r"\b" + re.escape(token) + r"\b")))
+    for token in substrings:
+        pairs.append((token, re.compile(re.escape(token))))
+    return pairs
+
+
+# ---------------------------------------------------------------------------
+# Body extractor (supports class-level waiver)
+# ---------------------------------------------------------------------------
+
+def _strip_line_comment(line: str) -> str:
+    """Remove trailing // comment; crude but sufficient for brace counting."""
+    pos = line.find("//")
+    return line[:pos] if pos >= 0 else line
+
+
+def _find_class_body_end(lines: list[str], start: int) -> int | None:
+    """Return the 0-based index of the closing '}' line for the class at *start*.
+
+    Returns None when no opening brace is found (forward declaration).
+    """
+    depth = 0
+    found_open = False
+    for idx in range(start, len(lines)):
+        sc = _strip_line_comment(lines[idx])
+        opens  = sc.count("{")
+        closes = sc.count("}")
+        if not found_open:
+            if opens > 0:
+                found_open = True
+            elif ";" in sc:
+                return None  # Forward declaration.
+        if found_open:
+            depth += opens - closes
+            if depth <= 0:
+                return idx
+    return None
+
+
+# ---------------------------------------------------------------------------
+# File scanner
+# ---------------------------------------------------------------------------
+
+def scan_file(
+    path: Path,
+    patterns: list[tuple[str, re.Pattern]],
+    quiet: bool,
+) -> list[str]:
+    """Return violation strings for *path* (empty when clean)."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        msg = f"{path}: encoding error -- {exc}"
+        if not quiet:
+            print(msg, file=sys.stderr)
+        return [msg]
+
+    lines = text.splitlines()
+    violations: list[str] = []
+    skip_until: int = -1  # End index (inclusive) of a waiived class body.
+
+    idx = 0
+    while idx < len(lines):
+        # Skip waiived class body (set below when a class carries the marker).
+        if skip_until >= 0 and idx <= skip_until:
+            idx += 1
+            continue
+
+        skip_until = -1  # Reset once past the waiived block.
+        raw    = lines[idx]
+        lineno = idx + 1
+
+        # A line with the waiver marker is always safe.  If the marker appears
+        # on a class declaration line we also skip the entire class body so
+        # nested types cannot trigger false reports.
+        if WAIVER_MARKER in raw:
+            # Try to swallow the class body that follows (if this is a class decl).
+            end = _find_class_body_end(lines, idx)
+            if end is not None:
+                skip_until = end
+            idx += 1
+            continue
+
+        # Pure comment lines cannot introduce real dependencies.
+        if _is_comment_line(raw):
+            idx += 1
+            continue
+
+        # Check every forbidden token.
+        for token, pat in patterns:
+            if pat.search(raw):
+                msg = f"{path}:{lineno}: {token}"
+                violations.append(msg)
+                if not quiet:
+                    print(msg)
+                break  # One report per line is enough.
+
+        idx += 1
+
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Directory scanner
+# ---------------------------------------------------------------------------
+
+def scan_paths(
+    scan_roots: list[Path],
+    patterns: list[tuple[str, re.Pattern]],
+    quiet: bool,
+) -> tuple[int, int]:
+    """Scan all roots; return (files_scanned, violation_count)."""
+    files_scanned   = 0
+    violation_count = 0
+    for root in scan_roots:
+        if not root.exists():
+            msg = f"check_wrapper_encapsulation: path not found: {root}"
+            print(msg, file=sys.stderr)
+            violation_count += 1
+            continue
+        for p in sorted(root.rglob("*")):
+            if p.suffix not in EXTENSIONS or not p.is_file():
+                continue
+            files_scanned += 1
+            hits = scan_file(p, patterns, quiet)
+            violation_count += len(hits)
+    return files_scanned, violation_count
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Check INV-11 wrapper encapsulation: wrapper/facade public headers "
+            "must not reference graph-substrate types or namespaces."
+        )
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=None,
+        help="Repo root (default: parent of the directory containing this script).",
+    )
+    parser.add_argument(
+        "--path",
+        dest="extra_paths",
+        action="append",
+        type=Path,
+        default=[],
+        help=(
+            "Path to scan (can be repeated). "
+            "When provided, replaces the default wrapper paths."
+        ),
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["wrapper", "facade"],
+        default="wrapper",
+        help=(
+            "Checking mode: 'wrapper' (default) checks Level-1 headers; "
+            "'facade' extends the forbidden list for Level-2 facade headers."
+        ),
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress per-violation output; print only the summary line.",
+    )
+    args = parser.parse_args(argv)
+
+    # Resolve repo root.
+    if args.root is not None:
+        repo_root = args.root.resolve()
+    else:
+        repo_root = Path(__file__).resolve().parent.parent
+
+    # Resolve scan roots.
+    if args.extra_paths:
+        scan_roots = [
+            p if p.is_absolute() else repo_root / p
+            for p in args.extra_paths
+        ]
+    else:
+        scan_roots = [repo_root / d for d in DEFAULT_WRAPPER_PATHS]
+
+    # Build forbidden-token patterns.
+    identifiers = list(_WRAPPER_IDENTIFIERS)
+    substrings  = list(_WRAPPER_SUBSTRINGS)
+    if args.mode == "facade":
+        identifiers += _FACADE_EXTRA_IDENTIFIERS
+        substrings  += _FACADE_EXTRA_SUBSTRINGS
+
+    patterns = _build_patterns(identifiers, substrings)
+
+    files_scanned, violation_count = scan_paths(scan_roots, patterns, args.quiet)
+
+    summary = (
+        f"check_wrapper_encapsulation: {files_scanned} files scanned, "
+        f"{violation_count} violations"
+    )
+    print(summary)
+
+    return 0 if violation_count == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/scripts/test_check_wrapper_encapsulation.py
+++ b/test/scripts/test_check_wrapper_encapsulation.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Unit tests for check_wrapper_encapsulation.py.
+
+Six test cases per plan_28:
+
+  1. Wrapper mode clean   -- a directory with no forbidden tokens exits 0.
+  2. Wrapper mode violation -- NodeId in a service header triggers exit 1.
+  3. Waiver respected      -- // INV-11 EXEMPTION: on a violating line is skipped.
+  4. Facade mode clean     -- a directory with no forbidden facade tokens exits 0.
+  5. Facade mode violation -- IBusControlBlock in a facade header triggers exit 1.
+  6. Facade waiver         -- facade token covered by // INV-11 EXEMPTION: is skipped.
+
+Each test uses a temporary directory so tests are fully isolated and
+leave no state behind.
+"""
+
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+# Make the scripts/ directory importable without installing the package.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "scripts"))
+
+import check_wrapper_encapsulation as cwe  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write(tmp: Path, rel: str, content: str) -> Path:
+    """Create a file at *tmp/rel* with the given (dedented) content."""
+    p = tmp / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(textwrap.dedent(content), encoding="utf-8")
+    return p
+
+
+def _run(argv: list[str]) -> int:
+    """Invoke cwe.main() and return the exit code."""
+    return cwe.main(argv)
+
+
+# ---------------------------------------------------------------------------
+# Test 1: wrapper mode -- clean directory
+# ---------------------------------------------------------------------------
+
+
+def test_wrapper_clean(tmp_path: Path) -> None:
+    """A service header with no graph types exits 0 (wrapper mode default)."""
+    svc_dir = tmp_path / "include" / "vigine" / "service"
+    svc_dir.mkdir(parents=True)
+    _write(
+        svc_dir,
+        "iwidget.h",
+        """\
+        #pragma once
+        #include <memory>
+        #include "vigine/service/serviceid.h"
+
+        namespace vigine::service {
+        class IWidget {
+        public:
+            virtual ~IWidget() = default;
+            virtual int value() const noexcept = 0;
+        };
+        } // namespace vigine::service
+        """,
+    )
+    assert _run(["--path", str(svc_dir), "--quiet"]) == 0
+
+
+# ---------------------------------------------------------------------------
+# Test 2: wrapper mode -- violation (NodeId)
+# ---------------------------------------------------------------------------
+
+
+def test_wrapper_violation_node_id(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """NodeId in a wrapper header triggers exit 1 with a path:line diagnostic."""
+    svc_dir = tmp_path / "include" / "vigine" / "service"
+    svc_dir.mkdir(parents=True)
+    _write(
+        svc_dir,
+        "ibadsurface.h",
+        """\
+        #pragma once
+        #include "vigine/service/serviceid.h"
+
+        namespace vigine::service {
+        class IBadSurface {
+        public:
+            virtual ~IBadSurface() = default;
+            virtual NodeId nodeRef() const = 0;
+        };
+        } // namespace vigine::service
+        """,
+    )
+    code = _run(["--path", str(svc_dir)])
+    out  = capsys.readouterr().out
+    assert code == 1, "Expected exit 1 for NodeId in wrapper header"
+    assert "ibadsurface.h" in out
+    assert "NodeId" in out
+
+
+# ---------------------------------------------------------------------------
+# Test 3: waiver respected (wrapper mode)
+# ---------------------------------------------------------------------------
+
+
+def test_wrapper_waiver_respected(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """A line containing // INV-11 EXEMPTION: is not reported as a violation."""
+    svc_dir = tmp_path / "include" / "vigine" / "service"
+    svc_dir.mkdir(parents=True)
+    _write(
+        svc_dir,
+        "iwaivedservice.h",
+        """\
+        #pragma once
+        #include "vigine/service/serviceid.h"
+
+        namespace vigine::service {
+        class IWaivedService {
+        public:
+            virtual ~IWaivedService() = default;
+            virtual NodeId nodeRef() const = 0;  // INV-11 EXEMPTION: legacy cross-layer pinning, approved by arch
+        };
+        } // namespace vigine::service
+        """,
+    )
+    code = _run(["--path", str(svc_dir), "--quiet"])
+    out  = capsys.readouterr().out
+    assert code == 0, "Expected exit 0 when the only violation carries a waiver"
+    assert "0 violations" in out
+
+
+# ---------------------------------------------------------------------------
+# Test 4: facade mode -- clean directory
+# ---------------------------------------------------------------------------
+
+
+def test_facade_clean(tmp_path: Path) -> None:
+    """A facade header with no forbidden tokens exits 0 in facade mode."""
+    facade_dir = tmp_path / "include" / "vigine" / "signalemitter"
+    facade_dir.mkdir(parents=True)
+    _write(
+        facade_dir,
+        "isignalemitter.h",
+        """\
+        #pragma once
+        #include <memory>
+
+        namespace vigine::signalemitter {
+        class ISignalEmitter {
+        public:
+            virtual ~ISignalEmitter() = default;
+            virtual void emit(int signal) = 0;
+        };
+        } // namespace vigine::signalemitter
+        """,
+    )
+    assert _run(["--path", str(facade_dir), "--mode", "facade", "--quiet"]) == 0
+
+
+# ---------------------------------------------------------------------------
+# Test 5: facade mode -- violation (IBusControlBlock)
+# ---------------------------------------------------------------------------
+
+
+def test_facade_violation_bus_control_block(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """IBusControlBlock in a facade header triggers exit 1 in facade mode."""
+    facade_dir = tmp_path / "include" / "vigine" / "connector"
+    facade_dir.mkdir(parents=True)
+    _write(
+        facade_dir,
+        "iconnector.h",
+        """\
+        #pragma once
+        #include <memory>
+
+        namespace vigine::connector {
+        class IConnector {
+        public:
+            virtual ~IConnector() = default;
+            virtual void attach(IBusControlBlock &bus) = 0;
+        };
+        } // namespace vigine::connector
+        """,
+    )
+    code = _run(["--path", str(facade_dir), "--mode", "facade"])
+    out  = capsys.readouterr().out
+    assert code == 1, "Expected exit 1 for IBusControlBlock in facade header"
+    assert "iconnector.h" in out
+    assert "IBusControlBlock" in out
+
+
+# ---------------------------------------------------------------------------
+# Test 6: facade mode -- waiver respected
+# ---------------------------------------------------------------------------
+
+
+def test_facade_waiver_respected(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """A facade token covered by // INV-11 EXEMPTION: is skipped in facade mode."""
+    facade_dir = tmp_path / "include" / "vigine" / "hub"
+    facade_dir.mkdir(parents=True)
+    _write(
+        facade_dir,
+        "ihub.h",
+        """\
+        #pragma once
+        #include <memory>
+
+        namespace vigine::hub {
+        class IHub {
+        public:
+            virtual ~IHub() = default;
+            virtual void attach(IBusControlBlock &bus) = 0;  // INV-11 EXEMPTION: hub is the integration seam
+        };
+        } // namespace vigine::hub
+        """,
+    )
+    code = _run(["--path", str(facade_dir), "--mode", "facade", "--quiet"])
+    out  = capsys.readouterr().out
+    assert code == 0, "Expected exit 0 when the only violation carries a facade waiver"
+    assert "0 violations" in out


### PR DESCRIPTION
Adds `scripts/check_wrapper_encapsulation.py` — a static checker that
scans every wrapper public header folder (`service/`, `ecs/`,
`statemachine/`, `taskflow/`, `context/`, `messaging/`, `payload/`,
`threading/`) and fails when any header references graph-substrate types
(`NodeId`, `EdgeId`, `IGraph`, `INode`, `IEdge`, `AbstractGraph`,
`vigine::graph::`, etc.).

Two modes:
- `--mode wrapper` (default): Level-1 forbidden list.
- `--mode facade`: extends with `IBusControlBlock`, `IConnectionToken`,
  `vigine::graph::kind::`.

Waiver marker: `// INV-11 EXEMPTION:` — skips a line (or a whole class
body when placed on the class declaration line).

Adds `// INV-11 EXEMPTION:` annotations to the three `kind.h` files and
to `abstractmessagebus.h` where graph substrate use is architecturally
intentional.

## Tests

- `test/scripts/test_check_wrapper_encapsulation.py` — 6 cases: clean
  wrapper, NodeId violation, waiver respected, clean facade, facade
  violation, facade waiver.
- All 6 pass locally.

## CI

- New `wrapper-encapsulation` job in `.github/workflows/ci.yml`.
- New step in `unit-tests-scripts` job runs the test file.

Closes #126