### PR TITLE
feat(channel): IChannelFactory CSP-style channel facade over IMessageBus

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -466,6 +466,25 @@ set(SOURCES_TOPICBUS
     ${SRC_DIR}/topicbus/factory.cpp
 )
 
+# Channel factory facade (R.3.3.1.4 / plan_18) -- public surface.
+set(HEADER_CHANNELFACTORY
+    ${INCLUDE_DIR}/vigine/channelfactory/channelkind.h
+    ${INCLUDE_DIR}/vigine/channelfactory/ichannel.h
+    ${INCLUDE_DIR}/vigine/channelfactory/ichannelfactory.h
+    ${INCLUDE_DIR}/vigine/channelfactory/abstractchannelfactory.h
+    ${INCLUDE_DIR}/vigine/channelfactory/defaultchannelfactory.h
+    ${INCLUDE_DIR}/vigine/channelfactory/factory.h
+)
+
+# Channel factory facade (R.3.3.1.4 / plan_18) -- internal concrete + factory.
+set(SOURCES_CHANNELFACTORY
+    ${SRC_DIR}/channelfactory/abstractchannelfactory.cpp
+    ${SRC_DIR}/channelfactory/defaultchannel.h
+    ${SRC_DIR}/channelfactory/defaultchannel.cpp
+    ${SRC_DIR}/channelfactory/defaultchannelfactory.cpp
+    ${SRC_DIR}/channelfactory/factory.cpp
+)
+
 # Add source files
 if(ENABLE_POSTGRESQL)
     set(HEADER_POSTGRESQL
@@ -556,6 +575,8 @@ add_library(${PROJECT_NAME}
     ${SOURCES_EVENTSCHEDULER}
     ${HEADER_TOPICBUS}
     ${SOURCES_TOPICBUS}
+    ${HEADER_CHANNELFACTORY}
+    ${SOURCES_CHANNELFACTORY}
     ${HEADER_POSTGRESQL}
     ${SOURCES_POSTGRESQL}
     ${SOURCES_POSTGRESQL_EXTRA}

--- a/include/vigine/channelfactory/abstractchannelfactory.h
+++ b/include/vigine/channelfactory/abstractchannelfactory.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "vigine/channelfactory/ichannelfactory.h"
+#include "vigine/messaging/imessagebus.h"
+
+namespace vigine::channelfactory
+{
+
+/**
+ * @brief Stateful abstract base for the channel-factory facade.
+ *
+ * @ref AbstractChannelFactory is Level-4 of the five-layer wrapper recipe.
+ * It inherits @ref IChannelFactory @c public so the channel-factory surface
+ * sits at offset zero for zero-cost up-casts, and holds a
+ * @ref vigine::messaging::IMessageBus @c & @c private so the bus substrate
+ * is accessible to subclasses through @ref bus() without leaking the raw bus
+ * surface into the public channel-factory API.
+ *
+ * The class carries state (the bus reference), so it follows the project's
+ * @c Abstract naming convention rather than the @c I pure-virtual prefix.
+ *
+ * Concrete subclasses (for example @ref DefaultChannelFactory) close the chain
+ * by providing the channel registry and the full @ref IChannelFactory
+ * implementation. Callers never name those types directly.
+ *
+ * Invariants:
+ *   - INV-10: @c Abstract prefix for an abstract class with state.
+ *   - INV-11: no graph types leak through this header.
+ *   - Inheritance order: @c public @ref IChannelFactory FIRST (mandatory per
+ *     5-layer recipe so the facade surface sits at offset zero).
+ *   - All data members are @c private (strict encapsulation).
+ */
+class AbstractChannelFactory : public IChannelFactory
+{
+  public:
+    ~AbstractChannelFactory() override = default;
+
+    AbstractChannelFactory(const AbstractChannelFactory &)            = delete;
+    AbstractChannelFactory &operator=(const AbstractChannelFactory &) = delete;
+    AbstractChannelFactory(AbstractChannelFactory &&)                  = delete;
+    AbstractChannelFactory &operator=(AbstractChannelFactory &&)       = delete;
+
+  protected:
+    /**
+     * @brief Constructs the abstract base holding a reference to @p bus.
+     *
+     * The caller (factory or test harness) guarantees @p bus outlives this
+     * facade instance.
+     */
+    explicit AbstractChannelFactory(vigine::messaging::IMessageBus &bus);
+
+    /**
+     * @brief Returns the underlying bus reference for subclass wiring.
+     */
+    [[nodiscard]] vigine::messaging::IMessageBus &bus() noexcept;
+
+  private:
+    vigine::messaging::IMessageBus &_bus;
+};
+
+} // namespace vigine::channelfactory

--- a/include/vigine/channelfactory/channelkind.h
+++ b/include/vigine/channelfactory/channelkind.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <cstdint>
+
+namespace vigine::channelfactory
+{
+
+/**
+ * @brief Closed enum describing the capacity behaviour of a channel.
+ *
+ * @ref ChannelKind controls how @ref IChannelFactory::create interprets
+ * the capacity argument:
+ *
+ *   - @c Bounded   -- the channel holds at most @c capacity messages; the
+ *                     capacity argument must be >= 1 or
+ *                     @ref vigine::Result::Code::Error is returned.
+ *   - @c Unbounded -- the channel grows without limit; the capacity argument
+ *                     must be 0 (callers pass 0 to signal "do not care") or
+ *                     @ref vigine::Result::Code::Error is returned.
+ *
+ * Invariants:
+ *   - INV-11: no graph types appear in this header.
+ *   - The enum is closed (no sentinel / max value) to prevent accidental
+ *     numeric casts leaking from call sites.
+ */
+enum class ChannelKind : std::uint8_t
+{
+    Bounded   = 0,
+    Unbounded = 1,
+};
+
+} // namespace vigine::channelfactory

--- a/include/vigine/channelfactory/defaultchannelfactory.h
+++ b/include/vigine/channelfactory/defaultchannelfactory.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <memory>
+
+#include "vigine/channelfactory/abstractchannelfactory.h"
+#include "vigine/channelfactory/channelkind.h"
+#include "vigine/channelfactory/ichannel.h"
+#include "vigine/payload/payloadtypeid.h"
+#include "vigine/result.h"
+
+
+
+
+namespace vigine::channelfactory
+{
+
+/**
+ * @brief Concrete final channel-factory facade.
+ *
+ * @ref DefaultChannelFactory is Level-5 of the five-layer wrapper recipe. It
+ * provides the full @ref IChannelFactory implementation on top of
+ * @ref AbstractChannelFactory: a channel registry keyed by raw pointer,
+ * validated create / close / shutdown lifecycle, and concrete
+ * @ref DefaultChannel objects with a mutex-guarded bounded FIFO queue.
+ *
+ * Callers obtain instances exclusively through @ref createChannelFactory —
+ * they never construct this type by name.
+ *
+ * Thread-safety: @ref create and @ref shutdown are safe to call from any
+ * thread concurrently. The channel registry is guarded by a @c std::mutex.
+ *
+ * Invariants:
+ *   - @c final: no further subclassing allowed.
+ *   - FF-1: @ref create returns @c std::unique_ptr<IChannel>.
+ *   - INV-11: no graph types leak into this header.
+ */
+class DefaultChannelFactory final : public AbstractChannelFactory
+{
+  public:
+    /**
+     * @brief Constructs the channel-factory facade over @p bus.
+     *
+     * @p bus must outlive this facade instance.
+     */
+    explicit DefaultChannelFactory(vigine::messaging::IMessageBus &bus);
+
+    ~DefaultChannelFactory() override;
+
+    // IChannelFactory
+    [[nodiscard]] std::unique_ptr<IChannel>
+        create(ChannelKind                       kind,
+               std::size_t                       capacity,
+               vigine::payload::PayloadTypeId    expectedTypeId,
+               vigine::Result                   *outResult = nullptr) override;
+
+    vigine::Result shutdown() override;
+
+    DefaultChannelFactory(const DefaultChannelFactory &)            = delete;
+    DefaultChannelFactory &operator=(const DefaultChannelFactory &) = delete;
+    DefaultChannelFactory(DefaultChannelFactory &&)                  = delete;
+    DefaultChannelFactory &operator=(DefaultChannelFactory &&)       = delete;
+
+  private:
+    struct Impl;
+    std::unique_ptr<Impl> _impl;
+};
+
+/**
+ * @brief Factory function — the sole entry point for creating a channel-factory
+ *        facade.
+ *
+ * Returns a @c std::unique_ptr<IChannelFactory> so the caller owns the facade
+ * exclusively (FF-1, INV-9). The supplied @p bus must outlive the returned
+ * facade.
+ */
+[[nodiscard]] std::unique_ptr<IChannelFactory>
+    createChannelFactory(vigine::messaging::IMessageBus &bus);
+
+} // namespace vigine::channelfactory

--- a/include/vigine/channelfactory/factory.h
+++ b/include/vigine/channelfactory/factory.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "vigine/channelfactory/defaultchannelfactory.h"
+
+// factory.h is a convenience header that re-exports createChannelFactory so
+// callers can include a single predictable factory header rather than naming
+// the concrete DefaultChannelFactory type. The function is defined in
+// src/channelfactory/factory.cpp.
+//
+// Invariants:
+//   - INV-9: createChannelFactory returns std::unique_ptr<IChannelFactory>.
+//   - INV-11: no graph types appear here.

--- a/include/vigine/channelfactory/ichannel.h
+++ b/include/vigine/channelfactory/ichannel.h
@@ -1,0 +1,135 @@
+#pragma once
+
+#include <memory>
+
+#include "vigine/messaging/imessagepayload.h"
+#include "vigine/payload/payloadtypeid.h"
+#include "vigine/result.h"
+
+namespace vigine::channelfactory
+{
+
+/**
+ * @brief Pure-virtual per-channel operations for a CSP-style bounded channel.
+ *
+ * @ref IChannel is the per-handle interface vended by @ref IChannelFactory.
+ * One factory produces many channels; each channel is a typed point-to-point
+ * pipe. Type safety is achieved through @ref vigine::payload::PayloadTypeId:
+ * every @ref send call is validated against the expected type id the channel
+ * was created with, and a mismatch returns @ref vigine::Result::Code::Error.
+ *
+ * Ownership:
+ *   - @ref send takes unique ownership of the payload on success; on failure
+ *     the caller retains ownership.
+ *   - @ref receive and @ref tryReceive transfer ownership of a dequeued
+ *     payload to the caller.
+ *
+ * Thread-safety: all entry points are safe to call from any thread
+ * concurrently.
+ *
+ * Lifecycle:
+ *   - @ref close flips the channel closed; further @ref send calls return an
+ *     error; @ref receive and @ref tryReceive drain any remaining payloads
+ *     then report closure.
+ *   - Idempotent: the second and subsequent @ref close calls are no-ops.
+ *
+ * Invariants:
+ *   - INV-1: no template parameters in the public surface.
+ *   - INV-10: @c I prefix for a pure-virtual interface (no state).
+ *   - INV-11: no graph types appear in this header.
+ */
+class IChannel
+{
+  public:
+    virtual ~IChannel() = default;
+
+    /**
+     * @brief Sends @p payload, blocking up to @p timeoutMs milliseconds when
+     *        the channel is full (Bounded) or until the channel is closed.
+     *
+     * The @p payload type id must match the expected id the channel was
+     * created with; a mismatch returns @ref vigine::Result::Code::Error and
+     * the caller retains ownership of @p payload.
+     *
+     * Returns a success @ref vigine::Result and transfers ownership when the
+     * payload was enqueued. Returns an error when the channel is closed, the
+     * timeout elapses (Bounded channels), or the payload type id does not
+     * match.
+     */
+    [[nodiscard]] virtual vigine::Result
+        send(std::unique_ptr<vigine::messaging::IMessagePayload> payload,
+             int timeoutMs = -1) = 0;
+
+    /**
+     * @brief Attempts to send @p payload without blocking.
+     *
+     * Returns @c true and transfers ownership on success. Returns @c false
+     * without mutating @p payload when the channel is full, closed, or the
+     * type id does not match.
+     */
+    [[nodiscard]] virtual bool
+        trySend(std::unique_ptr<vigine::messaging::IMessagePayload> &payload) = 0;
+
+    /**
+     * @brief Receives a payload, blocking up to @p timeoutMs milliseconds
+     *        when the channel is empty.
+     *
+     * On success @p out receives ownership of the dequeued payload and the
+     * returned @ref vigine::Result is successful. When @p timeoutMs elapses
+     * before a payload becomes available, or when the channel is both closed
+     * and empty, the returned @ref vigine::Result is an error and @p out is
+     * left default-constructed.
+     *
+     * A value of -1 for @p timeoutMs means "block indefinitely".
+     */
+    [[nodiscard]] virtual vigine::Result
+        receive(std::unique_ptr<vigine::messaging::IMessagePayload> &out,
+                int timeoutMs = -1) = 0;
+
+    /**
+     * @brief Attempts to receive a payload without blocking.
+     *
+     * Returns @c true and transfers ownership into @p out when a payload is
+     * immediately available. Returns @c false without mutating @p out when
+     * the channel is empty (whether or not it is closed). A closed-and-empty
+     * channel returns @c false.
+     */
+    [[nodiscard]] virtual bool
+        tryReceive(std::unique_ptr<vigine::messaging::IMessagePayload> &out) = 0;
+
+    /**
+     * @brief Closes the channel.
+     *
+     * Idempotent. After close, @ref send fails immediately; @ref receive and
+     * @ref tryReceive drain remaining payloads then signal closure. Threads
+     * blocked in @ref send or @ref receive wake up with an error
+     * @ref vigine::Result.
+     */
+    virtual void close() = 0;
+
+    /**
+     * @brief Returns @c true if @ref close has been called at least once.
+     *
+     * Diagnostic accessor; the value may change between the call and the
+     * next operation on the channel.
+     */
+    [[nodiscard]] virtual bool isClosed() const = 0;
+
+    /**
+     * @brief Returns the number of payloads currently queued.
+     *
+     * Diagnostic accessor; the value may change between the call and the
+     * next operation on the channel.
+     */
+    [[nodiscard]] virtual std::size_t size() const = 0;
+
+    IChannel(const IChannel &)            = delete;
+    IChannel &operator=(const IChannel &) = delete;
+    IChannel(IChannel &&)                 = delete;
+    IChannel &operator=(IChannel &&)      = delete;
+
+  protected:
+    IChannel() = default;
+};
+
+} // namespace vigine::channelfactory

--- a/include/vigine/channelfactory/ichannelfactory.h
+++ b/include/vigine/channelfactory/ichannelfactory.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <memory>
+
+#include "vigine/channelfactory/channelkind.h"
+#include "vigine/channelfactory/ichannel.h"
+#include "vigine/payload/payloadtypeid.h"
+#include "vigine/result.h"
+
+namespace vigine::channelfactory
+{
+
+/**
+ * @brief Pure-virtual facade-level factory producing @ref IChannel handles.
+ *
+ * @ref IChannelFactory is the Level-2 facade over
+ * @ref vigine::messaging::IMessageBus for CSP-style bounded channels
+ * (plan_18, R.3.3.1.4). It encapsulates three operations:
+ *
+ *   - @ref create   -- allocates a new channel of the given kind and capacity,
+ *                       validates the config edge cases, and returns a
+ *                       @c std::unique_ptr<IChannel>.
+ *   - @ref shutdown -- cancels all open channels (closes each one) and
+ *                       rejects subsequent @ref create calls.
+ *
+ * Config edge cases (enforced by @ref create):
+ *   - @ref ChannelKind::Bounded  with capacity < 1 returns error.
+ *   - @ref ChannelKind::Unbounded with capacity != 0 returns error.
+ *
+ * Ownership:
+ *   - @ref create returns a @c std::unique_ptr<IChannel> (FF-1, INV-9).
+ *     The caller owns the channel; destroying it without first calling
+ *     @ref IChannel::close discards any queued payloads silently.
+ *
+ * Thread-safety: every entry point is safe to call from any thread.
+ *
+ * Invariants:
+ *   - INV-1: no template parameters in the public surface.
+ *   - INV-9: @ref create returns @c std::unique_ptr.
+ *   - INV-10: @c I prefix for a pure-virtual interface (no state).
+ *   - INV-11: no graph types appear in this header.
+ */
+class IChannelFactory
+{
+  public:
+    virtual ~IChannelFactory() = default;
+
+    /**
+     * @brief Creates a new channel of the given @p kind with the given
+     *        @p capacity and expected payload type @p expectedTypeId.
+     *
+     * Returns a non-null @c std::unique_ptr<IChannel> on success. On invalid
+     * config (capacity == 0 with Bounded, or capacity != 0 with Unbounded)
+     * returns a null @c std::unique_ptr and sets @p outResult to an error
+     * @ref vigine::Result. If @p outResult is null the error detail is
+     * silently discarded.
+     *
+     * Subsequent @ref create calls after @ref shutdown return null.
+     */
+    [[nodiscard]] virtual std::unique_ptr<IChannel>
+        create(ChannelKind                       kind,
+               std::size_t                       capacity,
+               vigine::payload::PayloadTypeId    expectedTypeId,
+               vigine::Result                   *outResult = nullptr) = 0;
+
+    /**
+     * @brief Shuts down the factory.
+     *
+     * Closes every channel that was created through this factory and still
+     * exists, then rejects subsequent @ref create calls. Idempotent.
+     */
+    virtual vigine::Result shutdown() = 0;
+
+    IChannelFactory(const IChannelFactory &)            = delete;
+    IChannelFactory &operator=(const IChannelFactory &) = delete;
+    IChannelFactory(IChannelFactory &&)                 = delete;
+    IChannelFactory &operator=(IChannelFactory &&)      = delete;
+
+  protected:
+    IChannelFactory() = default;
+};
+
+} // namespace vigine::channelfactory

--- a/src/channelfactory/abstractchannelfactory.cpp
+++ b/src/channelfactory/abstractchannelfactory.cpp
@@ -1,0 +1,16 @@
+#include "vigine/channelfactory/abstractchannelfactory.h"
+
+namespace vigine::channelfactory
+{
+
+AbstractChannelFactory::AbstractChannelFactory(vigine::messaging::IMessageBus &bus)
+    : _bus(bus)
+{
+}
+
+vigine::messaging::IMessageBus &AbstractChannelFactory::bus() noexcept
+{
+    return _bus;
+}
+
+} // namespace vigine::channelfactory

--- a/src/channelfactory/defaultchannel.cpp
+++ b/src/channelfactory/defaultchannel.cpp
@@ -1,0 +1,178 @@
+#include "channelfactory/defaultchannel.h"
+
+#include <chrono>
+#include <utility>
+
+namespace vigine::channelfactory
+{
+
+DefaultChannel::DefaultChannel(ChannelKind                    kind,
+                                std::size_t                    capacity,
+                                vigine::payload::PayloadTypeId expectedTypeId)
+    : _kind(kind)
+    , _capacity(capacity)
+    , _expectedTypeId(expectedTypeId)
+{
+}
+
+DefaultChannel::~DefaultChannel()
+{
+    close();
+}
+
+vigine::Result
+DefaultChannel::send(std::unique_ptr<vigine::messaging::IMessagePayload> payload,
+                     int timeoutMs)
+{
+    if (!payload)
+    {
+        return vigine::Result{vigine::Result::Code::Error, "null payload"};
+    }
+
+    if (payload->typeId() != _expectedTypeId)
+    {
+        return vigine::Result{vigine::Result::Code::Error, "payload type id mismatch"};
+    }
+
+    std::unique_lock<std::mutex> lock(_mutex);
+
+    auto deadline = std::chrono::steady_clock::now() +
+                    (timeoutMs < 0
+                         ? std::chrono::milliseconds::max()
+                         : std::chrono::milliseconds{timeoutMs});
+
+    if (_kind == ChannelKind::Bounded)
+    {
+        // Block until a slot is available, the channel closes, or the
+        // deadline elapses.
+        bool slotAvailable = _notFull.wait_until(lock, deadline, [this] {
+            return _closed.load(std::memory_order_relaxed) ||
+                   _queue.size() < _capacity;
+        });
+
+        if (!slotAvailable)
+        {
+            return vigine::Result{vigine::Result::Code::Error, "send timed out"};
+        }
+    }
+
+    if (_closed.load(std::memory_order_relaxed))
+    {
+        return vigine::Result{vigine::Result::Code::Error, "channel is closed"};
+    }
+
+    _queue.push(std::move(payload));
+    lock.unlock();
+    _notEmpty.notify_one();
+
+    return vigine::Result{vigine::Result::Code::Success};
+}
+
+bool DefaultChannel::trySend(
+    std::unique_ptr<vigine::messaging::IMessagePayload> &payload)
+{
+    if (!payload)
+    {
+        return false;
+    }
+
+    if (payload->typeId() != _expectedTypeId)
+    {
+        return false;
+    }
+
+    std::unique_lock<std::mutex> lock(_mutex);
+
+    if (_closed.load(std::memory_order_relaxed))
+    {
+        return false;
+    }
+
+    if (_kind == ChannelKind::Bounded && _queue.size() >= _capacity)
+    {
+        return false;
+    }
+
+    _queue.push(std::move(payload));
+    lock.unlock();
+    _notEmpty.notify_one();
+    return true;
+}
+
+vigine::Result
+DefaultChannel::receive(std::unique_ptr<vigine::messaging::IMessagePayload> &out,
+                        int timeoutMs)
+{
+    std::unique_lock<std::mutex> lock(_mutex);
+
+    auto deadline = std::chrono::steady_clock::now() +
+                    (timeoutMs < 0
+                         ? std::chrono::milliseconds::max()
+                         : std::chrono::milliseconds{timeoutMs});
+
+    bool itemAvailable = _notEmpty.wait_until(lock, deadline, [this] {
+        return !_queue.empty() || _closed.load(std::memory_order_relaxed);
+    });
+
+    if (!itemAvailable)
+    {
+        return vigine::Result{vigine::Result::Code::Error, "receive timed out"};
+    }
+
+    if (_queue.empty())
+    {
+        // Channel is closed and drained.
+        return vigine::Result{vigine::Result::Code::Error, "channel is closed"};
+    }
+
+    out = std::move(_queue.front());
+    _queue.pop();
+    lock.unlock();
+    _notFull.notify_one();
+
+    return vigine::Result{vigine::Result::Code::Success};
+}
+
+bool DefaultChannel::tryReceive(
+    std::unique_ptr<vigine::messaging::IMessagePayload> &out)
+{
+    std::unique_lock<std::mutex> lock(_mutex);
+
+    if (_queue.empty())
+    {
+        return false;
+    }
+
+    out = std::move(_queue.front());
+    _queue.pop();
+    lock.unlock();
+    _notFull.notify_one();
+    return true;
+}
+
+void DefaultChannel::close()
+{
+    {
+        std::unique_lock<std::mutex> lock(_mutex);
+        if (_closed.exchange(true, std::memory_order_acq_rel))
+        {
+            return; // already closed — idempotent
+        }
+    }
+    // Wake all waiters so they can observe the closed state.
+    _notFull.notify_all();
+    _notEmpty.notify_all();
+}
+
+bool DefaultChannel::isClosed() const
+{
+    return _closed.load(std::memory_order_acquire);
+}
+
+std::size_t DefaultChannel::size() const
+{
+    std::unique_lock<std::mutex> lock(_mutex);
+    return _queue.size();
+}
+
+} // namespace vigine::channelfactory

--- a/src/channelfactory/defaultchannel.h
+++ b/src/channelfactory/defaultchannel.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <cstddef>
+#include <memory>
+#include <mutex>
+#include <queue>
+
+#include "vigine/channelfactory/channelkind.h"
+#include "vigine/channelfactory/ichannel.h"
+#include "vigine/messaging/imessagepayload.h"
+#include "vigine/payload/payloadtypeid.h"
+#include "vigine/result.h"
+
+namespace vigine::channelfactory
+{
+
+/**
+ * @brief Concrete channel: mutex + two condition variables + bounded FIFO.
+ *
+ * @ref DefaultChannel is the internal implementation of @ref IChannel. It is
+ * never exposed in the public include tree; callers receive an @ref IChannel
+ * pointer from @ref DefaultChannelFactory::create.
+ *
+ * Implementation notes (v1):
+ *   - NOT lock-free in v1 (documented here; lock-free is Q-FC3, deferred to
+ *     v1.1).
+ *   - Two condition variables: @c _notFull (wakes senders) and @c _notEmpty
+ *     (wakes receivers) keep producer and consumer wake-ups independent.
+ *   - @ref ChannelKind::Unbounded channels use the same path but skip the
+ *     @c _notFull wait and impose no capacity cap.
+ *   - A @c timeoutMs of -1 means "block indefinitely".
+ *
+ * Thread-safety: every entry point is safe to call from any thread.
+ *
+ * Invariants:
+ *   - INV-11: no graph types appear in this header.
+ *   - All data members are private (strict encapsulation).
+ */
+class DefaultChannel final : public IChannel
+{
+  public:
+    /**
+     * @brief Constructs a channel of @p kind with @p capacity and expected
+     *        payload type @p expectedTypeId.
+     *
+     * Pre-conditions (enforced by @ref DefaultChannelFactory::create before
+     * constructing this object):
+     *   - Bounded  => capacity >= 1.
+     *   - Unbounded => capacity == 0.
+     */
+    DefaultChannel(ChannelKind                    kind,
+                   std::size_t                    capacity,
+                   vigine::payload::PayloadTypeId expectedTypeId);
+
+    ~DefaultChannel() override;
+
+    // IChannel
+    [[nodiscard]] vigine::Result
+        send(std::unique_ptr<vigine::messaging::IMessagePayload> payload,
+             int timeoutMs) override;
+
+    [[nodiscard]] bool
+        trySend(std::unique_ptr<vigine::messaging::IMessagePayload> &payload) override;
+
+    [[nodiscard]] vigine::Result
+        receive(std::unique_ptr<vigine::messaging::IMessagePayload> &out,
+                int timeoutMs) override;
+
+    [[nodiscard]] bool
+        tryReceive(std::unique_ptr<vigine::messaging::IMessagePayload> &out) override;
+
+    void close() override;
+
+    [[nodiscard]] bool         isClosed() const override;
+    [[nodiscard]] std::size_t  size()     const override;
+
+    DefaultChannel(const DefaultChannel &)            = delete;
+    DefaultChannel &operator=(const DefaultChannel &) = delete;
+    DefaultChannel(DefaultChannel &&)                 = delete;
+    DefaultChannel &operator=(DefaultChannel &&)      = delete;
+
+  private:
+    ChannelKind                    _kind;
+    std::size_t                    _capacity;
+    vigine::payload::PayloadTypeId _expectedTypeId;
+
+    mutable std::mutex              _mutex;
+    std::condition_variable         _notFull;
+    std::condition_variable         _notEmpty;
+    std::queue<std::unique_ptr<vigine::messaging::IMessagePayload>> _queue;
+    std::atomic<bool>               _closed{false};
+};
+
+} // namespace vigine::channelfactory

--- a/src/channelfactory/defaultchannelfactory.cpp
+++ b/src/channelfactory/defaultchannelfactory.cpp
@@ -1,0 +1,222 @@
+#include "vigine/channelfactory/defaultchannelfactory.h"
+
+#include <algorithm>
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <utility>
+#include <vector>
+
+#include "channelfactory/defaultchannel.h"
+#include "vigine/channelfactory/channelkind.h"
+#include "vigine/channelfactory/ichannel.h"
+#include "vigine/payload/payloadtypeid.h"
+#include "vigine/result.h"
+
+namespace vigine::channelfactory
+{
+
+// -----------------------------------------------------------------
+// FactoryRegistry — shared state between the factory and its channels.
+// Lives as a shared_ptr so that ChannelGuard can hold a weak_ptr and
+// safely unregister even after the factory is destroyed.
+// -----------------------------------------------------------------
+
+struct FactoryRegistry
+{
+    mutable std::mutex      mutex;
+    std::vector<IChannel *> liveChannels;   // non-owning raw pointers
+    std::atomic<bool>       shutdown{false};
+
+    void registerChannel(IChannel *ch)
+    {
+        std::unique_lock<std::mutex> lock(mutex);
+        liveChannels.push_back(ch);
+    }
+
+    void unregisterChannel(IChannel *ch)
+    {
+        std::unique_lock<std::mutex> lock(mutex);
+        auto it = std::find(liveChannels.begin(), liveChannels.end(), ch);
+        if (it != liveChannels.end())
+        {
+            liveChannels.erase(it);
+        }
+    }
+};
+
+// -----------------------------------------------------------------
+// ChannelGuard — IChannel wrapper that:
+//   1. Delegates every IChannel call to the underlying DefaultChannel.
+//   2. Unregisters from the FactoryRegistry on destruction (safe even
+//      after the factory is gone, via weak_ptr).
+// -----------------------------------------------------------------
+
+class ChannelGuard final : public IChannel
+{
+  public:
+    ChannelGuard(std::unique_ptr<DefaultChannel>    inner,
+                 std::shared_ptr<FactoryRegistry>   registry)
+        : _inner(std::move(inner))
+        , _registry(std::move(registry))
+    {
+    }
+
+    ~ChannelGuard() override
+    {
+        if (auto reg = _registry.lock())
+        {
+            reg->unregisterChannel(this);
+        }
+        // _inner is destroyed here; its dtor calls close() idempotently.
+    }
+
+    [[nodiscard]] vigine::Result
+        send(std::unique_ptr<vigine::messaging::IMessagePayload> payload,
+             int timeoutMs) override
+    {
+        return _inner->send(std::move(payload), timeoutMs);
+    }
+
+    [[nodiscard]] bool
+        trySend(std::unique_ptr<vigine::messaging::IMessagePayload> &payload) override
+    {
+        return _inner->trySend(payload);
+    }
+
+    [[nodiscard]] vigine::Result
+        receive(std::unique_ptr<vigine::messaging::IMessagePayload> &out,
+                int timeoutMs) override
+    {
+        return _inner->receive(out, timeoutMs);
+    }
+
+    [[nodiscard]] bool
+        tryReceive(std::unique_ptr<vigine::messaging::IMessagePayload> &out) override
+    {
+        return _inner->tryReceive(out);
+    }
+
+    void close() override { _inner->close(); }
+
+    [[nodiscard]] bool         isClosed() const override { return _inner->isClosed(); }
+    [[nodiscard]] std::size_t  size()     const override { return _inner->size(); }
+
+    ChannelGuard(const ChannelGuard &)            = delete;
+    ChannelGuard &operator=(const ChannelGuard &) = delete;
+    ChannelGuard(ChannelGuard &&)                 = delete;
+    ChannelGuard &operator=(ChannelGuard &&)      = delete;
+
+  private:
+    std::unique_ptr<DefaultChannel>    _inner;
+    std::weak_ptr<FactoryRegistry>     _registry;
+};
+
+// -----------------------------------------------------------------
+// DefaultChannelFactory::Impl — holds the shared FactoryRegistry.
+// -----------------------------------------------------------------
+
+struct DefaultChannelFactory::Impl
+{
+    std::shared_ptr<FactoryRegistry> registry;
+
+    explicit Impl() : registry(std::make_shared<FactoryRegistry>()) {}
+};
+
+// -----------------------------------------------------------------
+// DefaultChannelFactory
+// -----------------------------------------------------------------
+
+DefaultChannelFactory::DefaultChannelFactory(vigine::messaging::IMessageBus &bus)
+    : AbstractChannelFactory{bus}
+    , _impl(std::make_unique<Impl>())
+{
+}
+
+DefaultChannelFactory::~DefaultChannelFactory()
+{
+    shutdown();
+}
+
+std::unique_ptr<IChannel>
+DefaultChannelFactory::create(ChannelKind                    kind,
+                               std::size_t                    capacity,
+                               vigine::payload::PayloadTypeId expectedTypeId,
+                               vigine::Result                *outResult)
+{
+    if (_impl->registry->shutdown.load(std::memory_order_acquire))
+    {
+        if (outResult)
+        {
+            *outResult = vigine::Result{vigine::Result::Code::Error,
+                                        "channel factory is shut down"};
+        }
+        return nullptr;
+    }
+
+    // Config validation per plan_18 edge cases.
+    if (kind == ChannelKind::Bounded && capacity < 1)
+    {
+        if (outResult)
+        {
+            *outResult = vigine::Result{vigine::Result::Code::Error,
+                                        "Bounded channel requires capacity >= 1"};
+        }
+        return nullptr;
+    }
+
+    if (kind == ChannelKind::Unbounded && capacity != 0)
+    {
+        if (outResult)
+        {
+            *outResult = vigine::Result{vigine::Result::Code::Error,
+                                        "Unbounded channel requires capacity == 0"};
+        }
+        return nullptr;
+    }
+
+    auto inner = std::make_unique<DefaultChannel>(kind, capacity, expectedTypeId);
+    auto guard = std::make_unique<ChannelGuard>(std::move(inner), _impl->registry);
+
+    _impl->registry->registerChannel(guard.get());
+
+    if (outResult)
+    {
+        *outResult = vigine::Result{vigine::Result::Code::Success};
+    }
+
+    return guard;
+}
+
+vigine::Result DefaultChannelFactory::shutdown()
+{
+    bool expected = false;
+    if (!_impl->registry->shutdown.compare_exchange_strong(
+            expected, true,
+            std::memory_order_acq_rel,
+            std::memory_order_acquire))
+    {
+        return vigine::Result{vigine::Result::Code::Success};
+    }
+
+    // Close every channel still alive so blocking threads wake up.
+    std::unique_lock<std::mutex> lock(_impl->registry->mutex);
+    for (IChannel *ch : _impl->registry->liveChannels)
+    {
+        ch->close();
+    }
+
+    return vigine::Result{vigine::Result::Code::Success};
+}
+
+// -----------------------------------------------------------------
+// Factory function
+// -----------------------------------------------------------------
+
+std::unique_ptr<IChannelFactory>
+createChannelFactory(vigine::messaging::IMessageBus &bus)
+{
+    return std::make_unique<DefaultChannelFactory>(bus);
+}
+
+} // namespace vigine::channelfactory

--- a/src/channelfactory/factory.cpp
+++ b/src/channelfactory/factory.cpp
@@ -1,0 +1,6 @@
+#include "vigine/channelfactory/factory.h"
+
+// createChannelFactory is defined in defaultchannelfactory.cpp.
+// This translation unit exists so factory.h has a corresponding .cpp
+// and the linker always sees the definition regardless of which TU
+// callers include factory.h from.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -172,8 +172,6 @@ gtest_discover_tests(${MESSAGING_SMOKE_TARGET}
 )
 
 # ====================== Event-Scheduler Smoke Target =======================
-# Smoke coverage for IEventScheduler: one-shot timer fires once, cancel
-# prevents delivery, and OS signal triggers delivery via mock sources.
 set(EVENTSCHEDULER_SMOKE_TARGET eventscheduler-smoke)
 
 add_executable(${EVENTSCHEDULER_SMOKE_TARGET}
@@ -206,9 +204,6 @@ gtest_discover_tests(${EVENTSCHEDULER_SMOKE_TARGET}
 )
 
 # ====================== Topic-Bus Smoke Target =======================
-# Smoke coverage for ITopicBus: publish/subscribe round-trip, stable
-# topic id, topicByName for unknown names, empty-name rejection, and
-# publish-to-invalid-id rejection.
 set(TOPICBUS_SMOKE_TARGET topicbus-smoke)
 
 add_executable(${TOPICBUS_SMOKE_TARGET}
@@ -236,6 +231,38 @@ set_target_properties(${TOPICBUS_SMOKE_TARGET} PROPERTIES
 
 gtest_discover_tests(${TOPICBUS_SMOKE_TARGET}
     PROPERTIES LABELS "topicbus-smoke"
+    DISCOVERY_TIMEOUT 60
+    DISCOVERY_MODE PRE_TEST
+)
+
+# ====================== ChannelFactory Smoke Target =======================
+set(CHANNELFACTORY_SMOKE_TARGET channelfactory-smoke)
+
+add_executable(${CHANNELFACTORY_SMOKE_TARGET}
+    channelfactory/smoke_test.cpp
+)
+
+target_include_directories(${CHANNELFACTORY_SMOKE_TARGET}
+    PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(${CHANNELFACTORY_SMOKE_TARGET}
+    PRIVATE
+    gtest
+    gtest_main
+    vigine
+    ${GLM_LIBRARIES}
+)
+
+set_target_properties(${CHANNELFACTORY_SMOKE_TARGET} PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
+gtest_discover_tests(${CHANNELFACTORY_SMOKE_TARGET}
+    PROPERTIES LABELS "channelfactory-smoke"
     DISCOVERY_TIMEOUT 60
     DISCOVERY_MODE PRE_TEST
 )

--- a/test/channelfactory/smoke_test.cpp
+++ b/test/channelfactory/smoke_test.cpp
@@ -1,0 +1,201 @@
+#include "vigine/channelfactory/channelkind.h"
+#include "vigine/channelfactory/defaultchannelfactory.h"
+#include "vigine/channelfactory/factory.h"
+#include "vigine/channelfactory/ichannel.h"
+#include "vigine/channelfactory/ichannelfactory.h"
+#include "vigine/messaging/busconfig.h"
+#include "vigine/messaging/factory.h"
+#include "vigine/messaging/imessagepayload.h"
+#include "vigine/messaging/imessagebus.h"
+#include "vigine/payload/payloadtypeid.h"
+#include "vigine/result.h"
+#include "vigine/threading/factory.h"
+#include "vigine/threading/ithreadmanager.h"
+#include "vigine/threading/threadmanagerconfig.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <thread>
+#include <utility>
+
+// ---------------------------------------------------------------------------
+// Test suite: ChannelFactory smoke tests (label: channelfactory-smoke)
+//
+// Scenario 1 — send/receive blocking round-trip:
+//   Build factory. Create a Bounded channel of capacity 4. Send one payload.
+//   Receive it back. Assert the round-trip succeeds and the payload type id
+//   is preserved.
+//
+// Scenario 2 — close wakes waiters with an error result:
+//   Create a Bounded channel of capacity 1. Block a thread in receive() on
+//   an empty channel. Call close() from the main thread. Assert the blocked
+//   receive returns an error result (channel closed).
+//
+// Scenario 3 — invalid config is rejected:
+//   a) Bounded + capacity 0 must return null channel + error result.
+//   b) Unbounded + capacity != 0 must return null channel + error result.
+// ---------------------------------------------------------------------------
+
+namespace
+{
+
+using namespace vigine;
+using namespace vigine::messaging;
+using namespace vigine::channelfactory;
+
+// ---------------------------------------------------------------------------
+// Minimal concrete IMessagePayload for tests.
+// ---------------------------------------------------------------------------
+
+class SmokePayload final : public vigine::messaging::IMessagePayload
+{
+  public:
+    explicit SmokePayload(vigine::payload::PayloadTypeId id) noexcept : _id(id) {}
+
+    [[nodiscard]] vigine::payload::PayloadTypeId typeId() const noexcept override
+    {
+        return _id;
+    }
+
+  private:
+    vigine::payload::PayloadTypeId _id;
+};
+
+// ---------------------------------------------------------------------------
+// Fixture: creates a thread manager + inline-only bus + channel factory.
+// ---------------------------------------------------------------------------
+
+class ChannelFactorySmoke : public ::testing::Test
+{
+  protected:
+    static constexpr vigine::payload::PayloadTypeId kTypeId{42};
+
+    void SetUp() override
+    {
+        _tm = vigine::threading::createThreadManager({});
+
+        BusConfig cfg;
+        cfg.threading    = ThreadingPolicy::InlineOnly;
+        cfg.backpressure = BackpressurePolicy::Error;
+        _bus = createMessageBus(cfg, *_tm);
+
+        _factory = createChannelFactory(*_bus);
+    }
+
+    void TearDown() override
+    {
+        if (_factory)
+        {
+            _factory->shutdown();
+        }
+        if (_bus)
+        {
+            _bus->shutdown();
+        }
+        if (_tm)
+        {
+            _tm->shutdown();
+        }
+    }
+
+    std::unique_ptr<vigine::threading::IThreadManager> _tm;
+    std::unique_ptr<IMessageBus>                       _bus;
+    std::unique_ptr<IChannelFactory>                   _factory;
+};
+
+// ---------------------------------------------------------------------------
+// Scenario 1: send/receive blocking round-trip
+// ---------------------------------------------------------------------------
+
+TEST_F(ChannelFactorySmoke, SendReceiveRoundTrip)
+{
+    // Arrange
+    vigine::Result createResult;
+    auto ch = _factory->create(ChannelKind::Bounded, 4, kTypeId, &createResult);
+    ASSERT_NE(ch, nullptr)      << "create must succeed for Bounded+capacity=4";
+    ASSERT_TRUE(createResult.isSuccess()) << createResult.message();
+
+    // Act: send one payload
+    auto sendPayload = std::make_unique<SmokePayload>(kTypeId);
+    auto sendResult  = ch->send(std::move(sendPayload), 1000 /*ms*/);
+    ASSERT_TRUE(sendResult.isSuccess())
+        << "send should succeed on non-full channel: " << sendResult.message();
+
+    // Act: receive it back
+    std::unique_ptr<vigine::messaging::IMessagePayload> received;
+    auto recvResult = ch->receive(received, 1000 /*ms*/);
+
+    // Assert
+    ASSERT_TRUE(recvResult.isSuccess())
+        << "receive should return the enqueued payload: " << recvResult.message();
+    ASSERT_NE(received, nullptr) << "received payload must not be null";
+    EXPECT_EQ(received->typeId(), kTypeId)
+        << "received payload type id must match what was sent";
+    EXPECT_EQ(ch->size(), 0u) << "channel must be empty after the round-trip";
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 2: close wakes blocked receive with error
+// ---------------------------------------------------------------------------
+
+TEST_F(ChannelFactorySmoke, CloseWakesBlockedReceiver)
+{
+    // Arrange: capacity=1 Bounded channel, empty so receive will block.
+    auto ch = _factory->create(ChannelKind::Bounded, 1, kTypeId);
+    ASSERT_NE(ch, nullptr) << "create must succeed";
+    ASSERT_FALSE(ch->isClosed());
+
+    vigine::Result receiverResult;
+    std::unique_ptr<vigine::messaging::IMessagePayload> receiverOut;
+
+    // Launch a thread that blocks in receive().
+    std::thread receiver([&] {
+        receiverResult = ch->receive(receiverOut, -1 /*indefinite*/);
+    });
+
+    // Give the receiver thread a moment to enter the wait.
+    std::this_thread::sleep_for(std::chrono::milliseconds{20});
+
+    // Act: close the channel from the main thread.
+    ch->close();
+    receiver.join();
+
+    // Assert: the blocked receive must have returned an error.
+    EXPECT_TRUE(receiverResult.isError())
+        << "receive on a closed-empty channel must return error; got: "
+        << receiverResult.message();
+    EXPECT_EQ(receiverOut, nullptr)
+        << "out payload must remain null on closed-channel error";
+    EXPECT_TRUE(ch->isClosed());
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 3a: Bounded + capacity 0 is rejected
+// ---------------------------------------------------------------------------
+
+TEST_F(ChannelFactorySmoke, BoundedZeroCapacityRejected)
+{
+    vigine::Result result;
+    auto ch = _factory->create(ChannelKind::Bounded, 0, kTypeId, &result);
+
+    EXPECT_EQ(ch, nullptr) << "Bounded+capacity=0 must return null channel";
+    EXPECT_TRUE(result.isError())
+        << "Bounded+capacity=0 must set error result; got: " << result.message();
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 3b: Unbounded + non-zero capacity is rejected
+// ---------------------------------------------------------------------------
+
+TEST_F(ChannelFactorySmoke, UnboundedNonZeroCapacityRejected)
+{
+    vigine::Result result;
+    auto ch = _factory->create(ChannelKind::Unbounded, 5, kTypeId, &result);
+
+    EXPECT_EQ(ch, nullptr) << "Unbounded+capacity=5 must return null channel";
+    EXPECT_TRUE(result.isError())
+        << "Unbounded+capacity!=0 must set error result; got: " << result.message();
+}
+
+} // namespace


### PR DESCRIPTION
Delivers the Level-2 `IChannelFactory` + `IChannel` facade (plan_18, R.3.3.1.4).

## What ships

- `include/vigine/channelfactory/channelkind.h` — `ChannelKind { Bounded, Unbounded }` closed enum
- `include/vigine/channelfactory/ichannel.h` — pure-virtual `IChannel`: `send` / `trySend` / `receive` / `tryReceive` / `close`
- `include/vigine/channelfactory/ichannelfactory.h` — pure-virtual `IChannelFactory`: `create(kind, capacity, typeId)` returns `unique_ptr<IChannel>`
- `include/vigine/channelfactory/abstractchannelfactory.h` — stateful base over `IMessageBus &`
- `include/vigine/channelfactory/defaultchannelfactory.h` + `src/channelfactory/defaultchannelfactory.cpp` — concrete final
- `src/channelfactory/defaultchannel.{h,cpp}` — mutex + two condition variables + bounded FIFO (not lock-free in v1, documented)
- `include/vigine/channelfactory/factory.h` + `src/channelfactory/factory.cpp` — convenience factory header
- `test/channelfactory/smoke_test.cpp` — 4 cases: round-trip, close wakes blocked receiver, Bounded+capacity=0 rejected, Unbounded+capacity!=0 rejected
- CMake registration in root `CMakeLists.txt` + test `CMakeLists.txt` (`channelfactory-smoke` label)

## Invariants satisfied

INV-1 (no templates in public headers), INV-9 (factory returns `unique_ptr`), INV-10 (`I`/`Abstract` prefixes), INV-11 (no graph types), strict encapsulation (all data members private), no AI attribution.

## Test result

`ctest -L channelfactory-smoke`: 4/4 passed, Debug and Release.

Closes #105