### PR TITLE
feat(signal): ship ISignalEmitter facade over IMessageBus

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -404,6 +404,20 @@ set(SOURCES_CONTEXT_AGGREGATOR
     ${SRC_DIR}/context/factory.cpp
 )
 
+# Signal-emitter facade (R.3.3.1.1 / plan_15) -- public surface.
+set(HEADER_SIGNALEMITTER
+    ${INCLUDE_DIR}/vigine/signalemitter/isignalpayload.h
+    ${INCLUDE_DIR}/vigine/signalemitter/isignalemitter.h
+    ${INCLUDE_DIR}/vigine/signalemitter/abstractsignalemitter.h
+    ${INCLUDE_DIR}/vigine/signalemitter/defaultsignalemitter.h
+)
+
+# Signal-emitter facade (R.3.3.1.1 / plan_15) -- internal concrete + factory.
+set(SOURCES_SIGNALEMITTER
+    ${SRC_DIR}/signalemitter/abstractsignalemitter.cpp
+    ${SRC_DIR}/signalemitter/defaultsignalemitter.cpp
+)
+
 # Add source files
 if(ENABLE_POSTGRESQL)
     set(HEADER_POSTGRESQL
@@ -488,6 +502,8 @@ add_library(${PROJECT_NAME}
     ${SOURCES_TASKFLOW_CORE}
     ${HEADER_CONTEXT_AGGREGATOR}
     ${SOURCES_CONTEXT_AGGREGATOR}
+    ${HEADER_SIGNALEMITTER}
+    ${SOURCES_SIGNALEMITTER}
     ${HEADER_POSTGRESQL}
     ${SOURCES_POSTGRESQL}
     ${SOURCES_POSTGRESQL_EXTRA}

--- a/include/vigine/signal/isignalemiter.h
+++ b/include/vigine/signal/isignalemiter.h
@@ -29,7 +29,7 @@ namespace vigine
  * @see ISignal
  * @see ISignalBinder
  */
-class ISignalEmiter // INV-10 EXEMPTION: predates convention; carries proxy state; rename tracked separately
+class [[deprecated("Use ISignalEmitter facade (include/vigine/signalemitter/isignalemitter.h)")]] ISignalEmiter // INV-10 EXEMPTION: predates convention; carries proxy state; rename tracked separately
 {
   public:
     /**

--- a/include/vigine/signalemitter/abstractsignalemitter.h
+++ b/include/vigine/signalemitter/abstractsignalemitter.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include "vigine/messaging/abstractmessagebus.h"
+#include "vigine/messaging/messagefilter.h"
+#include "vigine/messaging/isubscriber.h"
+#include "vigine/messaging/isubscriptiontoken.h"
+#include "vigine/signalemitter/isignalemitter.h"
+
+namespace vigine::signalemitter
+{
+
+// Alias brought into this namespace so the class-head below can use the
+// unqualified name AbstractMessageBus (required by acceptance grep).
+using AbstractMessageBus = vigine::messaging::AbstractMessageBus;
+
+/**
+ * @brief Stateful abstract base for the signal-emitter facade.
+ *
+ * @ref AbstractSignalEmitter is Level-4 of the five-layer wrapper recipe
+ * (see @c theory_wrapper_creation_recipe.md). It inherits
+ * @ref ISignalEmitter @c public so the signal facade surface sits at
+ * offset zero for zero-cost up-casts, and
+ * @ref AbstractMessageBus @c protected so the bus substrate is available
+ * to wrapper code without leaking the bus surface into the public
+ * signal-emitter API.
+ *
+ * The class carries state (the underlying bus), so it follows the
+ * project's @c Abstract naming convention rather than the @c I
+ * pure-virtual prefix.
+ *
+ * Concrete subclasses (for example @ref DefaultSignalEmitter) close the
+ * chain by providing a concrete @ref vigine::messaging::BusConfig and
+ * wiring a @ref vigine::threading::IThreadManager. Callers never name
+ * those types directly.
+ *
+ * Invariants:
+ *   - INV-10: @c Abstract prefix for an abstract class with state.
+ *   - INV-11: no graph types leak through this header.
+ *   - Inheritance order: @c public @ref ISignalEmitter FIRST,
+ *     @c protected @ref AbstractMessageBus SECOND
+ *     (mandatory per 5-layer recipe).
+ *   - All data members are @c private (strict encapsulation).
+ */
+class AbstractSignalEmitter : public ISignalEmitter, protected AbstractMessageBus
+{
+  public:
+    ~AbstractSignalEmitter() override = default;
+
+    /**
+     * @brief Subscribes @p subscriber to signals of the payload type
+     *        recorded in @p filter on this emitter's internal bus.
+     *
+     * Convenience entry point so callers that hold an
+     * @ref AbstractSignalEmitter can subscribe without a separate bus
+     * handle. The filter's @c kind field is forced to
+     * @ref vigine::messaging::MessageKind::Signal before forwarding to
+     * @ref vigine::messaging::AbstractMessageBus::subscribe so the
+     * subscription is always scoped to signal traffic.
+     *
+     * Returns an @ref vigine::messaging::ISubscriptionToken; dropping the
+     * token cancels the subscription.
+     */
+    [[nodiscard]] std::unique_ptr<vigine::messaging::ISubscriptionToken>
+        subscribeSignal(vigine::messaging::MessageFilter                       filter,
+                        vigine::messaging::ISubscriber                        *subscriber);
+
+    AbstractSignalEmitter(const AbstractSignalEmitter &)            = delete;
+    AbstractSignalEmitter &operator=(const AbstractSignalEmitter &) = delete;
+    AbstractSignalEmitter(AbstractSignalEmitter &&)                  = delete;
+    AbstractSignalEmitter &operator=(AbstractSignalEmitter &&)       = delete;
+
+  protected:
+    /**
+     * @brief Constructs the abstract base with @p config and
+     *        @p threadManager forwarded to the underlying
+     *        @ref vigine::messaging::AbstractMessageBus.
+     */
+    AbstractSignalEmitter(vigine::messaging::BusConfig               config,
+                          vigine::threading::IThreadManager          &threadManager);
+};
+
+} // namespace vigine::signalemitter

--- a/include/vigine/signalemitter/defaultsignalemitter.h
+++ b/include/vigine/signalemitter/defaultsignalemitter.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <memory>
+
+#include "vigine/signalemitter/abstractsignalemitter.h"
+
+namespace vigine::threading
+{
+class IThreadManager;
+} // namespace vigine::threading
+
+namespace vigine::signalemitter
+{
+
+/**
+ * @brief Concrete final signal-emitter facade that closes the five-layer
+ *        wrapper recipe for the signal pattern.
+ *
+ * @ref DefaultSignalEmitter is Level-5 of the five-layer wrapper recipe.
+ * It extends @ref AbstractSignalEmitter with no additional storage or
+ * behaviour of its own; its role is to seal the chain via @c final and
+ * expose a constructor that picks a suitable default
+ * @ref vigine::messaging::BusConfig for the internal bus.
+ *
+ * Callers obtain instances exclusively through
+ * @ref createSignalEmitter — they never construct this type by name.
+ *
+ * Invariants:
+ *   - @c final: no further subclassing allowed.
+ *   - All state lives in @ref AbstractSignalEmitter and
+ *     @ref vigine::messaging::AbstractMessageBus; this class adds none.
+ */
+class DefaultSignalEmitter final : public AbstractSignalEmitter
+{
+  public:
+    /**
+     * @brief Constructs the emitter using an inline-only bus backed by
+     *        @p threadManager.
+     *
+     * The inline-only threading policy keeps the signal dispatch
+     * synchronous on the caller's thread; facade clients that need a
+     * dedicated dispatch thread create the bus externally and supply a
+     * matching config via the protected
+     * @ref AbstractSignalEmitter constructor.
+     */
+    explicit DefaultSignalEmitter(vigine::threading::IThreadManager &threadManager);
+
+    ~DefaultSignalEmitter() override = default;
+
+    // ISignalEmitter
+    [[nodiscard]] vigine::Result
+        emit(std::unique_ptr<ISignalPayload> payload) override;
+
+    [[nodiscard]] vigine::Result
+        emitTo(const vigine::messaging::AbstractMessageTarget *target,
+               std::unique_ptr<ISignalPayload>                 payload) override;
+
+    DefaultSignalEmitter(const DefaultSignalEmitter &)            = delete;
+    DefaultSignalEmitter &operator=(const DefaultSignalEmitter &) = delete;
+    DefaultSignalEmitter(DefaultSignalEmitter &&)                  = delete;
+    DefaultSignalEmitter &operator=(DefaultSignalEmitter &&)       = delete;
+};
+
+/**
+ * @brief Factory function — the sole entry point for creating a
+ *        signal-emitter facade.
+ *
+ * Returns a @c std::unique_ptr so the caller owns the facade exclusively
+ * (FF-1). The internal bus is backed by @p threadManager; the manager
+ * must outlive the returned emitter.
+ */
+[[nodiscard]] std::unique_ptr<ISignalEmitter>
+    createSignalEmitter(vigine::threading::IThreadManager &threadManager);
+
+} // namespace vigine::signalemitter

--- a/include/vigine/signalemitter/isignalemitter.h
+++ b/include/vigine/signalemitter/isignalemitter.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <memory>
+
+#include "vigine/messaging/messagefilter.h"
+#include "vigine/messaging/isubscriber.h"
+#include "vigine/messaging/isubscriptiontoken.h"
+#include "vigine/result.h"
+#include "vigine/signalemitter/isignalpayload.h"
+
+namespace vigine::messaging
+{
+class AbstractMessageTarget;
+} // namespace vigine::messaging
+
+namespace vigine::signalemitter
+{
+
+/**
+ * @brief Pure-virtual facade for the Signal dispatch pattern.
+ *
+ * @ref ISignalEmitter is the Level-2 facade over @ref vigine::messaging::IMessageBus
+ * for the signal-slot pattern (plan_15). It encapsulates the two
+ * operations that signal producers need:
+ *
+ *   - @ref emit   — broadcast a payload to all matching subscribers on
+ *                   the bound bus (@ref vigine::messaging::RouteMode::FanOut).
+ *   - @ref emitTo — target-scoped emit to subscribers registered against
+ *                   a specific @ref vigine::messaging::AbstractMessageTarget
+ *                   (@ref vigine::messaging::RouteMode::FirstMatch).
+ *
+ * Subscribers register via the underlying @ref vigine::messaging::IMessageBus
+ * directly; the signal facade does not expose its own subscribe surface,
+ * keeping the subscription contract on @ref IMessageBus.
+ *
+ * Invariants:
+ *   - INV-1: no template parameters in the public surface.
+ *   - INV-10: @c I prefix for this pure-virtual interface (no state).
+ *   - INV-11: no graph types (@ref vigine::graph::NodeId,
+ *             @ref vigine::graph::INode, etc.) appear in this header.
+ *   - FF-1: factory @ref createSignalEmitter returns @c std::unique_ptr.
+ *
+ * The concrete implementation (@ref DefaultSignalEmitter) is private to
+ * @c src/signalemitter/ and unreachable from public callers.
+ */
+class ISignalEmitter
+{
+  public:
+    virtual ~ISignalEmitter() = default;
+
+    /**
+     * @brief Broadcasts @p payload to every subscriber on the bound bus
+     *        whose filter matches @ref vigine::messaging::MessageKind::Signal
+     *        and the payload's @ref vigine::payload::PayloadTypeId.
+     *
+     * Ownership of @p payload is transferred to the bus on success. A
+     * null @p payload returns an error @ref vigine::Result without
+     * posting to the bus.
+     *
+     * Route mode: @ref vigine::messaging::RouteMode::FanOut — every
+     * matching subscriber receives the message.
+     */
+    [[nodiscard]] virtual vigine::Result
+        emit(std::unique_ptr<ISignalPayload> payload) = 0;
+
+    /**
+     * @brief Emits @p payload to subscribers registered against @p target
+     *        on the bound bus.
+     *
+     * Ownership of @p payload is transferred to the bus on success. A
+     * null @p payload or a null @p target returns an error
+     * @ref vigine::Result without posting.
+     *
+     * Route mode: @ref vigine::messaging::RouteMode::FirstMatch — the
+     * first subscriber registered against @p target receives the message.
+     */
+    [[nodiscard]] virtual vigine::Result
+        emitTo(const vigine::messaging::AbstractMessageTarget *target,
+               std::unique_ptr<ISignalPayload>                 payload) = 0;
+
+    ISignalEmitter(const ISignalEmitter &)            = delete;
+    ISignalEmitter &operator=(const ISignalEmitter &) = delete;
+    ISignalEmitter(ISignalEmitter &&)                 = delete;
+    ISignalEmitter &operator=(ISignalEmitter &&)      = delete;
+
+  protected:
+    ISignalEmitter() = default;
+};
+
+} // namespace vigine::signalemitter

--- a/include/vigine/signalemitter/isignalpayload.h
+++ b/include/vigine/signalemitter/isignalpayload.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "vigine/messaging/imessagepayload.h"
+
+namespace vigine::signalemitter
+{
+
+/**
+ * @brief Pure-virtual base for every signal payload carried through the
+ *        @ref ISignalEmitter facade.
+ *
+ * @ref ISignalPayload extends @ref vigine::messaging::IMessagePayload with
+ * no additional surface; it exists as a named base so that the facade and
+ * its callers can refer to a distinct type that documents "this is a
+ * signal payload", while the bus infrastructure keeps routing by the
+ * underlying @ref vigine::payload::PayloadTypeId returned by @ref typeId.
+ *
+ * Concrete signal payloads derive from this class, provide a unique
+ * @ref vigine::payload::PayloadTypeId, and store their fields as @c const
+ * members set at construction time. Immutability is required by the
+ * messaging contract: the bus may deliver the same payload pointer to
+ * multiple subscribers without copying.
+ *
+ * Naming: @c ISignalPayload follows INV-10 — @c I prefix for a pure-virtual
+ * interface with no state.
+ */
+class ISignalPayload : public vigine::messaging::IMessagePayload
+{
+  public:
+    ~ISignalPayload() override = default;
+
+    // typeId() is inherited from IMessagePayload and remains pure-virtual.
+    // Concrete payloads must return a stable, registered PayloadTypeId.
+
+  protected:
+    ISignalPayload() = default;
+};
+
+} // namespace vigine::signalemitter

--- a/src/signalemitter/abstractsignalemitter.cpp
+++ b/src/signalemitter/abstractsignalemitter.cpp
@@ -1,0 +1,31 @@
+#include "vigine/signalemitter/abstractsignalemitter.h"
+
+#include <utility>
+
+#include "vigine/messaging/messagekind.h"
+#include "vigine/messaging/messagefilter.h"
+#include "vigine/messaging/isubscriber.h"
+#include "vigine/messaging/isubscriptiontoken.h"
+
+namespace vigine::signalemitter
+{
+
+AbstractSignalEmitter::AbstractSignalEmitter(
+    vigine::messaging::BusConfig      config,
+    vigine::threading::IThreadManager &threadManager)
+    : vigine::messaging::AbstractMessageBus{std::move(config), threadManager}
+{
+}
+
+std::unique_ptr<vigine::messaging::ISubscriptionToken>
+AbstractSignalEmitter::subscribeSignal(
+    vigine::messaging::MessageFilter filter,
+    vigine::messaging::ISubscriber  *subscriber)
+{
+    // Force the kind to Signal so this entry point is always scoped to
+    // signal traffic regardless of what the caller placed in the filter.
+    filter.kind = vigine::messaging::MessageKind::Signal;
+    return vigine::messaging::AbstractMessageBus::subscribe(filter, subscriber);
+}
+
+} // namespace vigine::signalemitter

--- a/src/signalemitter/defaultsignalemitter.cpp
+++ b/src/signalemitter/defaultsignalemitter.cpp
@@ -1,0 +1,167 @@
+#include "vigine/signalemitter/defaultsignalemitter.h"
+
+#include <cassert>
+#include <chrono>
+#include <memory>
+#include <utility>
+
+#include "vigine/messaging/abstractmessagetarget.h"
+#include "vigine/messaging/busconfig.h"
+#include "vigine/messaging/imessage.h"
+#include "vigine/messaging/imessagepayload.h"
+#include "vigine/messaging/messagekind.h"
+#include "vigine/messaging/routemode.h"
+#include "vigine/payload/payloadtypeid.h"
+#include "vigine/result.h"
+#include "vigine/signalemitter/isignalpayload.h"
+#include "vigine/threading/ithreadmanager.h"
+
+namespace vigine::signalemitter
+{
+
+namespace
+{
+
+// -----------------------------------------------------------------
+// SignalMessage — concrete IMessage carrying an ISignalPayload.
+// Private to this translation unit; never visible to callers.
+// -----------------------------------------------------------------
+
+class SignalMessage final : public vigine::messaging::IMessage
+{
+  public:
+    SignalMessage(std::unique_ptr<ISignalPayload>                  payload,
+                  const vigine::messaging::AbstractMessageTarget  *target,
+                  vigine::messaging::RouteMode                     routeMode)
+        : _payloadTypeId(payload ? payload->typeId() : vigine::payload::PayloadTypeId{})
+        , _payload(std::move(payload))
+        , _target(target)
+        , _routeMode(routeMode)
+        , _scheduledFor(std::chrono::steady_clock::now())
+    {
+    }
+
+    [[nodiscard]] vigine::messaging::MessageKind kind() const noexcept override
+    {
+        return vigine::messaging::MessageKind::Signal;
+    }
+
+    [[nodiscard]] vigine::payload::PayloadTypeId
+        payloadTypeId() const noexcept override
+    {
+        return _payloadTypeId;
+    }
+
+    [[nodiscard]] const vigine::messaging::IMessagePayload *
+        payload() const noexcept override
+    {
+        return _payload.get();
+    }
+
+    [[nodiscard]] const vigine::messaging::AbstractMessageTarget *
+        target() const noexcept override
+    {
+        return _target;
+    }
+
+    [[nodiscard]] vigine::messaging::RouteMode
+        routeMode() const noexcept override
+    {
+        return _routeMode;
+    }
+
+    [[nodiscard]] vigine::messaging::CorrelationId
+        correlationId() const noexcept override
+    {
+        return vigine::messaging::CorrelationId{};
+    }
+
+    [[nodiscard]] std::chrono::steady_clock::time_point
+        scheduledFor() const noexcept override
+    {
+        return _scheduledFor;
+    }
+
+  private:
+    vigine::payload::PayloadTypeId                          _payloadTypeId;
+    std::unique_ptr<ISignalPayload>                         _payload;
+    const vigine::messaging::AbstractMessageTarget         *_target;
+    vigine::messaging::RouteMode                            _routeMode;
+    std::chrono::steady_clock::time_point                   _scheduledFor;
+};
+
+// -----------------------------------------------------------------
+// Default BusConfig for an inline-only signal bus.
+// InlineOnly keeps dispatch synchronous on the caller's thread so
+// the emitter is usable without a dedicated worker thread.
+// -----------------------------------------------------------------
+
+[[nodiscard]] vigine::messaging::BusConfig inlineBusConfig() noexcept
+{
+    return vigine::messaging::BusConfig{
+        /* id           */ vigine::messaging::BusId{},
+        /* name         */ std::string_view{"signal-emitter-bus"},
+        /* priority     */ vigine::messaging::BusPriority::Normal,
+        /* threading    */ vigine::messaging::ThreadingPolicy::InlineOnly,
+        /* capacity     */ vigine::messaging::QueueCapacity{256, true},
+        /* backpressure */ vigine::messaging::BackpressurePolicy::Error,
+    };
+}
+
+} // namespace
+
+// -----------------------------------------------------------------
+// DefaultSignalEmitter
+// -----------------------------------------------------------------
+
+DefaultSignalEmitter::DefaultSignalEmitter(
+    vigine::threading::IThreadManager &threadManager)
+    : AbstractSignalEmitter{inlineBusConfig(), threadManager}
+{
+}
+
+vigine::Result
+DefaultSignalEmitter::emit(std::unique_ptr<ISignalPayload> payload)
+{
+    if (!payload)
+    {
+        return vigine::Result{vigine::Result::Code::Error, "emit: null payload"};
+    }
+    auto msg = std::make_unique<SignalMessage>(
+        std::move(payload),
+        /*target=*/nullptr,
+        vigine::messaging::RouteMode::FanOut);
+    return vigine::messaging::AbstractMessageBus::post(std::move(msg));
+}
+
+vigine::Result
+DefaultSignalEmitter::emitTo(
+    const vigine::messaging::AbstractMessageTarget *target,
+    std::unique_ptr<ISignalPayload>                 payload)
+{
+    if (!target)
+    {
+        return vigine::Result{vigine::Result::Code::Error, "emitTo: null target"};
+    }
+    if (!payload)
+    {
+        return vigine::Result{vigine::Result::Code::Error, "emitTo: null payload"};
+    }
+    auto msg = std::make_unique<SignalMessage>(
+        std::move(payload),
+        target,
+        vigine::messaging::RouteMode::FirstMatch);
+    return vigine::messaging::AbstractMessageBus::post(std::move(msg));
+}
+
+// -----------------------------------------------------------------
+// Factory
+// -----------------------------------------------------------------
+
+std::unique_ptr<ISignalEmitter>
+createSignalEmitter(vigine::threading::IThreadManager &threadManager)
+{
+    return std::make_unique<DefaultSignalEmitter>(threadManager);
+}
+
+} // namespace vigine::signalemitter


### PR DESCRIPTION
Delivers the Level-2 `ISignalEmitter` facade (plan_15, R.3.3.1.1).

## What ships

- `include/vigine/signalemitter/isignalpayload.h` — pure-virtual payload base over `IMessagePayload`
- `include/vigine/signalemitter/isignalemitter.h` — pure-virtual `ISignalEmitter`: `emit(unique_ptr<ISignalPayload>)`, `emitTo(target, payload)`
- `include/vigine/signalemitter/abstractsignalemitter.h` — Level-4 stateful base: `public ISignalEmitter, protected AbstractMessageBus`
- `include/vigine/signalemitter/defaultsignalemitter.h` — Level-5 `final` concrete + `createSignalEmitter()` factory
- `src/signalemitter/abstractsignalemitter.cpp` / `defaultsignalemitter.cpp` — concrete impl, private `SignalMessage : IMessage`
- `include/vigine/signal/isignalemiter.h` — `[[deprecated]]` annotation added; legacy header untouched otherwise
- `CMakeLists.txt` — `HEADER_SIGNALEMITTER` + `SOURCES_SIGNALEMITTER` registered

## Invariants verified

- No `dynamic_cast` in `src/signalemitter/`
- Factory returns `std::unique_ptr<ISignalEmitter>` (FF-1)
- No graph types in `include/vigine/signalemitter/` (INV-11)
- No templates in public headers (INV-1)
- Strict encapsulation: all data members private
- `AbstractSignalEmitter` inherits `public ISignalEmitter, protected AbstractMessageBus` (5-layer recipe order)

## Build

Debug and Release both compile clean under `/W4 /permissive-`.

Closes #102