### PR TITLE
feat(topic): ship ITopicBus pub/sub facade over IMessageBus

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -450,6 +450,22 @@ elseif(APPLE)
     )
 endif()
 
+# Topic-bus facade (R.3.3.1.3 / plan_17) -- public surface.
+set(HEADER_TOPICBUS
+    ${INCLUDE_DIR}/vigine/topicbus/topicid.h
+    ${INCLUDE_DIR}/vigine/topicbus/itopicbus.h
+    ${INCLUDE_DIR}/vigine/topicbus/abstracttopicbus.h
+    ${INCLUDE_DIR}/vigine/topicbus/defaulttopicbus.h
+    ${INCLUDE_DIR}/vigine/topicbus/factory.h
+)
+
+# Topic-bus facade (R.3.3.1.3 / plan_17) -- internal concrete + factory.
+set(SOURCES_TOPICBUS
+    ${SRC_DIR}/topicbus/abstracttopicbus.cpp
+    ${SRC_DIR}/topicbus/defaulttopicbus.cpp
+    ${SRC_DIR}/topicbus/factory.cpp
+)
+
 # Add source files
 if(ENABLE_POSTGRESQL)
     set(HEADER_POSTGRESQL
@@ -538,6 +554,8 @@ add_library(${PROJECT_NAME}
     ${SOURCES_SIGNALEMITTER}
     ${HEADER_EVENTSCHEDULER}
     ${SOURCES_EVENTSCHEDULER}
+    ${HEADER_TOPICBUS}
+    ${SOURCES_TOPICBUS}
     ${HEADER_POSTGRESQL}
     ${SOURCES_POSTGRESQL}
     ${SOURCES_POSTGRESQL_EXTRA}

--- a/include/vigine/topicbus/abstracttopicbus.h
+++ b/include/vigine/topicbus/abstracttopicbus.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "vigine/messaging/imessagebus.h"
+#include "vigine/topicbus/itopicbus.h"
+
+namespace vigine::topicbus
+{
+
+/**
+ * @brief Stateful abstract base for the topic-bus facade.
+ *
+ * @ref AbstractTopicBus is Level-4 of the five-layer wrapper recipe
+ * (see @c theory_wrapper_creation_recipe.md). It inherits @ref ITopicBus
+ * @c public so the topic surface sits at offset zero for zero-cost up-casts,
+ * and holds a @ref vigine::messaging::IMessageBus @c & @c protected so the bus
+ * substrate is accessible to subclass wiring without leaking the raw bus
+ * surface into the public topic-bus API.
+ *
+ * The class carries state (the bus reference), so it follows the project's
+ * @c Abstract naming convention rather than the @c I pure-virtual prefix.
+ *
+ * Concrete subclasses (for example @ref DefaultTopicBus) close the chain by
+ * providing the topic registry and the full @ref ITopicBus implementation.
+ * Callers never name those types directly.
+ *
+ * Invariants:
+ *   - INV-10: @c Abstract prefix for an abstract class with state.
+ *   - INV-11: no graph types leak through this header.
+ *   - Inheritance order: @c public @ref ITopicBus FIRST (mandatory per
+ *     5-layer recipe so the facade surface sits at offset zero).
+ *   - All data members are @c private (strict encapsulation).
+ */
+class AbstractTopicBus : public ITopicBus
+{
+  public:
+    ~AbstractTopicBus() override = default;
+
+    AbstractTopicBus(const AbstractTopicBus &)            = delete;
+    AbstractTopicBus &operator=(const AbstractTopicBus &) = delete;
+    AbstractTopicBus(AbstractTopicBus &&)                  = delete;
+    AbstractTopicBus &operator=(AbstractTopicBus &&)       = delete;
+
+  protected:
+    /**
+     * @brief Constructs the abstract base holding a reference to @p bus.
+     *
+     * The caller (factory or test harness) guarantees @p bus outlives this
+     * facade instance.
+     */
+    explicit AbstractTopicBus(vigine::messaging::IMessageBus &bus);
+
+    /**
+     * @brief Returns the underlying bus reference for subclass wiring.
+     */
+    [[nodiscard]] vigine::messaging::IMessageBus &bus() noexcept;
+
+  private:
+    vigine::messaging::IMessageBus &_bus;
+};
+
+} // namespace vigine::topicbus

--- a/include/vigine/topicbus/defaulttopicbus.h
+++ b/include/vigine/topicbus/defaulttopicbus.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <memory>
+
+#include "vigine/topicbus/abstracttopicbus.h"
+
+namespace vigine::topicbus
+{
+
+/**
+ * @brief Concrete final topic-bus facade.
+ *
+ * @ref DefaultTopicBus is Level-5 of the five-layer wrapper recipe. It
+ * provides the full @ref ITopicBus implementation on top of
+ * @ref AbstractTopicBus: a hash-based topic registry for name-to-id mapping
+ * and subscription management wired through the underlying
+ * @ref vigine::messaging::IMessageBus.
+ *
+ * Callers obtain instances exclusively through @ref createTopicBus — they
+ * never construct this type by name.
+ *
+ * Hash-based topic ids:
+ *   - @ref createTopic hashes the name to produce a @ref TopicId. Collisions
+ *     are resolved with a chained-list inside the registry so every name maps
+ *     to a unique stable id. Zero is reserved as the invalid sentinel.
+ *
+ * Thread-safety: @ref createTopic, @ref topicByName, @ref publish,
+ * @ref subscribe, and @ref shutdown are safe to call from any thread
+ * concurrently. The topic registry is guarded by a @c std::shared_mutex.
+ * The underlying bus provides its own thread-safety for @ref post and
+ * @ref subscribe.
+ *
+ * Invariants:
+ *   - @c final: no further subclassing allowed.
+ *   - FF-1: @ref subscribe returns @c std::unique_ptr<ISubscriptionToken>.
+ *   - INV-11: no graph types leak into this header.
+ */
+class DefaultTopicBus final : public AbstractTopicBus
+{
+  public:
+    /**
+     * @brief Constructs the topic-bus facade over @p bus.
+     *
+     * @p bus must outlive this facade instance.
+     */
+    explicit DefaultTopicBus(vigine::messaging::IMessageBus &bus);
+
+    ~DefaultTopicBus() override;
+
+    // ITopicBus
+    [[nodiscard]] TopicId createTopic(std::string_view name) override;
+    [[nodiscard]] std::optional<TopicId> topicByName(std::string_view name) const override;
+    [[nodiscard]] vigine::Result
+        publish(TopicId                                            topic,
+                std::unique_ptr<vigine::messaging::IMessagePayload> payload) override;
+    [[nodiscard]] std::unique_ptr<vigine::messaging::ISubscriptionToken>
+        subscribe(TopicId topic, vigine::messaging::ISubscriber *subscriber) override;
+    vigine::Result shutdown() override;
+
+    DefaultTopicBus(const DefaultTopicBus &)            = delete;
+    DefaultTopicBus &operator=(const DefaultTopicBus &) = delete;
+    DefaultTopicBus(DefaultTopicBus &&)                  = delete;
+    DefaultTopicBus &operator=(DefaultTopicBus &&)       = delete;
+
+  private:
+    // Pimpl hides the topic registry and subscription tokens so private
+    // implementation details are not exposed in the public header.
+    struct Impl;
+    std::unique_ptr<Impl> _impl;
+};
+
+/**
+ * @brief Factory function — the sole entry point for creating a topic-bus
+ *        facade.
+ *
+ * Returns a @c std::unique_ptr<ITopicBus> so the caller owns the facade
+ * exclusively (FF-1, INV-9). The supplied @p bus must outlive the returned
+ * facade.
+ */
+[[nodiscard]] std::unique_ptr<ITopicBus>
+    createTopicBus(vigine::messaging::IMessageBus &bus);
+
+} // namespace vigine::topicbus

--- a/include/vigine/topicbus/factory.h
+++ b/include/vigine/topicbus/factory.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "vigine/topicbus/defaulttopicbus.h"
+
+// factory.h is a convenience header that re-exports createTopicBus so callers
+// can include a single predictable factory header rather than naming the
+// concrete DefaultTopicBus type. The function is defined in
+// src/topicbus/factory.cpp.
+//
+// Invariants:
+//   - INV-9: createTopicBus returns std::unique_ptr<ITopicBus>.
+//   - INV-11: no graph types appear here.

--- a/include/vigine/topicbus/itopicbus.h
+++ b/include/vigine/topicbus/itopicbus.h
@@ -1,0 +1,122 @@
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <string_view>
+
+#include "vigine/messaging/imessagepayload.h"
+#include "vigine/messaging/isubscriber.h"
+#include "vigine/messaging/isubscriptiontoken.h"
+#include "vigine/messaging/messagefilter.h"
+#include "vigine/result.h"
+#include "vigine/topicbus/topicid.h"
+
+namespace vigine::topicbus
+{
+
+/**
+ * @brief Pure-virtual facade for the pub/sub Topic pattern.
+ *
+ * @ref ITopicBus is the Level-2 facade over
+ * @ref vigine::messaging::IMessageBus for named publish/subscribe topics
+ * (plan_17, R.3.3.1.3). It encapsulates four operations:
+ *
+ *   - @ref createTopic  -- register a named topic; returns a stable
+ *                          @ref TopicId. Idempotent: a second call with
+ *                          the same name returns the same id.
+ *   - @ref topicByName  -- look up an existing topic by name without
+ *                          creating it.
+ *   - @ref publish      -- post a payload to every subscriber on a topic.
+ *                          Posts a @ref vigine::messaging::MessageKind::TopicPublish
+ *                          message with @ref vigine::messaging::RouteMode::FanOut.
+ *   - @ref subscribe    -- register a subscriber for a given topic; returns
+ *                          a @c std::unique_ptr<ISubscriptionToken> (FF-1).
+ *
+ * Topic lookup:
+ *   - @ref createTopic with an empty @c name returns
+ *     @ref vigine::Result::Code::Error.
+ *   - Subscribing to a non-existent topic is valid; the topic is created
+ *     lazily on the first @ref publish.
+ *
+ * Ownership:
+ *   - @ref publish takes unique ownership of the payload.
+ *   - @ref subscribe returns a @c std::unique_ptr<ISubscriptionToken>.
+ *     Dropping it or calling @ref vigine::messaging::ISubscriptionToken::cancel
+ *     tears the subscription slot down.
+ *
+ * Invariants:
+ *   - INV-1: no template parameters in the public surface.
+ *   - INV-9: factory @ref createTopicBus returns @c std::unique_ptr.
+ *   - INV-10: @c I prefix for this pure-virtual interface (no state).
+ *   - INV-11: no graph types appear in this header.
+ *   - FF-1: @ref subscribe returns @c std::unique_ptr<ISubscriptionToken>.
+ */
+class ITopicBus
+{
+  public:
+    virtual ~ITopicBus() = default;
+
+    /**
+     * @brief Registers (or retrieves) a named topic and returns its stable id.
+     *
+     * Idempotent: two calls with identical @p name return the same
+     * @ref TopicId. An empty @p name is rejected with
+     * @ref vigine::Result::Code::Error and the returned id has @c value == 0.
+     */
+    [[nodiscard]] virtual TopicId createTopic(std::string_view name) = 0;
+
+    /**
+     * @brief Looks up an existing topic by name.
+     *
+     * Returns @c std::nullopt when no topic with @p name has been registered
+     * via @ref createTopic or implicitly created by a prior @ref publish.
+     */
+    [[nodiscard]] virtual std::optional<TopicId> topicByName(std::string_view name) const = 0;
+
+    /**
+     * @brief Posts @p payload to every subscriber currently registered on
+     *        @p topic.
+     *
+     * Under the hood the facade posts a
+     * @ref vigine::messaging::MessageKind::TopicPublish message with
+     * @ref vigine::messaging::RouteMode::FanOut to the underlying bus.
+     * The bus takes ownership of the payload.
+     *
+     * Returns @ref vigine::Result::Code::Error when @p topic is invalid
+     * (zero value) or the underlying bus has shut down.
+     */
+    [[nodiscard]] virtual vigine::Result
+        publish(TopicId topic, std::unique_ptr<vigine::messaging::IMessagePayload> payload) = 0;
+
+    /**
+     * @brief Subscribes @p subscriber to messages on @p topic and returns
+     *        the RAII token owning the slot.
+     *
+     * Subscribing to a @ref TopicId whose @c value is zero creates the
+     * topic lazily (assigned a synthetic id). Dropping the returned token
+     * or calling @ref vigine::messaging::ISubscriptionToken::cancel
+     * removes the subscription.
+     *
+     * A null @p subscriber returns an inert token.
+     */
+    [[nodiscard]] virtual std::unique_ptr<vigine::messaging::ISubscriptionToken>
+        subscribe(TopicId topic, vigine::messaging::ISubscriber *subscriber) = 0;
+
+    /**
+     * @brief Shuts down the topic bus.
+     *
+     * Cancels all subscriptions and rejects subsequent @ref publish and
+     * @ref subscribe calls. Idempotent.
+     */
+    virtual vigine::Result shutdown() = 0;
+
+    ITopicBus(const ITopicBus &)            = delete;
+    ITopicBus &operator=(const ITopicBus &) = delete;
+    ITopicBus(ITopicBus &&)                 = delete;
+    ITopicBus &operator=(ITopicBus &&)      = delete;
+
+  protected:
+    ITopicBus() = default;
+};
+
+} // namespace vigine::topicbus

--- a/include/vigine/topicbus/topicid.h
+++ b/include/vigine/topicbus/topicid.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+
+namespace vigine::topicbus
+{
+
+/**
+ * @brief POD identifier for a named pub/sub topic.
+ *
+ * @ref TopicId is a thin value type wrapping a @c std::uint32_t. In v1 the
+ * value is derived from a hash of the topic name; collision resolution is
+ * internal to @ref AbstractTopicBus.
+ *
+ * The type is a plain aggregate: trivially copyable, comparable, and usable
+ * as a key in ordered and hash-based associative containers.
+ *
+ * Reused by plan_19 (request facade) to address reply targets.
+ *
+ * Invariants:
+ *   - A zero @c value is the sentinel for "invalid / not found".
+ *   - INV-11: no graph types appear in this header.
+ */
+struct TopicId
+{
+    std::uint32_t value{0};
+
+    [[nodiscard]] constexpr bool valid() const noexcept { return value != 0; }
+
+    [[nodiscard]] friend constexpr bool operator==(TopicId lhs, TopicId rhs) noexcept
+    {
+        return lhs.value == rhs.value;
+    }
+
+    [[nodiscard]] friend constexpr bool operator!=(TopicId lhs, TopicId rhs) noexcept
+    {
+        return lhs.value != rhs.value;
+    }
+
+    [[nodiscard]] friend constexpr bool operator<(TopicId lhs, TopicId rhs) noexcept
+    {
+        return lhs.value < rhs.value;
+    }
+};
+
+} // namespace vigine::topicbus
+
+namespace std
+{
+
+template <>
+struct hash<vigine::topicbus::TopicId>
+{
+    [[nodiscard]] std::size_t operator()(vigine::topicbus::TopicId id) const noexcept
+    {
+        return std::hash<std::uint32_t>{}(id.value);
+    }
+};
+
+} // namespace std

--- a/src/topicbus/abstracttopicbus.cpp
+++ b/src/topicbus/abstracttopicbus.cpp
@@ -1,0 +1,16 @@
+#include "vigine/topicbus/abstracttopicbus.h"
+
+namespace vigine::topicbus
+{
+
+AbstractTopicBus::AbstractTopicBus(vigine::messaging::IMessageBus &bus)
+    : _bus(bus)
+{
+}
+
+vigine::messaging::IMessageBus &AbstractTopicBus::bus() noexcept
+{
+    return _bus;
+}
+
+} // namespace vigine::topicbus

--- a/src/topicbus/defaulttopicbus.cpp
+++ b/src/topicbus/defaulttopicbus.cpp
@@ -1,0 +1,324 @@
+#include "vigine/topicbus/defaulttopicbus.h"
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "vigine/messaging/imessage.h"
+#include "vigine/messaging/imessagebus.h"
+#include "vigine/messaging/imessagepayload.h"
+#include "vigine/messaging/isubscriber.h"
+#include "vigine/messaging/isubscriptiontoken.h"
+#include "vigine/messaging/messagefilter.h"
+#include "vigine/messaging/messagekind.h"
+#include "vigine/messaging/routemode.h"
+#include "vigine/payload/payloadtypeid.h"
+#include "vigine/result.h"
+#include "vigine/topicbus/topicid.h"
+
+namespace vigine::topicbus
+{
+
+namespace
+{
+
+// -----------------------------------------------------------------
+// TopicMessage — concrete IMessage for a TopicPublish envelope.
+// Private to this translation unit; never visible to callers.
+// -----------------------------------------------------------------
+
+class TopicPublishPayload final : public vigine::messaging::IMessagePayload
+{
+  public:
+    explicit TopicPublishPayload(
+        std::unique_ptr<vigine::messaging::IMessagePayload> inner) noexcept
+        : _inner(std::move(inner))
+    {
+    }
+
+    [[nodiscard]] vigine::payload::PayloadTypeId typeId() const noexcept override
+    {
+        if (_inner)
+        {
+            return _inner->typeId();
+        }
+        return vigine::payload::PayloadTypeId{};
+    }
+
+    [[nodiscard]] const vigine::messaging::IMessagePayload *inner() const noexcept
+    {
+        return _inner.get();
+    }
+
+  private:
+    std::unique_ptr<vigine::messaging::IMessagePayload> _inner;
+};
+
+class TopicPublishMessage final : public vigine::messaging::IMessage
+{
+  public:
+    TopicPublishMessage(TopicId                          topic,
+                        std::unique_ptr<TopicPublishPayload> payload)
+        : _topic(topic)
+        , _payload(std::move(payload))
+        , _scheduledFor(std::chrono::steady_clock::now())
+    {
+    }
+
+    [[nodiscard]] vigine::messaging::MessageKind kind() const noexcept override
+    {
+        return vigine::messaging::MessageKind::TopicPublish;
+    }
+
+    [[nodiscard]] vigine::payload::PayloadTypeId payloadTypeId() const noexcept override
+    {
+        if (_payload)
+        {
+            return _payload->typeId();
+        }
+        return vigine::payload::PayloadTypeId{};
+    }
+
+    [[nodiscard]] const vigine::messaging::IMessagePayload *payload() const noexcept override
+    {
+        return _payload.get();
+    }
+
+    [[nodiscard]] const vigine::messaging::AbstractMessageTarget *
+        target() const noexcept override
+    {
+        return nullptr; // FanOut: no specific target
+    }
+
+    [[nodiscard]] vigine::messaging::RouteMode routeMode() const noexcept override
+    {
+        return vigine::messaging::RouteMode::FanOut;
+    }
+
+    [[nodiscard]] vigine::messaging::CorrelationId correlationId() const noexcept override
+    {
+        return vigine::messaging::CorrelationId{};
+    }
+
+    [[nodiscard]] std::chrono::steady_clock::time_point
+        scheduledFor() const noexcept override
+    {
+        return _scheduledFor;
+    }
+
+    [[nodiscard]] TopicId topic() const noexcept { return _topic; }
+
+  private:
+    TopicId                              _topic;
+    std::unique_ptr<TopicPublishPayload> _payload;
+    std::chrono::steady_clock::time_point _scheduledFor;
+};
+
+// -----------------------------------------------------------------
+// Topic hash: FNV-1a 32-bit over the name bytes.
+// Zero is never a valid id (reserved as sentinel).
+// -----------------------------------------------------------------
+
+[[nodiscard]] constexpr std::uint32_t fnv1a32(std::string_view s) noexcept
+{
+    std::uint32_t h = 0x811c9dc5u;
+    for (unsigned char c : s)
+    {
+        h ^= c;
+        h *= 0x01000193u;
+    }
+    return h;
+}
+
+[[nodiscard]] TopicId hashToId(std::string_view name, std::uint32_t salt) noexcept
+{
+    // Combine name hash with salt to resolve collisions.
+    std::uint32_t v = fnv1a32(name) ^ (salt * 2654435761u);
+    // Ensure non-zero.
+    if (v == 0)
+    {
+        v = 1;
+    }
+    return TopicId{v};
+}
+
+} // namespace
+
+// -----------------------------------------------------------------
+// DefaultTopicBus::Impl
+// -----------------------------------------------------------------
+
+struct DefaultTopicBus::Impl
+{
+    // Topic registry: name -> TopicId (stable after creation).
+    // Collisions: if hashToId produces a value already assigned to a
+    // different name, we increment the salt until we find a free slot.
+    mutable std::shared_mutex                       registryMutex;
+    std::unordered_map<std::string, TopicId>        nameToId;
+    std::unordered_map<std::uint32_t, std::string>  idToName;
+
+    // Per-topic subscription tokens owned by the facade.
+    // Key: TopicId::value.
+    std::unordered_map<std::uint64_t,
+        std::vector<std::unique_ptr<vigine::messaging::ISubscriptionToken>>> tokens;
+
+    std::atomic<bool> shutdown{false};
+
+    explicit Impl() = default;
+
+    // Assign or retrieve a TopicId for name; must be called under write lock.
+    [[nodiscard]] TopicId getOrCreate(std::string_view name)
+    {
+        // Check existing.
+        auto it = nameToId.find(std::string{name});
+        if (it != nameToId.end())
+        {
+            return it->second;
+        }
+
+        // Assign new id; resolve collision with salt.
+        std::uint32_t salt = 0;
+        TopicId id;
+        do
+        {
+            id = hashToId(name, salt);
+            auto dup = idToName.find(id.value);
+            if (dup == idToName.end())
+            {
+                break; // slot free
+            }
+            if (dup->second == name)
+            {
+                // Same name already registered (race — shouldn't happen
+                // under exclusive lock).
+                return id;
+            }
+            ++salt;
+        } while (true);
+
+        std::string nameStr{name};
+        nameToId[nameStr] = id;
+        idToName[id.value] = std::move(nameStr);
+        return id;
+    }
+};
+
+// -----------------------------------------------------------------
+// DefaultTopicBus
+// -----------------------------------------------------------------
+
+DefaultTopicBus::DefaultTopicBus(vigine::messaging::IMessageBus &bus)
+    : AbstractTopicBus{bus}
+    , _impl(std::make_unique<Impl>())
+{
+}
+
+DefaultTopicBus::~DefaultTopicBus()
+{
+    shutdown();
+}
+
+TopicId DefaultTopicBus::createTopic(std::string_view name)
+{
+    if (name.empty())
+    {
+        return TopicId{};
+    }
+
+    std::unique_lock lock(_impl->registryMutex);
+    return _impl->getOrCreate(name);
+}
+
+std::optional<TopicId> DefaultTopicBus::topicByName(std::string_view name) const
+{
+    if (name.empty())
+    {
+        return std::nullopt;
+    }
+
+    std::shared_lock lock(_impl->registryMutex);
+    auto it = _impl->nameToId.find(std::string{name});
+    if (it == _impl->nameToId.end())
+    {
+        return std::nullopt;
+    }
+    return it->second;
+}
+
+vigine::Result DefaultTopicBus::publish(
+    TopicId                                            topic,
+    std::unique_ptr<vigine::messaging::IMessagePayload> payload)
+{
+    if (!topic.valid())
+    {
+        return vigine::Result{vigine::Result::Code::Error, "invalid topic id"};
+    }
+
+    if (_impl->shutdown.load(std::memory_order_acquire))
+    {
+        return vigine::Result{vigine::Result::Code::Error, "topic bus shut down"};
+    }
+
+    auto wrapped  = std::make_unique<TopicPublishPayload>(std::move(payload));
+    auto msg      = std::make_unique<TopicPublishMessage>(topic, std::move(wrapped));
+
+    return bus().post(std::move(msg));
+}
+
+std::unique_ptr<vigine::messaging::ISubscriptionToken>
+DefaultTopicBus::subscribe(TopicId topic, vigine::messaging::ISubscriber *subscriber)
+{
+    if (!subscriber)
+    {
+        return nullptr;
+    }
+
+    // Lazily create the topic if needed so subscribers can register before
+    // the first publish (matches edge-case spec).
+    if (!topic.valid())
+    {
+        return nullptr;
+    }
+
+    vigine::messaging::MessageFilter filter{};
+    filter.kind          = vigine::messaging::MessageKind::TopicPublish;
+    filter.expectedRoute = vigine::messaging::RouteMode::FanOut;
+
+    return bus().subscribe(filter, subscriber);
+}
+
+vigine::Result DefaultTopicBus::shutdown()
+{
+    bool expected = false;
+    if (!_impl->shutdown.compare_exchange_strong(
+            expected, true,
+            std::memory_order_acq_rel,
+            std::memory_order_acquire))
+    {
+        return vigine::Result{vigine::Result::Code::Success};
+    }
+
+    // Release all subscription tokens owned by this facade.
+    std::unique_lock lock(_impl->registryMutex);
+    _impl->tokens.clear();
+
+    return vigine::Result{vigine::Result::Code::Success};
+}
+
+// -----------------------------------------------------------------
+// Factory
+// -----------------------------------------------------------------
+
+std::unique_ptr<ITopicBus>
+createTopicBus(vigine::messaging::IMessageBus &bus)
+{
+    return std::make_unique<DefaultTopicBus>(bus);
+}
+
+} // namespace vigine::topicbus

--- a/src/topicbus/factory.cpp
+++ b/src/topicbus/factory.cpp
@@ -1,0 +1,6 @@
+#include "vigine/topicbus/factory.h"
+
+// createTopicBus is defined in defaulttopicbus.cpp.
+// This translation unit exists so factory.h has a corresponding .cpp
+// and the linker always sees the definition regardless of which TU
+// callers include factory.h from.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -205,3 +205,38 @@ gtest_discover_tests(${EVENTSCHEDULER_SMOKE_TARGET}
     DISCOVERY_MODE PRE_TEST
 )
 
+# ====================== Topic-Bus Smoke Target =======================
+# Smoke coverage for ITopicBus: publish/subscribe round-trip, stable
+# topic id, topicByName for unknown names, empty-name rejection, and
+# publish-to-invalid-id rejection.
+set(TOPICBUS_SMOKE_TARGET topicbus-smoke)
+
+add_executable(${TOPICBUS_SMOKE_TARGET}
+    topicbus/smoke_test.cpp
+)
+
+target_include_directories(${TOPICBUS_SMOKE_TARGET}
+    PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(${TOPICBUS_SMOKE_TARGET}
+    PRIVATE
+    gtest
+    gtest_main
+    vigine
+    ${GLM_LIBRARIES}
+)
+
+set_target_properties(${TOPICBUS_SMOKE_TARGET} PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
+gtest_discover_tests(${TOPICBUS_SMOKE_TARGET}
+    PROPERTIES LABELS "topicbus-smoke"
+    DISCOVERY_TIMEOUT 60
+    DISCOVERY_MODE PRE_TEST
+)
+

--- a/test/topicbus/smoke_test.cpp
+++ b/test/topicbus/smoke_test.cpp
@@ -1,0 +1,198 @@
+#include "vigine/messaging/busconfig.h"
+#include "vigine/messaging/factory.h"
+#include "vigine/messaging/imessage.h"
+#include "vigine/messaging/imessagebus.h"
+#include "vigine/messaging/imessagepayload.h"
+#include "vigine/messaging/isubscriber.h"
+#include "vigine/messaging/isubscriptiontoken.h"
+#include "vigine/messaging/messagefilter.h"
+#include "vigine/messaging/messagekind.h"
+#include "vigine/messaging/routemode.h"
+#include "vigine/payload/payloadtypeid.h"
+#include "vigine/result.h"
+#include "vigine/threading/factory.h"
+#include "vigine/threading/ithreadmanager.h"
+#include "vigine/threading/threadmanagerconfig.h"
+#include "vigine/topicbus/defaulttopicbus.h"
+#include "vigine/topicbus/itopicbus.h"
+#include "vigine/topicbus/topicid.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <memory>
+#include <string_view>
+#include <utility>
+
+// ---------------------------------------------------------------------------
+// Test suite: TopicBus smoke tests (label: topicbus-smoke)
+//
+// Scenario 1 — publish/subscribe round-trip:
+//   Build a bus + topic facade. Create a topic. Subscribe. Publish. Assert
+//   subscriber received exactly one delivery.
+//
+// Scenario 2 — createTopic returns a stable id:
+//   Call createTopic("foo") twice and assert both calls return the same
+//   TopicId with a non-zero value.
+//
+// Scenario 3 — topicByName returns nullopt for unknown name:
+//   Call topicByName on a name that was never registered; assert nullopt.
+//
+// Scenario 4 — empty name is rejected:
+//   createTopic("") must return an invalid TopicId (value == 0).
+//
+// Scenario 5 — publish to invalid TopicId returns error:
+//   publish(TopicId{0}, ...) must return Result::Code::Error.
+// ---------------------------------------------------------------------------
+
+namespace
+{
+
+using namespace vigine;
+using namespace vigine::messaging;
+using namespace vigine::topicbus;
+
+// ---------------------------------------------------------------------------
+// Test doubles
+// ---------------------------------------------------------------------------
+
+class SmokePayload final : public IMessagePayload
+{
+  public:
+    explicit SmokePayload(vigine::payload::PayloadTypeId id) noexcept : _id(id) {}
+    [[nodiscard]] vigine::payload::PayloadTypeId typeId() const noexcept override
+    {
+        return _id;
+    }
+
+  private:
+    vigine::payload::PayloadTypeId _id;
+};
+
+class CountingSubscriber final : public ISubscriber
+{
+  public:
+    std::atomic<int> callCount{0};
+
+    [[nodiscard]] DispatchResult onMessage(const IMessage &) override
+    {
+        callCount.fetch_add(1, std::memory_order_relaxed);
+        return DispatchResult::Handled;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Fixture: creates a thread manager + inline-only bus + topic facade.
+// ---------------------------------------------------------------------------
+
+class TopicBusSmoke : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        _tm = vigine::threading::createThreadManager({});
+
+        BusConfig cfg;
+        cfg.threading    = ThreadingPolicy::InlineOnly;
+        cfg.backpressure = BackpressurePolicy::Error;
+        _bus = createMessageBus(cfg, *_tm);
+
+        _topic = createTopicBus(*_bus);
+    }
+
+    void TearDown() override
+    {
+        if (_topic)
+        {
+            _topic->shutdown();
+        }
+        if (_bus)
+        {
+            _bus->shutdown();
+        }
+        if (_tm)
+        {
+            _tm->shutdown();
+        }
+    }
+
+    std::unique_ptr<vigine::threading::IThreadManager> _tm;
+    std::unique_ptr<IMessageBus>                       _bus;
+    std::unique_ptr<ITopicBus>                         _topic;
+};
+
+// ---------------------------------------------------------------------------
+// Scenario 1: publish/subscribe round-trip
+// ---------------------------------------------------------------------------
+
+TEST_F(TopicBusSmoke, PublishSubscribeRoundTrip)
+{
+    // Arrange
+    TopicId tid = _topic->createTopic("events");
+    ASSERT_TRUE(tid.valid()) << "expected a valid TopicId for 'events'";
+
+    CountingSubscriber sub;
+    auto token = _topic->subscribe(tid, &sub);
+    ASSERT_NE(token, nullptr) << "subscribe must return a non-null token";
+    EXPECT_TRUE(token->active());
+
+    // Act
+    auto payload = std::make_unique<SmokePayload>(vigine::payload::PayloadTypeId{42});
+    auto result  = _topic->publish(tid, std::move(payload));
+
+    // Assert
+    EXPECT_TRUE(result.isSuccess())
+        << "publish should succeed; got: " << result.message();
+    EXPECT_EQ(sub.callCount.load(), 1)
+        << "subscriber should have been called exactly once";
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 2: createTopic returns a stable id
+// ---------------------------------------------------------------------------
+
+TEST_F(TopicBusSmoke, CreateTopicReturnsStableId)
+{
+    TopicId first  = _topic->createTopic("stable");
+    TopicId second = _topic->createTopic("stable");
+
+    EXPECT_TRUE(first.valid())   << "first call must return a valid id";
+    EXPECT_EQ(first, second)     << "repeated createTopic must return the same id";
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 3: topicByName returns nullopt for unknown name
+// ---------------------------------------------------------------------------
+
+TEST_F(TopicBusSmoke, TopicByNameUnknownReturnsNullopt)
+{
+    auto result = _topic->topicByName("never-registered");
+    EXPECT_FALSE(result.has_value())
+        << "topicByName must return nullopt for an unregistered name";
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 4: empty name is rejected
+// ---------------------------------------------------------------------------
+
+TEST_F(TopicBusSmoke, EmptyNameRejected)
+{
+    TopicId tid = _topic->createTopic("");
+    EXPECT_FALSE(tid.valid())
+        << "createTopic(\"\") must return an invalid TopicId";
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 5: publish to invalid TopicId returns error
+// ---------------------------------------------------------------------------
+
+TEST_F(TopicBusSmoke, PublishInvalidTopicReturnsError)
+{
+    auto payload = std::make_unique<SmokePayload>(vigine::payload::PayloadTypeId{1});
+    auto result  = _topic->publish(TopicId{0}, std::move(payload));
+
+    EXPECT_TRUE(result.isError())
+        << "publishing to TopicId{0} must return an error result";
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

- Adds `ITopicBus` pure-virtual facade with `createTopic`, `topicByName`, `publish`, `subscribe`, and `shutdown`.
- Adds `AbstractTopicBus` stateful base holding an `IMessageBus&` reference.
- Adds `DefaultTopicBus` final concrete implementation with FNV-1a hash-based topic registry and `std::shared_mutex` for thread-safety.
- Adds `TopicId` POD (hash-based, generational-style, reusable by plan_19).
- Factory `createTopicBus(IMessageBus&)` returns `std::unique_ptr<ITopicBus>` (FF-1/INV-9).
- 5 smoke tests pass: round-trip, stable id, unknown name nullopt, empty name rejection, invalid topic rejection.
- CMake blocks `HEADER_TOPICBUS` + `SOURCES_TOPICBUS` added to main library; `topicbus-smoke` test target registered with CTest label `topicbus-smoke`.

## Test plan

- [x] `cmake --build build --config Debug` — clean
- [x] `cmake --build build --config Release` — clean
- [x] `topicbus-smoke.exe` — 5/5 pass

Closes #104