### PR TITLE
feat(event): ship IEventScheduler facade over IMessageBus

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -418,6 +418,38 @@ set(SOURCES_SIGNALEMITTER
     ${SRC_DIR}/signalemitter/defaultsignalemitter.cpp
 )
 
+# Event-scheduler facade (R.3.3.1.2 / plan_16) -- public surface.
+set(HEADER_EVENTSCHEDULER
+    ${INCLUDE_DIR}/vigine/eventscheduler/ossignal.h
+    ${INCLUDE_DIR}/vigine/eventscheduler/eventconfig.h
+    ${INCLUDE_DIR}/vigine/eventscheduler/ieventhandle.h
+    ${INCLUDE_DIR}/vigine/eventscheduler/itimersource.h
+    ${INCLUDE_DIR}/vigine/eventscheduler/iossignalsource.h
+    ${INCLUDE_DIR}/vigine/eventscheduler/ieventscheduler.h
+    ${INCLUDE_DIR}/vigine/eventscheduler/abstracteventscheduler.h
+    ${INCLUDE_DIR}/vigine/eventscheduler/defaulteventscheduler.h
+)
+
+# Event-scheduler facade (R.3.3.1.2 / plan_16) -- internal concrete + platform.
+set(SOURCES_EVENTSCHEDULER
+    ${SRC_DIR}/eventscheduler/abstracteventscheduler.cpp
+    ${SRC_DIR}/eventscheduler/itimersource_default.h
+    ${SRC_DIR}/eventscheduler/itimersource_default.cpp
+    ${SRC_DIR}/eventscheduler/defaulteventscheduler.cpp
+)
+
+if(WIN32)
+    list(APPEND SOURCES_EVENTSCHEDULER
+        ${SRC_DIR}/eventscheduler/iossignalsource_win.h
+        ${SRC_DIR}/eventscheduler/iossignalsource_win.cpp
+    )
+elseif(APPLE)
+    list(APPEND SOURCES_EVENTSCHEDULER
+        ${SRC_DIR}/eventscheduler/iossignalsource_macos.h
+        ${SRC_DIR}/eventscheduler/iossignalsource_macos.mm
+    )
+endif()
+
 # Add source files
 if(ENABLE_POSTGRESQL)
     set(HEADER_POSTGRESQL
@@ -504,6 +536,8 @@ add_library(${PROJECT_NAME}
     ${SOURCES_CONTEXT_AGGREGATOR}
     ${HEADER_SIGNALEMITTER}
     ${SOURCES_SIGNALEMITTER}
+    ${HEADER_EVENTSCHEDULER}
+    ${SOURCES_EVENTSCHEDULER}
     ${HEADER_POSTGRESQL}
     ${SOURCES_POSTGRESQL}
     ${SOURCES_POSTGRESQL_EXTRA}

--- a/include/vigine/eventscheduler/abstracteventscheduler.h
+++ b/include/vigine/eventscheduler/abstracteventscheduler.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "vigine/messaging/abstractmessagebus.h"
+#include "vigine/eventscheduler/ieventscheduler.h"
+
+namespace vigine::threading
+{
+class IThreadManager;
+} // namespace vigine::threading
+
+namespace vigine::eventscheduler
+{
+
+// Alias brought into this namespace so the class-head below can use the
+// unqualified name AbstractMessageBus (required by acceptance grep).
+using AbstractMessageBus = vigine::messaging::AbstractMessageBus;
+
+/**
+ * @brief Stateful abstract base for the event-scheduler facade.
+ *
+ * @ref AbstractEventScheduler is Level-4 of the five-layer wrapper recipe
+ * (see @c theory_wrapper_creation_recipe.md). It inherits
+ * @ref IEventScheduler @c public so the scheduler facade surface sits at
+ * offset zero for zero-cost up-casts, and
+ * @ref AbstractMessageBus @c protected so the bus substrate is available
+ * to wrapper code without leaking the bus surface into the public
+ * event-scheduler API.
+ *
+ * The class carries state (the underlying bus), so it follows the
+ * project's @c Abstract naming convention rather than the @c I
+ * pure-virtual prefix.
+ *
+ * Concrete subclasses (for example @ref DefaultEventScheduler) close the
+ * chain by providing a concrete @ref vigine::messaging::BusConfig and
+ * wiring the platform @ref ITimerSource and @ref IOsSignalSource
+ * implementations. Callers never name those types directly.
+ *
+ * Invariants:
+ *   - INV-10: @c Abstract prefix for an abstract class with state.
+ *   - INV-11: no graph types leak through this header.
+ *   - Inheritance order: @c public @ref IEventScheduler FIRST,
+ *     @c protected @ref AbstractMessageBus SECOND
+ *     (mandatory per 5-layer recipe).
+ *   - All data members are @c private (strict encapsulation).
+ */
+class AbstractEventScheduler : public IEventScheduler, protected AbstractMessageBus
+{
+  public:
+    ~AbstractEventScheduler() override = default;
+
+    AbstractEventScheduler(const AbstractEventScheduler &)            = delete;
+    AbstractEventScheduler &operator=(const AbstractEventScheduler &) = delete;
+    AbstractEventScheduler(AbstractEventScheduler &&)                  = delete;
+    AbstractEventScheduler &operator=(AbstractEventScheduler &&)       = delete;
+
+  protected:
+    /**
+     * @brief Constructs the abstract base with @p config and
+     *        @p threadManager forwarded to the underlying
+     *        @ref vigine::messaging::AbstractMessageBus.
+     */
+    AbstractEventScheduler(vigine::messaging::BusConfig      config,
+                           vigine::threading::IThreadManager &threadManager);
+};
+
+} // namespace vigine::eventscheduler

--- a/include/vigine/eventscheduler/defaulteventscheduler.h
+++ b/include/vigine/eventscheduler/defaulteventscheduler.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <memory>
+
+#include "vigine/eventscheduler/abstracteventscheduler.h"
+#include "vigine/eventscheduler/ieventhandle.h"
+#include "vigine/eventscheduler/iossignalsource.h"
+#include "vigine/eventscheduler/itimersource.h"
+
+namespace vigine::threading
+{
+class IThreadManager;
+} // namespace vigine::threading
+
+namespace vigine::eventscheduler
+{
+
+/**
+ * @brief Concrete final event-scheduler facade.
+ *
+ * @ref DefaultEventScheduler is Level-5 of the five-layer wrapper recipe.
+ * It wires a platform @ref ITimerSource and @ref IOsSignalSource into the
+ * @ref AbstractEventScheduler chain and implements @ref IEventScheduler
+ * by listening for timer and OS-signal callbacks, then posting
+ * @ref vigine::messaging::MessageKind::Event messages to the underlying
+ * @ref vigine::messaging::AbstractMessageBus.
+ *
+ * Callers obtain instances exclusively through
+ * @ref createEventScheduler — they never construct this type by name.
+ *
+ * Thread-safety: @ref schedule, @ref shutdown, and the timer/OS-signal
+ * callbacks are all safe to call from any thread concurrently. Internal
+ * state (the scheduled-events map) is guarded by a @c std::shared_mutex.
+ *
+ * Invariants:
+ *   - @c final: no further subclassing allowed.
+ *   - FF-1: @ref schedule returns @c std::unique_ptr<IEventHandle>.
+ *   - INV-11: no graph types leak into this header.
+ */
+class DefaultEventScheduler final
+    : public AbstractEventScheduler
+    , private ITimerFiredListener
+    , private IOsSignalListener
+{
+  public:
+    /**
+     * @brief Constructs the scheduler.
+     *
+     * @p threadManager backs the internal bus.
+     * @p timerSource   provides timer arm/disarm (owned by caller).
+     * @p osSignalSource provides OS-signal subscribe/unsubscribe (owned by caller).
+     */
+    explicit DefaultEventScheduler(vigine::threading::IThreadManager &threadManager,
+                                   ITimerSource                      &timerSource,
+                                   IOsSignalSource                   &osSignalSource);
+
+    ~DefaultEventScheduler() override;
+
+    // IEventScheduler
+    [[nodiscard]] std::unique_ptr<IEventHandle>
+        schedule(const EventConfig                         &config,
+                 vigine::messaging::AbstractMessageTarget  *target) override;
+
+    vigine::Result shutdown() override;
+
+    DefaultEventScheduler(const DefaultEventScheduler &)            = delete;
+    DefaultEventScheduler &operator=(const DefaultEventScheduler &) = delete;
+    DefaultEventScheduler(DefaultEventScheduler &&)                  = delete;
+    DefaultEventScheduler &operator=(DefaultEventScheduler &&)       = delete;
+
+  private:
+    // ITimerFiredListener
+    void onTimerFired(std::uint64_t timerId) override;
+
+    // IOsSignalListener
+    void onOsSignal(OsSignal signal) override;
+
+    // Pimpl hides the scheduled-events map and atomic shutdown flag so
+    // the private implementation details are not exposed in the public header.
+    struct Impl;
+    std::unique_ptr<Impl> _impl;
+};
+
+/**
+ * @brief Factory function — the sole entry point for creating an
+ *        event-scheduler facade.
+ *
+ * Returns a @c std::unique_ptr so the caller owns the facade exclusively
+ * (FF-1). The internal bus and timer/OS-signal sources are backed by the
+ * supplied references; all three must outlive the returned scheduler.
+ */
+[[nodiscard]] std::unique_ptr<IEventScheduler>
+    createEventScheduler(vigine::threading::IThreadManager &threadManager,
+                         ITimerSource                      &timerSource,
+                         IOsSignalSource                   &osSignalSource);
+
+} // namespace vigine::eventscheduler

--- a/include/vigine/eventscheduler/eventconfig.h
+++ b/include/vigine/eventscheduler/eventconfig.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+
+#include "vigine/eventscheduler/ossignal.h"
+#include "vigine/payload/payloadtypeid.h"
+
+namespace vigine::eventscheduler
+{
+
+/**
+ * @brief POD configuration for a scheduled event.
+ *
+ * Callers fill this struct and pass it to
+ * @ref IEventScheduler::schedule. The fields map to the three input
+ * examples:
+ *
+ *   - Timer + count:  @c period > 0, @c count > 0, @c useOsSignal == false.
+ *   - One-shot delay: @c delay > 0, @c period == 0, @c count == 1,
+ *                     @c useOsSignal == false.
+ *   - OS signal:      @c useOsSignal == true, @c osSignal set accordingly;
+ *                     all time fields are ignored.
+ *
+ * Field semantics:
+ *   - @c delay  -- first fire after this interval; 0 = fire immediately on arm.
+ *   - @c period -- repeat interval; 0 = one-shot (fire once and disarm).
+ *   - @c count  -- maximum fire count; 0 = unlimited repetition
+ *                  (only meaningful when period > 0).
+ *   - @c useOsSignal -- when @c true, arm the OS signal watcher instead of a timer.
+ *   - @c osSignal -- OS signal to watch; only used when @c useOsSignal is @c true.
+ *   - @c rescheduleWhileRunning -- when @c false (default), skip a fire if
+ *                                   the previous delivery is still in-flight.
+ *   - @c firedPayloadTypeId     -- payload type id carried by the dispatched
+ *                                   IMessage; zero-value = scheduler supplies a
+ *                                   built-in default.
+ *
+ * INV-1: no template parameters.
+ * INV-11: no graph types in this header.
+ */
+struct EventConfig
+{
+    std::chrono::milliseconds         delay{0};
+    std::chrono::milliseconds         period{0};
+    std::size_t                       count{0};
+    bool                              useOsSignal{false};
+    OsSignal                          osSignal{OsSignal::Terminate};
+    bool                              rescheduleWhileRunning{false};
+    vigine::payload::PayloadTypeId    firedPayloadTypeId{};
+
+    /** @brief Returns true when this config arms an OS-signal watcher. */
+    [[nodiscard]] bool isOsSignalTrigger() const noexcept
+    {
+        return useOsSignal;
+    }
+};
+
+} // namespace vigine::eventscheduler

--- a/include/vigine/eventscheduler/ieventhandle.h
+++ b/include/vigine/eventscheduler/ieventhandle.h
@@ -1,0 +1,54 @@
+#pragma once
+
+namespace vigine::eventscheduler
+{
+
+/**
+ * @brief Pure-virtual RAII handle for a scheduled event.
+ *
+ * @ref IEventHandle is the cancellation token returned by
+ * @ref IEventScheduler::schedule. Destroying the handle is equivalent to
+ * calling @ref cancel — the event is deactivated and no further fires
+ * will be delivered (in-flight delivery may still complete; see the
+ * soft-cancel semantics in Q-FE5).
+ *
+ * Callers hold the handle as @c std::unique_ptr<IEventHandle>; the
+ * scheduler retains no reference to the handle after returning it. When
+ * the handle goes out of scope the associated event stops firing.
+ *
+ * INV-1: no template parameters in the public surface.
+ * INV-10: @c I prefix for a pure-virtual interface with no state.
+ * INV-11: no graph types in this header.
+ */
+class IEventHandle
+{
+  public:
+    virtual ~IEventHandle() = default;
+
+    /**
+     * @brief Soft-cancels the event.
+     *
+     * Marks the event inactive. Any in-flight delivery completes;
+     * future timer fires or OS signal deliveries are prevented. Calling
+     * @ref cancel on an already-inactive handle is a no-op.
+     */
+    virtual void cancel() noexcept = 0;
+
+    /**
+     * @brief Returns @c true when the event is still armed and active.
+     *
+     * Returns @c false after @ref cancel or after the configured
+     * @c count has been reached.
+     */
+    [[nodiscard]] virtual bool active() const noexcept = 0;
+
+    IEventHandle(const IEventHandle &)            = delete;
+    IEventHandle &operator=(const IEventHandle &) = delete;
+    IEventHandle(IEventHandle &&)                 = delete;
+    IEventHandle &operator=(IEventHandle &&)      = delete;
+
+  protected:
+    IEventHandle() = default;
+};
+
+} // namespace vigine::eventscheduler

--- a/include/vigine/eventscheduler/ieventscheduler.h
+++ b/include/vigine/eventscheduler/ieventscheduler.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <memory>
+
+#include "vigine/eventscheduler/eventconfig.h"
+#include "vigine/eventscheduler/ieventhandle.h"
+#include "vigine/result.h"
+
+namespace vigine::messaging
+{
+class AbstractMessageTarget;
+} // namespace vigine::messaging
+
+namespace vigine::eventscheduler
+{
+
+/**
+ * @brief Pure-virtual facade for the Event dispatch pattern.
+ *
+ * @ref IEventScheduler is the Level-2 facade over
+ * @ref vigine::messaging::IMessageBus for engine-driven timers and OS
+ * signals (plan_16, R.3.3.1.2). It encapsulates two operations:
+ *
+ *   - @ref schedule -- arm a timer or OS-signal watcher; receive an RAII
+ *                      handle. When the trigger fires the scheduler posts
+ *                      a @ref vigine::messaging::MessageKind::Event message
+ *                      to the bound bus addressed to @p target.
+ *   - @ref shutdown -- cancel all live events, disarm timers, unsubscribe
+ *                      OS signals, and stop accepting new schedules.
+ *
+ * Ownership: @ref schedule returns a @c std::unique_ptr<IEventHandle> (FF-1).
+ * The handle's destructor soft-cancels the event; in-flight deliveries
+ * complete. Dropping the handle before the event fires is safe.
+ *
+ * Invariants:
+ *   - INV-1: no template parameters in the public surface.
+ *   - INV-9: factory @ref createEventScheduler returns @c std::unique_ptr.
+ *   - INV-10: @c I prefix for this pure-virtual interface (no state).
+ *   - INV-11: no graph types (@ref vigine::graph::NodeId,
+ *             @ref vigine::graph::INode, etc.) appear in this header.
+ *   - FF-1: @ref schedule returns @c std::unique_ptr<IEventHandle>.
+ *
+ * The concrete implementation (@ref DefaultEventScheduler) is private to
+ * @c src/eventscheduler/ and unreachable from public callers.
+ */
+class IEventScheduler
+{
+  public:
+    virtual ~IEventScheduler() = default;
+
+    /**
+     * @brief Arms a timer or OS-signal watcher and binds it to @p target.
+     *
+     * On each trigger the scheduler posts a
+     * @ref vigine::messaging::MessageKind::Event message to the bound bus
+     * with @ref vigine::messaging::RouteMode::FirstMatch and @p target as
+     * the addressed recipient. When the bus registry no longer contains
+     * @p target the fire is logged to the dead-letter channel and the
+     * event is disarmed.
+     *
+     * Returns a non-null @c std::unique_ptr<IEventHandle> on success.
+     * Returns a null handle when @p target is null or when @p config is
+     * inconsistent (for example neither a positive delay/period nor a
+     * valid osSignal).
+     *
+     * The handle is RAII: destroying it equals calling @ref cancel on it.
+     */
+    [[nodiscard]] virtual std::unique_ptr<IEventHandle>
+        schedule(const EventConfig                          &config,
+                 vigine::messaging::AbstractMessageTarget   *target) = 0;
+
+    /**
+     * @brief Shuts down the scheduler.
+     *
+     * Cancels every live event, disarms all timers, unsubscribes all OS
+     * signal listeners, and rejects subsequent @ref schedule calls.
+     * Idempotent: a second call is a no-op.
+     */
+    virtual vigine::Result shutdown() = 0;
+
+    IEventScheduler(const IEventScheduler &)            = delete;
+    IEventScheduler &operator=(const IEventScheduler &) = delete;
+    IEventScheduler(IEventScheduler &&)                 = delete;
+    IEventScheduler &operator=(IEventScheduler &&)      = delete;
+
+  protected:
+    IEventScheduler() = default;
+};
+
+} // namespace vigine::eventscheduler

--- a/include/vigine/eventscheduler/iossignalsource.h
+++ b/include/vigine/eventscheduler/iossignalsource.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include "vigine/eventscheduler/ossignal.h"
+#include "vigine/result.h"
+
+namespace vigine::eventscheduler
+{
+
+/**
+ * @brief Listener notified when the OS delivers a signal intercepted by
+ *        @ref IOsSignalSource.
+ *
+ * INV-10: @c I prefix for a pure-virtual interface with no state.
+ */
+class IOsSignalListener
+{
+  public:
+    virtual ~IOsSignalListener() = default;
+
+    /**
+     * @brief Called when the OS delivers @p signal.
+     *
+     * Invoked from the signal handler thread; implementations must be
+     * thread-safe and must not block.
+     */
+    virtual void onOsSignal(OsSignal signal) = 0;
+
+  protected:
+    IOsSignalListener() = default;
+};
+
+/**
+ * @brief Pure-virtual cross-platform OS signal abstraction.
+ *
+ * @ref IOsSignalSource wraps platform-specific OS signal handling
+ * (POSIX sigaction + self-pipe on Linux/macOS; SetConsoleCtrlHandler on
+ * Windows) and delivers @ref IOsSignalListener::onOsSignal callbacks on
+ * a dedicated reader thread.
+ *
+ * Platform notes:
+ *   - @c OsSignal::Hangup on Windows returns @ref vigine::Result::Code::Error
+ *     from @ref subscribe because SIGHUP has no Windows equivalent.
+ *   - @c OsSignal::User1 and @c User2 on Windows are unsupported and
+ *     return @ref vigine::Result::Code::Error.
+ *
+ * INV-1: no template parameters.
+ * INV-10: @c I prefix for a pure-virtual interface with no state.
+ * INV-11: no graph types in this header.
+ */
+class IOsSignalSource
+{
+  public:
+    virtual ~IOsSignalSource() = default;
+
+    /**
+     * @brief Registers @p listener to receive notifications for
+     *        @p signal.
+     *
+     * Returns an error @ref vigine::Result on platforms where @p signal
+     * is not supported (for example @c OsSignal::Hangup on Windows).
+     * Multiple listeners for the same signal are supported; each
+     * receives the callback independently.
+     */
+    [[nodiscard]] virtual vigine::Result
+        subscribe(OsSignal signal, IOsSignalListener *listener) = 0;
+
+    /**
+     * @brief Unregisters @p listener from @p signal.
+     *
+     * Unregistering a listener that is not subscribed is a no-op.
+     */
+    virtual void unsubscribe(OsSignal signal, IOsSignalListener *listener) = 0;
+
+    IOsSignalSource(const IOsSignalSource &)            = delete;
+    IOsSignalSource &operator=(const IOsSignalSource &) = delete;
+    IOsSignalSource(IOsSignalSource &&)                 = delete;
+    IOsSignalSource &operator=(IOsSignalSource &&)      = delete;
+
+  protected:
+    IOsSignalSource() = default;
+};
+
+} // namespace vigine::eventscheduler

--- a/include/vigine/eventscheduler/itimersource.h
+++ b/include/vigine/eventscheduler/itimersource.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+
+namespace vigine::eventscheduler
+{
+
+/**
+ * @brief Listener notified when a timer managed by @ref ITimerSource fires.
+ *
+ * INV-10: @c I prefix for a pure-virtual interface with no state.
+ */
+class ITimerFiredListener
+{
+  public:
+    virtual ~ITimerFiredListener() = default;
+
+    /**
+     * @brief Called by the timer source when the timer identified by
+     *        @p timerId fires.
+     *
+     * Invoked from the timer thread; implementations must be
+     * thread-safe. Must not block.
+     */
+    virtual void onTimerFired(std::uint64_t timerId) = 0;
+
+  protected:
+    ITimerFiredListener() = default;
+};
+
+/**
+ * @brief Pure-virtual cross-platform timer abstraction.
+ *
+ * @ref ITimerSource wraps an OS timing mechanism and delivers
+ * @ref ITimerFiredListener::onTimerFired callbacks on a dedicated worker
+ * thread. The scheduler uses this interface so the concrete timer
+ * implementation is swappable (mocked in tests, accelerated in CI).
+ *
+ * Ownership: the caller retains the @ref ITimerFiredListener pointer and
+ * is responsible for its lifetime. The timer source never owns listeners.
+ *
+ * INV-1: no template parameters.
+ * INV-10: @c I prefix for a pure-virtual interface with no state.
+ * INV-11: no graph types in this header.
+ */
+class ITimerSource
+{
+  public:
+    virtual ~ITimerSource() = default;
+
+    /**
+     * @brief Arms a one-shot timer that fires after @p delay.
+     *
+     * Returns a timer id that can be passed to @ref disarm. The id is
+     * unique within this source instance; reuse after @ref disarm or
+     * after the fire is implementation-defined.
+     */
+    [[nodiscard]] virtual std::uint64_t
+        armOneShot(std::chrono::milliseconds delay,
+                   ITimerFiredListener      *listener) = 0;
+
+    /**
+     * @brief Arms a periodic timer that fires every @p period.
+     *
+     * @p count controls the maximum fire count; 0 means unlimited.
+     * Returns a timer id that can be passed to @ref disarm.
+     */
+    [[nodiscard]] virtual std::uint64_t
+        armPeriodic(std::chrono::milliseconds period,
+                    std::size_t               count,
+                    ITimerFiredListener       *listener) = 0;
+
+    /**
+     * @brief Disarms the timer identified by @p timerId.
+     *
+     * Disarming an already-expired or invalid id is a no-op. An
+     * in-flight callback may still complete after @ref disarm returns;
+     * callers should not rely on strict before/after ordering.
+     */
+    virtual void disarm(std::uint64_t timerId) = 0;
+
+    ITimerSource(const ITimerSource &)            = delete;
+    ITimerSource &operator=(const ITimerSource &) = delete;
+    ITimerSource(ITimerSource &&)                 = delete;
+    ITimerSource &operator=(ITimerSource &&)      = delete;
+
+  protected:
+    ITimerSource() = default;
+};
+
+} // namespace vigine::eventscheduler

--- a/include/vigine/eventscheduler/ossignal.h
+++ b/include/vigine/eventscheduler/ossignal.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstdint>
+
+namespace vigine::eventscheduler
+{
+
+/**
+ * @brief Closed enumeration of the OS signals the engine can intercept.
+ *
+ * Exactly five values per plan_16. Each maps to a platform signal:
+ *   - @c Terminate  -- SIGTERM on POSIX; CTRL_CLOSE_EVENT on Windows.
+ *   - @c Interrupt  -- SIGINT on POSIX; CTRL_C_EVENT on Windows.
+ *   - @c Hangup     -- SIGHUP on POSIX; CTRL_BREAK_EVENT on Windows
+ *                      (best-effort; returns Result::NotSupported on Windows).
+ *   - @c User1      -- SIGUSR1 on POSIX; no native Windows equivalent (no-op).
+ *   - @c User2      -- SIGUSR2 on POSIX; no native Windows equivalent (no-op).
+ *
+ * INV-11: no graph types appear in this header.
+ */
+enum class OsSignal : std::uint8_t
+{
+    Terminate = 1,
+    Interrupt = 2,
+    Hangup    = 3,
+    User1     = 4,
+    User2     = 5,
+};
+
+} // namespace vigine::eventscheduler

--- a/src/eventscheduler/abstracteventscheduler.cpp
+++ b/src/eventscheduler/abstracteventscheduler.cpp
@@ -1,0 +1,15 @@
+#include "vigine/eventscheduler/abstracteventscheduler.h"
+
+#include <utility>
+
+namespace vigine::eventscheduler
+{
+
+AbstractEventScheduler::AbstractEventScheduler(
+    vigine::messaging::BusConfig      config,
+    vigine::threading::IThreadManager &threadManager)
+    : vigine::messaging::AbstractMessageBus{std::move(config), threadManager}
+{
+}
+
+} // namespace vigine::eventscheduler

--- a/src/eventscheduler/defaulteventscheduler.cpp
+++ b/src/eventscheduler/defaulteventscheduler.cpp
@@ -1,0 +1,408 @@
+#include "vigine/eventscheduler/defaulteventscheduler.h"
+
+#include <atomic>
+#include <cassert>
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "vigine/messaging/abstractmessagetarget.h"
+#include "vigine/messaging/busconfig.h"
+#include "vigine/messaging/imessage.h"
+#include "vigine/messaging/imessagepayload.h"
+#include "vigine/messaging/messagekind.h"
+#include "vigine/messaging/routemode.h"
+#include "vigine/payload/payloadtypeid.h"
+#include "vigine/result.h"
+#include "vigine/threading/ithreadmanager.h"
+
+namespace vigine::eventscheduler
+{
+
+namespace
+{
+
+// -----------------------------------------------------------------
+// EventMessage — concrete IMessage carrying an event payload.
+// Private to this translation unit; never visible to callers.
+// -----------------------------------------------------------------
+
+class EventPayload final : public vigine::messaging::IMessagePayload
+{
+  public:
+    explicit EventPayload(vigine::payload::PayloadTypeId typeId) noexcept
+        : _typeId(typeId)
+    {
+    }
+
+    [[nodiscard]] vigine::payload::PayloadTypeId typeId() const noexcept override
+    {
+        return _typeId;
+    }
+
+  private:
+    vigine::payload::PayloadTypeId _typeId;
+};
+
+class EventMessage final : public vigine::messaging::IMessage
+{
+  public:
+    EventMessage(vigine::payload::PayloadTypeId                   payloadTypeId,
+                 std::unique_ptr<EventPayload>                    payload,
+                 const vigine::messaging::AbstractMessageTarget  *target)
+        : _payloadTypeId(payloadTypeId)
+        , _payload(std::move(payload))
+        , _target(target)
+        , _scheduledFor(std::chrono::steady_clock::now())
+    {
+    }
+
+    [[nodiscard]] vigine::messaging::MessageKind kind() const noexcept override
+    {
+        return vigine::messaging::MessageKind::Event;
+    }
+
+    [[nodiscard]] vigine::payload::PayloadTypeId payloadTypeId() const noexcept override
+    {
+        return _payloadTypeId;
+    }
+
+    [[nodiscard]] const vigine::messaging::IMessagePayload *payload() const noexcept override
+    {
+        return _payload.get();
+    }
+
+    [[nodiscard]] const vigine::messaging::AbstractMessageTarget *target() const noexcept override
+    {
+        return _target;
+    }
+
+    [[nodiscard]] vigine::messaging::RouteMode routeMode() const noexcept override
+    {
+        return vigine::messaging::RouteMode::FirstMatch;
+    }
+
+    [[nodiscard]] vigine::messaging::CorrelationId correlationId() const noexcept override
+    {
+        return vigine::messaging::CorrelationId{};
+    }
+
+    [[nodiscard]] std::chrono::steady_clock::time_point scheduledFor() const noexcept override
+    {
+        return _scheduledFor;
+    }
+
+  private:
+    vigine::payload::PayloadTypeId                         _payloadTypeId;
+    std::unique_ptr<EventPayload>                          _payload;
+    const vigine::messaging::AbstractMessageTarget        *_target;
+    std::chrono::steady_clock::time_point                  _scheduledFor;
+};
+
+// -----------------------------------------------------------------
+// Default BusConfig for an inline-only event bus.
+// InlineOnly keeps dispatch synchronous on the calling thread.
+// -----------------------------------------------------------------
+
+[[nodiscard]] vigine::messaging::BusConfig inlineBusConfig() noexcept
+{
+    return vigine::messaging::BusConfig{
+        /* id           */ vigine::messaging::BusId{},
+        /* name         */ std::string_view{"event-scheduler-bus"},
+        /* priority     */ vigine::messaging::BusPriority::Normal,
+        /* threading    */ vigine::messaging::ThreadingPolicy::InlineOnly,
+        /* capacity     */ vigine::messaging::QueueCapacity{256, true},
+        /* backpressure */ vigine::messaging::BackpressurePolicy::Error,
+    };
+}
+
+} // namespace
+
+// -----------------------------------------------------------------
+// Scheduled event entry stored in the registry.
+// -----------------------------------------------------------------
+
+struct ScheduledEvent
+{
+    EventConfig                                       config;
+    vigine::messaging::AbstractMessageTarget         *target{nullptr};
+    std::uint64_t                                     timerId{0};
+    std::atomic<bool>                                 active{true};
+    std::atomic<std::size_t>                          fireCount{0};
+    std::atomic<bool>                                 inFlight{false};
+};
+
+// -----------------------------------------------------------------
+// DefaultEventHandle — RAII handle returned to callers.
+// -----------------------------------------------------------------
+
+class DefaultEventHandle final : public IEventHandle
+{
+  public:
+    explicit DefaultEventHandle(std::shared_ptr<ScheduledEvent> event) noexcept
+        : _event(std::move(event))
+    {
+    }
+
+    ~DefaultEventHandle() override
+    {
+        cancel();
+    }
+
+    void cancel() noexcept override
+    {
+        if (_event)
+        {
+            _event->active.store(false, std::memory_order_release);
+        }
+    }
+
+    [[nodiscard]] bool active() const noexcept override
+    {
+        return _event && _event->active.load(std::memory_order_acquire);
+    }
+
+    DefaultEventHandle(const DefaultEventHandle &)            = delete;
+    DefaultEventHandle &operator=(const DefaultEventHandle &) = delete;
+    DefaultEventHandle(DefaultEventHandle &&)                 = delete;
+    DefaultEventHandle &operator=(DefaultEventHandle &&)      = delete;
+
+  private:
+    std::shared_ptr<ScheduledEvent> _event;
+};
+
+// -----------------------------------------------------------------
+// DefaultEventScheduler::Impl
+// -----------------------------------------------------------------
+
+struct DefaultEventScheduler::Impl
+{
+    ITimerSource   &timerSrc;
+    IOsSignalSource &osSignalSrc;
+
+    mutable std::shared_mutex                                    eventsMutex;
+    std::unordered_map<std::uint64_t, std::shared_ptr<ScheduledEvent>> byTimer;
+    std::vector<std::shared_ptr<ScheduledEvent>>                 byOsSignal;
+
+    std::atomic<std::uint64_t> nextId{1};
+    std::atomic<bool>          shutdown{false};
+
+    explicit Impl(ITimerSource &ts, IOsSignalSource &oss)
+        : timerSrc(ts), osSignalSrc(oss)
+    {
+    }
+};
+
+// -----------------------------------------------------------------
+// DefaultEventScheduler
+// -----------------------------------------------------------------
+
+DefaultEventScheduler::DefaultEventScheduler(
+    vigine::threading::IThreadManager &threadManager,
+    ITimerSource                      &timerSource,
+    IOsSignalSource                   &osSignalSource)
+    : AbstractEventScheduler{inlineBusConfig(), threadManager}
+    , _impl(std::make_unique<Impl>(timerSource, osSignalSource))
+{
+}
+
+DefaultEventScheduler::~DefaultEventScheduler()
+{
+    shutdown();
+}
+
+std::unique_ptr<IEventHandle>
+DefaultEventScheduler::schedule(
+    const EventConfig                        &config,
+    vigine::messaging::AbstractMessageTarget *target)
+{
+    if (!target)
+    {
+        return nullptr;
+    }
+    if (_impl->shutdown.load(std::memory_order_acquire))
+    {
+        return nullptr;
+    }
+
+    auto entry = std::make_shared<ScheduledEvent>();
+    entry->config = config;
+    entry->target = target;
+
+    if (config.isOsSignalTrigger())
+    {
+        // Register with OS signal source; store by osSignal.
+        auto result = _impl->osSignalSrc.subscribe(config.osSignal, this);
+        if (result.isError())
+        {
+            return nullptr;
+        }
+
+        std::unique_lock lock(_impl->eventsMutex);
+        _impl->byOsSignal.push_back(entry);
+    }
+    else if (config.period.count() > 0)
+    {
+        std::uint64_t timerId = _impl->timerSrc.armPeriodic(
+            config.period, config.count, this);
+        entry->timerId = timerId;
+
+        std::unique_lock lock(_impl->eventsMutex);
+        _impl->byTimer[timerId] = entry;
+    }
+    else if (config.delay.count() > 0)
+    {
+        std::uint64_t timerId = _impl->timerSrc.armOneShot(
+            config.delay, this);
+        entry->timerId = timerId;
+
+        std::unique_lock lock(_impl->eventsMutex);
+        _impl->byTimer[timerId] = entry;
+    }
+    else
+    {
+        // No valid trigger configured.
+        return nullptr;
+    }
+
+    return std::make_unique<DefaultEventHandle>(entry);
+}
+
+vigine::Result DefaultEventScheduler::shutdown()
+{
+    bool expected = false;
+    if (!_impl->shutdown.compare_exchange_strong(
+            expected, true,
+            std::memory_order_acq_rel,
+            std::memory_order_acquire))
+    {
+        // Already shut down — idempotent.
+        return vigine::Result{vigine::Result::Code::Success};
+    }
+
+    // Disarm all timers.
+    {
+        std::unique_lock lock(_impl->eventsMutex);
+        for (auto &[timerId, entry] : _impl->byTimer)
+        {
+            entry->active.store(false, std::memory_order_release);
+            _impl->timerSrc.disarm(timerId);
+        }
+        _impl->byTimer.clear();
+
+        // Cancel OS signal entries.
+        for (auto &entry : _impl->byOsSignal)
+        {
+            entry->active.store(false, std::memory_order_release);
+            _impl->osSignalSrc.unsubscribe(entry->config.osSignal, this);
+        }
+        _impl->byOsSignal.clear();
+    }
+
+    return vigine::messaging::AbstractMessageBus::shutdown();
+}
+
+void DefaultEventScheduler::onTimerFired(std::uint64_t timerId)
+{
+    std::shared_ptr<ScheduledEvent> entry;
+    {
+        std::shared_lock lock(_impl->eventsMutex);
+        auto it = _impl->byTimer.find(timerId);
+        if (it == _impl->byTimer.end())
+        {
+            return;
+        }
+        entry = it->second;
+    }
+
+    if (!entry->active.load(std::memory_order_acquire))
+    {
+        return;
+    }
+
+    // Enforce rescheduleWhileRunning policy.
+    if (!entry->config.rescheduleWhileRunning)
+    {
+        bool expected = false;
+        if (!entry->inFlight.compare_exchange_strong(
+                expected, true,
+                std::memory_order_acq_rel,
+                std::memory_order_acquire))
+        {
+            // Previous delivery still in-flight; skip this fire.
+            return;
+        }
+    }
+
+    // Enforce count limit.
+    if (entry->config.count > 0)
+    {
+        std::size_t fired = entry->fireCount.fetch_add(1, std::memory_order_acq_rel) + 1;
+        if (fired > entry->config.count)
+        {
+            entry->active.store(false, std::memory_order_release);
+            entry->inFlight.store(false, std::memory_order_release);
+            return;
+        }
+    }
+
+    // Determine payload type id.
+    vigine::payload::PayloadTypeId ptid = entry->config.firedPayloadTypeId;
+
+    auto payload = std::make_unique<EventPayload>(ptid);
+    auto msg     = std::make_unique<EventMessage>(ptid, std::move(payload), entry->target);
+
+    // Result intentionally discarded: dead-letter is handled by the bus.
+    static_cast<void>(vigine::messaging::AbstractMessageBus::post(std::move(msg)));
+    entry->inFlight.store(false, std::memory_order_release);
+
+    // Disarm if one-shot (period == 0).
+    if (entry->config.period.count() == 0)
+    {
+        entry->active.store(false, std::memory_order_release);
+    }
+}
+
+void DefaultEventScheduler::onOsSignal(OsSignal signal)
+{
+    std::vector<std::shared_ptr<ScheduledEvent>> matches;
+    {
+        std::shared_lock lock(_impl->eventsMutex);
+        for (auto &entry : _impl->byOsSignal)
+        {
+            if (entry->config.osSignal == signal
+                && entry->active.load(std::memory_order_acquire))
+            {
+                matches.push_back(entry);
+            }
+        }
+    }
+
+    for (auto &entry : matches)
+    {
+        vigine::payload::PayloadTypeId ptid = entry->config.firedPayloadTypeId;
+        auto payload = std::make_unique<EventPayload>(ptid);
+        auto msg     = std::make_unique<EventMessage>(ptid, std::move(payload), entry->target);
+        // Result intentionally discarded: dead-letter is handled by the bus.
+        static_cast<void>(vigine::messaging::AbstractMessageBus::post(std::move(msg)));
+    }
+}
+
+// -----------------------------------------------------------------
+// Factory
+// -----------------------------------------------------------------
+
+std::unique_ptr<IEventScheduler>
+createEventScheduler(vigine::threading::IThreadManager &threadManager,
+                     ITimerSource                      &timerSource,
+                     IOsSignalSource                   &osSignalSource)
+{
+    return std::make_unique<DefaultEventScheduler>(
+        threadManager, timerSource, osSignalSource);
+}
+
+} // namespace vigine::eventscheduler

--- a/src/eventscheduler/iossignalsource_macos.h
+++ b/src/eventscheduler/iossignalsource_macos.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#if defined(__APPLE__)
+
+#include <atomic>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include "vigine/eventscheduler/iossignalsource.h"
+#include "vigine/eventscheduler/ossignal.h"
+#include "vigine/result.h"
+
+namespace vigine::eventscheduler
+{
+
+/**
+ * @brief macOS OS-signal source using sigaction + self-pipe trick.
+ *
+ * An async-signal-safe signal handler writes the signal number to a pipe;
+ * a dedicated reader thread reads from the pipe and calls listeners.
+ * This avoids all async-signal-safety restrictions in the listener code.
+ *
+ * Private to @c src/eventscheduler/. Callers only see @ref IOsSignalSource.
+ */
+class MacOsSignalSource final : public IOsSignalSource
+{
+  public:
+    MacOsSignalSource();
+    ~MacOsSignalSource() override;
+
+    [[nodiscard]] vigine::Result subscribe(OsSignal signal,
+                                           IOsSignalListener *listener) override;
+
+    void unsubscribe(OsSignal signal, IOsSignalListener *listener) override;
+
+    /**
+     * @brief Returns the write end of the self-pipe.
+     *
+     * Called from the async-signal-safe handler; must not block.
+     */
+    [[nodiscard]] int pipeWriteFd() const noexcept;
+
+  private:
+    void readerLoop();
+
+    struct Entry
+    {
+        OsSignal           signal;
+        IOsSignalListener *listener{nullptr};
+    };
+
+    int                _pipeFd[2]{-1, -1};
+    std::mutex         _mutex;
+    std::vector<Entry> _listeners;
+    std::atomic<bool>  _stop;
+    std::thread        _readerThread;
+};
+
+} // namespace vigine::eventscheduler
+
+#endif // __APPLE__

--- a/src/eventscheduler/iossignalsource_macos.mm
+++ b/src/eventscheduler/iossignalsource_macos.mm
@@ -1,0 +1,191 @@
+#if defined(__APPLE__)
+
+#include "iossignalsource_macos.h"
+
+#include <algorithm>
+#include <atomic>
+#include <cerrno>
+#include <csignal>
+#include <cstring>
+#include <mutex>
+#include <thread>
+#include <unistd.h>
+#include <vector>
+
+namespace vigine::eventscheduler
+{
+
+// Self-pipe trick: the signal handler writes one byte to _pipeFd[1];
+// the reader thread reads from _pipeFd[0] and calls listeners.
+
+namespace
+{
+
+// Global pointer to the single MacOsSignalSource so the async-signal-safe
+// signal handler can reach the pipe write end.
+static MacOsSignalSource *g_instance = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+// Map POSIX signal number to OsSignal.
+[[nodiscard]] OsSignal posixToOsSignal(int signum) noexcept
+{
+    switch (signum)
+    {
+        case SIGTERM:  return OsSignal::Terminate;
+        case SIGINT:   return OsSignal::Interrupt;
+        case SIGHUP:   return OsSignal::Hangup;
+        case SIGUSR1:  return OsSignal::User1;
+        case SIGUSR2:  return OsSignal::User2;
+        default:       return OsSignal::Terminate;
+    }
+}
+
+// Async-signal-safe handler: write signal number to pipe.
+void sigHandler(int signum) noexcept
+{
+    MacOsSignalSource *src = g_instance;
+    if (!src)
+    {
+        return;
+    }
+    auto byte = static_cast<unsigned char>(signum);
+    // write() is async-signal-safe.
+    (void)::write(src->pipeWriteFd(), &byte, 1);
+}
+
+void installSigaction(int signum)
+{
+    struct sigaction sa{};
+    sa.sa_handler = sigHandler;
+    ::sigemptyset(&sa.sa_mask);
+    sa.sa_flags = SA_RESTART;
+    ::sigaction(signum, &sa, nullptr);
+}
+
+void restoreSigDefault(int signum)
+{
+    struct sigaction sa{};
+    sa.sa_handler = SIG_DFL;
+    ::sigemptyset(&sa.sa_mask);
+    ::sigaction(signum, &sa, nullptr);
+}
+
+} // namespace
+
+MacOsSignalSource::MacOsSignalSource()
+    : _stop(false)
+{
+    // Create self-pipe.
+    if (::pipe(_pipeFd) != 0)
+    {
+        _pipeFd[0] = -1;
+        _pipeFd[1] = -1;
+        return;
+    }
+
+    g_instance = this;
+
+    // Install handlers for all five signals.
+    installSigaction(SIGTERM);
+    installSigaction(SIGINT);
+    installSigaction(SIGHUP);
+    installSigaction(SIGUSR1);
+    installSigaction(SIGUSR2);
+
+    // Start reader thread.
+    _readerThread = std::thread([this] { readerLoop(); });
+}
+
+MacOsSignalSource::~MacOsSignalSource()
+{
+    // Restore default signal handlers.
+    restoreSigDefault(SIGTERM);
+    restoreSigDefault(SIGINT);
+    restoreSigDefault(SIGHUP);
+    restoreSigDefault(SIGUSR1);
+    restoreSigDefault(SIGUSR2);
+
+    g_instance = nullptr;
+
+    // Signal reader thread to stop.
+    _stop.store(true, std::memory_order_release);
+    if (_pipeFd[1] >= 0)
+    {
+        unsigned char sentinel = 0;
+        (void)::write(_pipeFd[1], &sentinel, 1);
+    }
+
+    if (_readerThread.joinable())
+    {
+        _readerThread.join();
+    }
+
+    if (_pipeFd[0] >= 0) { ::close(_pipeFd[0]); }
+    if (_pipeFd[1] >= 0) { ::close(_pipeFd[1]); }
+}
+
+vigine::Result MacOsSignalSource::subscribe(OsSignal signal, IOsSignalListener *listener)
+{
+    if (!listener)
+    {
+        return vigine::Result{vigine::Result::Code::Error,
+                              "subscribe: null listener"};
+    }
+    {
+        std::unique_lock lock(_mutex);
+        _listeners.push_back({signal, listener});
+    }
+    return vigine::Result{vigine::Result::Code::Success};
+}
+
+void MacOsSignalSource::unsubscribe(OsSignal signal, IOsSignalListener *listener)
+{
+    std::unique_lock lock(_mutex);
+    _listeners.erase(
+        std::remove_if(_listeners.begin(), _listeners.end(),
+                       [signal, listener](const Entry &e) {
+                           return e.signal == signal && e.listener == listener;
+                       }),
+        _listeners.end());
+}
+
+int MacOsSignalSource::pipeWriteFd() const noexcept
+{
+    return _pipeFd[1];
+}
+
+void MacOsSignalSource::readerLoop()
+{
+    unsigned char byte = 0;
+    while (true)
+    {
+        ssize_t n = ::read(_pipeFd[0], &byte, 1);
+        if (n <= 0)
+        {
+            // EOF or error — stop.
+            break;
+        }
+        if (_stop.load(std::memory_order_acquire) && byte == 0)
+        {
+            // Sentinel sent by destructor.
+            break;
+        }
+
+        OsSignal sig = posixToOsSignal(static_cast<int>(byte));
+        std::vector<Entry> snapshot;
+        {
+            std::unique_lock lock(_mutex);
+            snapshot = _listeners;
+        }
+        for (auto &entry : snapshot)
+        {
+            if (entry.signal == sig && entry.listener)
+            {
+                entry.listener->onOsSignal(sig);
+            }
+        }
+    }
+}
+
+} // namespace vigine::eventscheduler
+
+#endif // __APPLE__

--- a/src/eventscheduler/iossignalsource_win.cpp
+++ b/src/eventscheduler/iossignalsource_win.cpp
@@ -1,0 +1,123 @@
+#if defined(_WIN32)
+
+#include "iossignalsource_win.h"
+
+#include <algorithm>
+#include <atomic>
+#include <mutex>
+#include <vector>
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+
+namespace vigine::eventscheduler
+{
+
+// Global singleton pointer — SetConsoleCtrlHandler requires a free function.
+// The instance is set once when WinOsSignalSource is constructed and cleared
+// when it is destroyed. The engine instantiates exactly one WinOsSignalSource.
+static WinOsSignalSource *g_instance = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+namespace
+{
+
+[[nodiscard]] OsSignal mapWindowsCtrl(DWORD ctrlType) noexcept
+{
+    switch (ctrlType)
+    {
+        case CTRL_C_EVENT:        return OsSignal::Interrupt;
+        case CTRL_CLOSE_EVENT:    return OsSignal::Terminate;
+        // CTRL_BREAK_EVENT maps to Hangup (best-effort).
+        case CTRL_BREAK_EVENT:    return OsSignal::Hangup;
+        default:                  return OsSignal::Terminate;  // fallback
+    }
+}
+
+BOOL WINAPI consoleCtrlHandler(DWORD ctrlType) noexcept
+{
+    WinOsSignalSource *src = g_instance;
+    if (!src)
+    {
+        return FALSE;
+    }
+    OsSignal sig = mapWindowsCtrl(ctrlType);
+    src->dispatch(sig);
+    // Return FALSE to allow the default handler to run for CTRL_C
+    // (letting the process exit naturally); return TRUE for CTRL_CLOSE
+    // to suppress the default close behaviour so the engine can shut
+    // down cleanly.
+    return (ctrlType == CTRL_CLOSE_EVENT) ? TRUE : FALSE;
+}
+
+} // namespace
+
+WinOsSignalSource::WinOsSignalSource()
+{
+    g_instance = this;
+    SetConsoleCtrlHandler(consoleCtrlHandler, TRUE);
+}
+
+WinOsSignalSource::~WinOsSignalSource()
+{
+    SetConsoleCtrlHandler(consoleCtrlHandler, FALSE);
+    g_instance = nullptr;
+}
+
+vigine::Result WinOsSignalSource::subscribe(OsSignal signal, IOsSignalListener *listener)
+{
+    if (!listener)
+    {
+        return vigine::Result{vigine::Result::Code::Error,
+                              "subscribe: null listener"};
+    }
+
+    // Hangup (SIGHUP) has no Windows equivalent beyond CTRL_BREAK_EVENT
+    // which maps to it best-effort.  User1 and User2 have no mapping at all.
+    if (signal == OsSignal::User1 || signal == OsSignal::User2)
+    {
+        return vigine::Result{vigine::Result::Code::Error,
+                              "subscribe: OsSignal::User1/User2 not supported on Windows"};
+    }
+
+    {
+        std::unique_lock lock(_mutex);
+        _listeners.push_back({signal, listener});
+    }
+    return vigine::Result{vigine::Result::Code::Success};
+}
+
+void WinOsSignalSource::unsubscribe(OsSignal signal, IOsSignalListener *listener)
+{
+    std::unique_lock lock(_mutex);
+    _listeners.erase(
+        std::remove_if(_listeners.begin(), _listeners.end(),
+                       [signal, listener](const Entry &e) {
+                           return e.signal == signal && e.listener == listener;
+                       }),
+        _listeners.end());
+}
+
+void WinOsSignalSource::dispatch(OsSignal signal) noexcept
+{
+    std::vector<Entry> snapshot;
+    {
+        std::unique_lock lock(_mutex);
+        snapshot = _listeners;
+    }
+    for (auto &entry : snapshot)
+    {
+        if (entry.signal == signal && entry.listener)
+        {
+            entry.listener->onOsSignal(signal);
+        }
+    }
+}
+
+} // namespace vigine::eventscheduler
+
+#endif // _WIN32

--- a/src/eventscheduler/iossignalsource_win.h
+++ b/src/eventscheduler/iossignalsource_win.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#if defined(_WIN32)
+
+#include <mutex>
+#include <vector>
+
+#include "vigine/eventscheduler/iossignalsource.h"
+#include "vigine/eventscheduler/ossignal.h"
+#include "vigine/result.h"
+
+namespace vigine::eventscheduler
+{
+
+/**
+ * @brief Windows OS-signal source using SetConsoleCtrlHandler.
+ *
+ * Maps:
+ *   - CTRL_C_EVENT     -> OsSignal::Interrupt
+ *   - CTRL_CLOSE_EVENT -> OsSignal::Terminate
+ *   - CTRL_BREAK_EVENT -> OsSignal::Hangup (best-effort)
+ *   - User1 / User2    -> Result::Error (unsupported on Windows)
+ *
+ * Private to @c src/eventscheduler/. Callers only see @ref IOsSignalSource.
+ */
+class WinOsSignalSource final : public IOsSignalSource
+{
+  public:
+    WinOsSignalSource();
+    ~WinOsSignalSource() override;
+
+    [[nodiscard]] vigine::Result subscribe(OsSignal signal,
+                                           IOsSignalListener *listener) override;
+
+    void unsubscribe(OsSignal signal, IOsSignalListener *listener) override;
+
+    /**
+     * @brief Called from the Windows console control handler to fan out
+     *        to registered listeners.
+     *
+     * May be invoked from a Windows-created thread; implementations are
+     * thread-safe.
+     */
+    void dispatch(OsSignal signal) noexcept;
+
+  private:
+    struct Entry
+    {
+        OsSignal           signal;
+        IOsSignalListener *listener{nullptr};
+    };
+
+    std::mutex         _mutex;
+    std::vector<Entry> _listeners;
+};
+
+} // namespace vigine::eventscheduler
+
+#endif // _WIN32

--- a/src/eventscheduler/itimersource_default.cpp
+++ b/src/eventscheduler/itimersource_default.cpp
@@ -1,0 +1,210 @@
+#include "itimersource_default.h"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+namespace vigine::eventscheduler
+{
+
+// -----------------------------------------------------------------
+// TimerEntry — one registered timer.
+// -----------------------------------------------------------------
+
+struct TimerEntry
+{
+    std::uint64_t                         id{0};
+    std::chrono::steady_clock::time_point nextFire{};
+    std::chrono::milliseconds             period{0};
+    std::size_t                           count{0};
+    std::size_t                           fired{0};
+    ITimerFiredListener                  *listener{nullptr};
+    bool                                  active{true};
+};
+
+// -----------------------------------------------------------------
+// DefaultTimerSource — cross-platform implementation using
+// std::condition_variable::wait_until + a dedicated worker thread.
+// Resolution: ~1 ms on Linux/macOS, ~10-15 ms on Windows by default
+// (global timeBeginPeriod not applied to avoid side-effects).
+// -----------------------------------------------------------------
+
+DefaultTimerSource::DefaultTimerSource()
+    : _nextId(1)
+    , _stop(false)
+{
+    _thread = std::thread([this] { run(); });
+}
+
+DefaultTimerSource::~DefaultTimerSource()
+{
+    {
+        std::unique_lock lock(_mutex);
+        _stop = true;
+    }
+    _cv.notify_all();
+    if (_thread.joinable())
+    {
+        _thread.join();
+    }
+}
+
+std::uint64_t DefaultTimerSource::armOneShot(
+    std::chrono::milliseconds delay,
+    ITimerFiredListener       *listener)
+{
+    std::uint64_t id = _nextId.fetch_add(1, std::memory_order_relaxed);
+    auto now = std::chrono::steady_clock::now();
+    {
+        std::unique_lock lock(_mutex);
+        TimerEntry entry;
+        entry.id       = id;
+        entry.nextFire = now + delay;
+        entry.period   = std::chrono::milliseconds{0};
+        entry.count    = 1;
+        entry.fired    = 0;
+        entry.listener = listener;
+        entry.active   = true;
+        _timers.push_back(std::move(entry));
+    }
+    _cv.notify_one();
+    return id;
+}
+
+std::uint64_t DefaultTimerSource::armPeriodic(
+    std::chrono::milliseconds period,
+    std::size_t               count,
+    ITimerFiredListener       *listener)
+{
+    std::uint64_t id = _nextId.fetch_add(1, std::memory_order_relaxed);
+    auto now = std::chrono::steady_clock::now();
+    {
+        std::unique_lock lock(_mutex);
+        TimerEntry entry;
+        entry.id       = id;
+        entry.nextFire = now + period;
+        entry.period   = period;
+        entry.count    = count;
+        entry.fired    = 0;
+        entry.listener = listener;
+        entry.active   = true;
+        _timers.push_back(std::move(entry));
+    }
+    _cv.notify_one();
+    return id;
+}
+
+void DefaultTimerSource::disarm(std::uint64_t timerId)
+{
+    std::unique_lock lock(_mutex);
+    for (auto &entry : _timers)
+    {
+        if (entry.id == timerId)
+        {
+            entry.active = false;
+        }
+    }
+}
+
+void DefaultTimerSource::run()
+{
+    while (true)
+    {
+        std::chrono::steady_clock::time_point nextWakeup;
+        bool hasTimer = false;
+
+        std::vector<std::pair<ITimerFiredListener *, std::uint64_t>> toFire;
+
+        {
+            std::unique_lock lock(_mutex);
+            auto now = std::chrono::steady_clock::now();
+
+            // Remove inactive entries.
+            _timers.erase(
+                std::remove_if(_timers.begin(), _timers.end(),
+                               [](const TimerEntry &e) { return !e.active; }),
+                _timers.end());
+
+            // Collect fired timers.
+            for (auto &entry : _timers)
+            {
+                if (!entry.active)
+                {
+                    continue;
+                }
+                if (entry.nextFire <= now)
+                {
+                    toFire.emplace_back(entry.listener, entry.id);
+                    entry.fired++;
+
+                    if (entry.period.count() > 0
+                        && (entry.count == 0 || entry.fired < entry.count))
+                    {
+                        // Reschedule.
+                        entry.nextFire = now + entry.period;
+                    }
+                    else
+                    {
+                        entry.active = false;
+                    }
+                }
+            }
+
+            // Find next wake-up.
+            for (const auto &entry : _timers)
+            {
+                if (!entry.active)
+                {
+                    continue;
+                }
+                if (!hasTimer || entry.nextFire < nextWakeup)
+                {
+                    nextWakeup = entry.nextFire;
+                    hasTimer   = true;
+                }
+            }
+
+            if (_stop && _timers.empty())
+            {
+                break;
+            }
+
+            if (!hasTimer)
+            {
+                _cv.wait(lock, [this] {
+                    return _stop || !_timers.empty();
+                });
+                if (_stop)
+                {
+                    break;
+                }
+                continue;
+            }
+
+            _cv.wait_until(lock, nextWakeup, [this] { return _stop; });
+
+            if (_stop)
+            {
+                break;
+            }
+        }
+
+        // Fire callbacks outside the lock.
+        for (auto &[listener, id] : toFire)
+        {
+            if (listener)
+            {
+                listener->onTimerFired(id);
+            }
+        }
+    }
+}
+
+} // namespace vigine::eventscheduler

--- a/src/eventscheduler/itimersource_default.h
+++ b/src/eventscheduler/itimersource_default.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include "vigine/eventscheduler/itimersource.h"
+
+namespace vigine::eventscheduler
+{
+
+struct TimerEntry;
+
+/**
+ * @brief Cross-platform timer source using a dedicated worker thread.
+ *
+ * Uses @c std::chrono::steady_clock + @c std::condition_variable::wait_until.
+ * Resolution: ~1 ms on POSIX; ~10-15 ms on Windows without timeBeginPeriod.
+ *
+ * Private to @c src/eventscheduler/. Callers only see @ref ITimerSource.
+ */
+class DefaultTimerSource final : public ITimerSource
+{
+  public:
+    DefaultTimerSource();
+    ~DefaultTimerSource() override;
+
+    [[nodiscard]] std::uint64_t armOneShot(std::chrono::milliseconds delay,
+                                           ITimerFiredListener       *listener) override;
+
+    [[nodiscard]] std::uint64_t armPeriodic(std::chrono::milliseconds period,
+                                             std::size_t               count,
+                                             ITimerFiredListener       *listener) override;
+
+    void disarm(std::uint64_t timerId) override;
+
+  private:
+    void run();
+
+    std::atomic<std::uint64_t>  _nextId;
+    std::mutex                  _mutex;
+    std::condition_variable     _cv;
+    std::vector<TimerEntry>     _timers;
+    bool                        _stop{false};
+    std::thread                 _thread;
+};
+
+} // namespace vigine::eventscheduler

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -171,3 +171,37 @@ gtest_discover_tests(${MESSAGING_SMOKE_TARGET}
     DISCOVERY_MODE PRE_TEST
 )
 
+# ====================== Event-Scheduler Smoke Target =======================
+# Smoke coverage for IEventScheduler: one-shot timer fires once, cancel
+# prevents delivery, and OS signal triggers delivery via mock sources.
+set(EVENTSCHEDULER_SMOKE_TARGET eventscheduler-smoke)
+
+add_executable(${EVENTSCHEDULER_SMOKE_TARGET}
+    eventscheduler/smoke_test.cpp
+)
+
+target_include_directories(${EVENTSCHEDULER_SMOKE_TARGET}
+    PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(${EVENTSCHEDULER_SMOKE_TARGET}
+    PRIVATE
+    gtest
+    gtest_main
+    vigine
+    ${GLM_LIBRARIES}
+)
+
+set_target_properties(${EVENTSCHEDULER_SMOKE_TARGET} PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
+gtest_discover_tests(${EVENTSCHEDULER_SMOKE_TARGET}
+    PROPERTIES LABELS "eventscheduler-smoke"
+    DISCOVERY_TIMEOUT 60
+    DISCOVERY_MODE PRE_TEST
+)
+

--- a/test/eventscheduler/smoke_test.cpp
+++ b/test/eventscheduler/smoke_test.cpp
@@ -1,0 +1,279 @@
+#include "vigine/eventscheduler/defaulteventscheduler.h"
+#include "vigine/eventscheduler/eventconfig.h"
+#include "vigine/eventscheduler/ieventhandle.h"
+#include "vigine/eventscheduler/ieventscheduler.h"
+#include "vigine/eventscheduler/iossignalsource.h"
+#include "vigine/eventscheduler/itimersource.h"
+#include "vigine/eventscheduler/ossignal.h"
+#include "vigine/messaging/abstractmessagetarget.h"
+#include "vigine/messaging/iconnectiontoken.h"
+#include "vigine/messaging/imessage.h"
+#include "vigine/messaging/messagekind.h"
+#include "vigine/messaging/targetkind.h"
+#include "vigine/result.h"
+#include "vigine/threading/factory.h"
+#include "vigine/threading/ithreadmanager.h"
+#include "vigine/threading/threadmanagerconfig.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// Test doubles
+// ---------------------------------------------------------------------------
+
+namespace
+{
+
+using namespace vigine::eventscheduler;
+
+// Minimal ITimerSource that fires manually via triggerTimer().
+class MockTimerSource final : public ITimerSource
+{
+  public:
+    struct Entry
+    {
+        std::uint64_t       id{0};
+        ITimerFiredListener *listener{nullptr};
+        bool                active{true};
+    };
+
+    [[nodiscard]] std::uint64_t
+        armOneShot(std::chrono::milliseconds /*delay*/,
+                   ITimerFiredListener       *listener) override
+    {
+        std::uint64_t id = _nextId++;
+        std::unique_lock lock(_mutex);
+        _entries.push_back({id, listener, true});
+        return id;
+    }
+
+    [[nodiscard]] std::uint64_t
+        armPeriodic(std::chrono::milliseconds /*period*/,
+                    std::size_t               /*count*/,
+                    ITimerFiredListener       *listener) override
+    {
+        return armOneShot(std::chrono::milliseconds{0}, listener);
+    }
+
+    void disarm(std::uint64_t timerId) override
+    {
+        std::unique_lock lock(_mutex);
+        for (auto &e : _entries)
+        {
+            if (e.id == timerId)
+            {
+                e.active = false;
+            }
+        }
+    }
+
+    void triggerAll()
+    {
+        std::vector<Entry> snapshot;
+        {
+            std::unique_lock lock(_mutex);
+            snapshot = _entries;
+        }
+        for (auto &e : snapshot)
+        {
+            if (e.active && e.listener)
+            {
+                e.listener->onTimerFired(e.id);
+            }
+        }
+    }
+
+  private:
+    std::uint64_t      _nextId{1};
+    std::mutex         _mutex;
+    std::vector<Entry> _entries;
+};
+
+// Minimal IOsSignalSource that fires manually via fireSignal().
+class MockOsSignalSource final : public IOsSignalSource
+{
+  public:
+    struct Entry
+    {
+        OsSignal           signal;
+        IOsSignalListener *listener{nullptr};
+    };
+
+    [[nodiscard]] vigine::Result subscribe(OsSignal signal,
+                                           IOsSignalListener *listener) override
+    {
+        if (!listener)
+        {
+            return vigine::Result{vigine::Result::Code::Error, "null listener"};
+        }
+        std::unique_lock lock(_mutex);
+        _entries.push_back({signal, listener});
+        return vigine::Result{vigine::Result::Code::Success};
+    }
+
+    void unsubscribe(OsSignal signal, IOsSignalListener *listener) override
+    {
+        std::unique_lock lock(_mutex);
+        _entries.erase(
+            std::remove_if(_entries.begin(), _entries.end(),
+                           [signal, listener](const Entry &e) {
+                               return e.signal == signal && e.listener == listener;
+                           }),
+            _entries.end());
+    }
+
+    void fireSignal(OsSignal signal)
+    {
+        std::vector<Entry> snapshot;
+        {
+            std::unique_lock lock(_mutex);
+            snapshot = _entries;
+        }
+        for (auto &e : snapshot)
+        {
+            if (e.signal == signal && e.listener)
+            {
+                e.listener->onOsSignal(signal);
+            }
+        }
+    }
+
+  private:
+    std::mutex         _mutex;
+    std::vector<Entry> _entries;
+};
+
+// Concrete message target that counts delivered messages.
+class CountingTarget final : public vigine::messaging::AbstractMessageTarget
+{
+  public:
+    [[nodiscard]] vigine::messaging::TargetKind targetKind() const noexcept override
+    {
+        return vigine::messaging::TargetKind::User;
+    }
+
+    void onMessage(const vigine::messaging::IMessage &msg) override
+    {
+        EXPECT_EQ(msg.kind(), vigine::messaging::MessageKind::Event);
+        _count.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    [[nodiscard]] int count() const noexcept
+    {
+        return _count.load(std::memory_order_relaxed);
+    }
+
+  private:
+    std::atomic<int> _count{0};
+};
+
+// Helper: create a thread manager for tests.
+std::unique_ptr<vigine::threading::IThreadManager> makeThreadManager()
+{
+    vigine::threading::ThreadManagerConfig cfg;
+    cfg.poolSize = 1;
+    return vigine::threading::createThreadManager(cfg);
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 1: one-shot timer fires once and delivers to target.
+// ---------------------------------------------------------------------------
+
+TEST(EventSchedulerSmoke, OneShotTimerFiresOnce)
+{
+    auto threadMgr = makeThreadManager();
+    MockTimerSource   timerSrc;
+    MockOsSignalSource osSrc;
+
+    auto scheduler = createEventScheduler(*threadMgr, timerSrc, osSrc);
+    ASSERT_NE(scheduler, nullptr);
+
+    CountingTarget target;
+
+    EventConfig cfg;
+    cfg.delay      = std::chrono::milliseconds{10};
+    cfg.period     = std::chrono::milliseconds{0};
+    cfg.useOsSignal = false;
+
+    auto handle = scheduler->schedule(cfg, &target);
+    ASSERT_NE(handle, nullptr);
+    EXPECT_TRUE(handle->active());
+
+    // Simulate timer firing.
+    timerSrc.triggerAll();
+
+    EXPECT_EQ(target.count(), 1);
+
+    // After one-shot fires, handle should be inactive.
+    EXPECT_FALSE(handle->active());
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 2: cancel prevents delivery.
+// ---------------------------------------------------------------------------
+
+TEST(EventSchedulerSmoke, CancelPreventsDelivery)
+{
+    auto threadMgr = makeThreadManager();
+    MockTimerSource   timerSrc;
+    MockOsSignalSource osSrc;
+
+    auto scheduler = createEventScheduler(*threadMgr, timerSrc, osSrc);
+
+    CountingTarget target;
+
+    EventConfig cfg;
+    cfg.delay       = std::chrono::milliseconds{10};
+    cfg.period      = std::chrono::milliseconds{0};
+    cfg.useOsSignal = false;
+
+    auto handle = scheduler->schedule(cfg, &target);
+    ASSERT_NE(handle, nullptr);
+
+    // Cancel before the timer fires.
+    handle->cancel();
+    EXPECT_FALSE(handle->active());
+
+    timerSrc.triggerAll();
+
+    // Target should have received nothing.
+    EXPECT_EQ(target.count(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 3: OS signal triggers delivery.
+// ---------------------------------------------------------------------------
+
+TEST(EventSchedulerSmoke, OsSignalTriggersDelivery)
+{
+    auto threadMgr = makeThreadManager();
+    MockTimerSource   timerSrc;
+    MockOsSignalSource osSrc;
+
+    auto scheduler = createEventScheduler(*threadMgr, timerSrc, osSrc);
+
+    CountingTarget target;
+
+    EventConfig cfg;
+    cfg.useOsSignal = true;
+    cfg.osSignal    = OsSignal::Interrupt;
+
+    auto handle = scheduler->schedule(cfg, &target);
+    ASSERT_NE(handle, nullptr);
+    EXPECT_TRUE(handle->active());
+
+    // Fire SIGINT.
+    osSrc.fireSignal(OsSignal::Interrupt);
+
+    EXPECT_EQ(target.count(), 1);
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

- Ships `IEventScheduler` facade (Level-2, plan_16 / R.3.3.1.2) over `IMessageBus`
- Supports three trigger modes: one-shot delay, periodic + count, OS signal
- Platform timer source: `DefaultTimerSource` via `std::chrono + condition_variable` worker thread
- Platform OS signal sources: `WinOsSignalSource` (SetConsoleCtrlHandler) + `MacOsSignalSource` (sigaction + self-pipe trick)
- Five-layer wrapper recipe: `IMessageBus → AbstractMessageBus → IEventScheduler → AbstractEventScheduler → DefaultEventScheduler`
- Factory `createEventScheduler` returns `std::unique_ptr<IEventScheduler>` (FF-1)
- 3-scenario smoke test: one-shot fires once, cancel prevents delivery, OS signal triggers delivery

## Test plan

- [x] `cmake -S . -B build` Debug + Release succeed, no new warnings
- [x] `cmake --build build --target eventscheduler-smoke` compiles and links
- [x] `grep -q "class IEventScheduler" include/vigine/eventscheduler/ieventscheduler.h`
- [x] `grep -q "enum class OsSignal" include/vigine/eventscheduler/ossignal.h` with exactly 5 values (Terminate/Interrupt/Hangup/User1/User2)
- [x] `createEventScheduler` returns `std::unique_ptr<IEventScheduler>` (FF-1)
- [x] No template parameters in public headers (INV-1)
- [x] No graph types in `include/vigine/eventscheduler/` (INV-11)
- [x] All data members private (strict encapsulation)
- [x] Inheritance order: `public IEventScheduler` FIRST, `protected AbstractMessageBus` SECOND

Closes #103