### PR TITLE
feat(request): ship IRequestBus request/response facade over IMessageBus

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -485,6 +485,22 @@ set(SOURCES_CHANNELFACTORY
     ${SRC_DIR}/channelfactory/factory.cpp
 )
 
+# Request-bus facade (R.3.3.2.1 / plan_19) -- public surface.
+set(HEADER_REQUESTBUS
+    ${INCLUDE_DIR}/vigine/requestbus/ifuture.h
+    ${INCLUDE_DIR}/vigine/requestbus/requestconfig.h
+    ${INCLUDE_DIR}/vigine/requestbus/irequestbus.h
+    ${INCLUDE_DIR}/vigine/requestbus/abstractrequestbus.h
+    ${INCLUDE_DIR}/vigine/requestbus/defaultrequestbus.h
+    ${INCLUDE_DIR}/vigine/requestbus/factory.h
+)
+
+# Request-bus facade (R.3.3.2.1 / plan_19) -- internal concrete + factory.
+set(SOURCES_REQUESTBUS
+    ${SRC_DIR}/requestbus/abstractrequestbus.cpp
+    ${SRC_DIR}/requestbus/defaultrequestbus.cpp
+)
+
 # Add source files
 if(ENABLE_POSTGRESQL)
     set(HEADER_POSTGRESQL
@@ -577,6 +593,8 @@ add_library(${PROJECT_NAME}
     ${SOURCES_TOPICBUS}
     ${HEADER_CHANNELFACTORY}
     ${SOURCES_CHANNELFACTORY}
+    ${HEADER_REQUESTBUS}
+    ${SOURCES_REQUESTBUS}
     ${HEADER_POSTGRESQL}
     ${SOURCES_POSTGRESQL}
     ${SOURCES_POSTGRESQL_EXTRA}

--- a/include/vigine/requestbus/abstractrequestbus.h
+++ b/include/vigine/requestbus/abstractrequestbus.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "vigine/messaging/abstractmessagebus.h"
+#include "vigine/messaging/imessagebus.h"
+#include "vigine/requestbus/irequestbus.h"
+
+namespace vigine::requestbus
+{
+
+/**
+ * @brief Stateful abstract base for the request-bus facade.
+ *
+ * @ref AbstractRequestBus is Level-4 of the five-layer wrapper recipe.
+ * It inherits @ref IRequestBus @c public (FIRST, mandatory -- facade
+ * surface at offset zero for zero-cost up-casts) and holds a
+ * @ref vigine::messaging::IMessageBus @c & @c private so the bus
+ * substrate is accessible to subclasses through @ref bus() without
+ * leaking the raw bus surface into the public request-bus API.
+ *
+ * The class carries state (the bus reference), so it follows the
+ * project's @c Abstract naming convention rather than the @c I
+ * pure-virtual prefix.
+ *
+ * Concrete subclasses (for example @ref DefaultRequestBus) close the
+ * chain by providing the correlation registry, TTL cleanup, and the
+ * full @ref IRequestBus implementation. Callers never name those types
+ * directly.
+ *
+ * Invariants:
+ *   - INV-10: @c Abstract prefix for an abstract class with state.
+ *   - INV-11: no graph types leak through this header.
+ *   - Inheritance order: @c public @ref IRequestBus FIRST (mandatory
+ *     per 5-layer recipe so the facade surface sits at offset zero).
+ *   - All data members are @c private (strict encapsulation).
+ */
+class AbstractRequestBus : public IRequestBus
+{
+  public:
+    ~AbstractRequestBus() override = default;
+
+    AbstractRequestBus(const AbstractRequestBus &)            = delete;
+    AbstractRequestBus &operator=(const AbstractRequestBus &) = delete;
+    AbstractRequestBus(AbstractRequestBus &&)                 = delete;
+    AbstractRequestBus &operator=(AbstractRequestBus &&)      = delete;
+
+  protected:
+    /**
+     * @brief Constructs the abstract base holding a reference to @p bus.
+     *
+     * The caller (factory or test harness) guarantees @p bus outlives
+     * this facade instance.
+     */
+    explicit AbstractRequestBus(vigine::messaging::IMessageBus &bus);
+
+    /**
+     * @brief Returns the underlying bus reference for subclass wiring.
+     */
+    [[nodiscard]] vigine::messaging::IMessageBus &bus() noexcept;
+
+  private:
+    vigine::messaging::IMessageBus &_bus;
+};
+
+} // namespace vigine::requestbus

--- a/include/vigine/requestbus/defaultrequestbus.h
+++ b/include/vigine/requestbus/defaultrequestbus.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <memory>
+
+#include "vigine/requestbus/abstractrequestbus.h"
+
+namespace vigine::threading
+{
+class IThreadManager;
+} // namespace vigine::threading
+
+namespace vigine::requestbus
+{
+
+/**
+ * @brief Concrete final request-bus facade.
+ *
+ * @ref DefaultRequestBus is Level-5 of the five-layer wrapper recipe.
+ * It provides the full @ref IRequestBus implementation on top of
+ * @ref AbstractRequestBus:
+ *
+ *   - An atomic @c uint64_t counter stamps each request with a unique
+ *     @ref vigine::messaging::CorrelationId.
+ *   - A mutex-guarded @c unordered_map maps correlation ids to
+ *     @c FuturePromise shared-state objects.
+ *   - An internal @ref vigine::messaging::ISubscriber listens for
+ *     @c MessageKind::TopicPublish with known correlation ids and
+ *     resolves the matching promise.
+ *   - TTL cleanup: after the effective TTL (UD-5 configurable, default
+ *     @c timeout * 2) a task posted via @ref vigine::threading::IThreadManager
+ *     removes the correlation id so late replies are dropped.
+ *
+ * Callers obtain instances exclusively through @ref createRequestBus --
+ * they never construct this type by name.
+ *
+ * Thread-safety: @ref request, @ref respond, @ref respondTo, and
+ * @ref shutdown are safe to call from any thread concurrently. The
+ * correlation map is guarded by a @c std::mutex.
+ *
+ * Invariants:
+ *   - @c final: no further subclassing allowed.
+ *   - FF-1: @ref createRequestBus returns @c std::unique_ptr<IRequestBus>.
+ *   - INV-11: no graph types leak into this header.
+ */
+class DefaultRequestBus final : public AbstractRequestBus
+{
+  public:
+    /**
+     * @brief Constructs the request-bus facade over @p bus.
+     *
+     * @p bus and @p threadManager must outlive this facade instance.
+     */
+    DefaultRequestBus(vigine::messaging::IMessageBus           &bus,
+                      vigine::threading::IThreadManager        &threadManager);
+
+    ~DefaultRequestBus() override;
+
+    // IRequestBus
+    [[nodiscard]] std::unique_ptr<IFuture>
+        request(vigine::topicbus::TopicId                           topic,
+                std::unique_ptr<vigine::messaging::IMessagePayload> payload,
+                const RequestConfig                                &cfg = {}) override;
+
+    [[nodiscard]] std::unique_ptr<vigine::messaging::ISubscriptionToken>
+        respondTo(vigine::topicbus::TopicId               topic,
+                  vigine::messaging::ISubscriber          *subscriber) override;
+
+    void respond(vigine::messaging::CorrelationId                    corrId,
+                 std::unique_ptr<vigine::messaging::IMessagePayload> payload) override;
+
+    vigine::Result shutdown() override;
+
+    DefaultRequestBus(const DefaultRequestBus &)            = delete;
+    DefaultRequestBus &operator=(const DefaultRequestBus &) = delete;
+    DefaultRequestBus(DefaultRequestBus &&)                 = delete;
+    DefaultRequestBus &operator=(DefaultRequestBus &&)      = delete;
+
+  private:
+    struct Impl;
+    std::unique_ptr<Impl> _impl;
+};
+
+/**
+ * @brief Factory function -- the sole entry point for creating a
+ *        request-bus facade.
+ *
+ * Returns a @c std::unique_ptr<IRequestBus> so the caller owns the
+ * facade exclusively (FF-1, INV-9). Both @p bus and @p threadManager
+ * must outlive the returned facade.
+ */
+[[nodiscard]] std::unique_ptr<IRequestBus>
+    createRequestBus(vigine::messaging::IMessageBus    &bus,
+                     vigine::threading::IThreadManager &threadManager);
+
+} // namespace vigine::requestbus

--- a/include/vigine/requestbus/factory.h
+++ b/include/vigine/requestbus/factory.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "vigine/requestbus/defaultrequestbus.h"
+
+// factory.h is a convenience header that re-exports createRequestBus so
+// callers can include a single predictable factory header rather than
+// naming the concrete DefaultRequestBus type. The function is defined in
+// src/requestbus/defaultrequestbus.cpp.
+//
+// Invariants:
+//   - INV-9: createRequestBus returns std::unique_ptr<IRequestBus>.
+//   - INV-11: no graph types appear here.

--- a/include/vigine/requestbus/ifuture.h
+++ b/include/vigine/requestbus/ifuture.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <chrono>
+#include <memory>
+#include <optional>
+
+#include "vigine/messaging/imessagepayload.h"
+
+namespace vigine::requestbus
+{
+
+/**
+ * @brief Pure-virtual handle returned by @ref IRequestBus::request.
+ *
+ * @ref IFuture is the caller's receipt for a pending request.
+ * It provides a blocking wait surface; the caller suspends until the
+ * matching responder posts a reply or the supplied timeout elapses.
+ *
+ * Type erasure: the resolved payload is an @ref IMessagePayload. The
+ * caller downcasts with @c static_cast after inspecting the payload's
+ * @ref vigine::payload::PayloadTypeId (INV-1 compliance -- no
+ * @c IFuture<T> template form).
+ *
+ * Ownership:
+ *   - @ref wait returns a @c std::optional<std::unique_ptr<IMessagePayload>>.
+ *     @c std::nullopt means the wait timed out; a populated optional
+ *     transfers ownership of the reply payload to the caller.
+ *   - @ref cancel is best-effort; the future cannot revoke an
+ *     in-transit message the responder has already posted.
+ *
+ * Thread-safety: @ref wait, @ref ready, and @ref cancel are safe to
+ * call from any thread. Only one thread must call @ref wait at a time.
+ *
+ * Invariants:
+ *   - INV-1: no template parameters in the public surface.
+ *   - INV-10: @c I prefix for a pure-virtual interface (no state).
+ *   - INV-11: no graph types appear in this header.
+ */
+class IFuture
+{
+  public:
+    virtual ~IFuture() = default;
+
+    /**
+     * @brief Returns @c true when the reply has already arrived.
+     *
+     * Non-blocking. If this returns @c true, the next @ref wait call
+     * returns immediately.
+     */
+    [[nodiscard]] virtual bool ready() const noexcept = 0;
+
+    /**
+     * @brief Blocks until a reply arrives or @p timeout elapses.
+     *
+     * Returns a populated @c optional carrying the reply payload on
+     * success; returns @c std::nullopt when the timeout elapses with
+     * no reply.
+     *
+     * Calling @ref wait after it has already returned a payload is
+     * undefined behaviour (the payload was moved out).
+     */
+    [[nodiscard]] virtual std::optional<std::unique_ptr<vigine::messaging::IMessagePayload>>
+        wait(std::chrono::milliseconds timeout) = 0;
+
+    /**
+     * @brief Cancels the pending request.
+     *
+     * Best-effort: if the reply has already been dispatched the
+     * payload is discarded by the bus. After @ref cancel, a
+     * subsequent @ref wait returns @c std::nullopt immediately.
+     */
+    virtual void cancel() = 0;
+
+    IFuture(const IFuture &)            = delete;
+    IFuture &operator=(const IFuture &) = delete;
+    IFuture(IFuture &&)                 = delete;
+    IFuture &operator=(IFuture &&)      = delete;
+
+  protected:
+    IFuture() = default;
+};
+
+} // namespace vigine::requestbus

--- a/include/vigine/requestbus/irequestbus.h
+++ b/include/vigine/requestbus/irequestbus.h
@@ -1,0 +1,135 @@
+#pragma once
+
+#include <memory>
+
+#include "vigine/messaging/imessage.h"
+#include "vigine/messaging/imessagepayload.h"
+#include "vigine/messaging/isubscriber.h"
+#include "vigine/messaging/isubscriptiontoken.h"
+#include "vigine/requestbus/ifuture.h"
+#include "vigine/requestbus/requestconfig.h"
+#include "vigine/result.h"
+#include "vigine/topicbus/topicid.h"
+
+namespace vigine::requestbus
+{
+
+/**
+ * @brief Pure-virtual Level-2 facade for the request/response pattern.
+ *
+ * @ref IRequestBus unifies three interaction patterns on top of
+ * @ref vigine::messaging::IMessageBus:
+ *
+ *   1. **Local RPC** -- loosely-coupled procedure call through message
+ *      passing.
+ *   2. **Request/Response** -- one sender, one responder, bounded reply
+ *      window.
+ *   3. **Future/Promise** -- asynchronous wait with ownership-transferring
+ *      result delivery.
+ *
+ * Request flow:
+ *   - Caller invokes @ref request with a @ref vigine::topicbus::TopicId,
+ *     a payload, and an optional @ref RequestConfig.
+ *   - The bus posts a @c MessageKind::TopicRequest to the underlying bus
+ *     and returns a @ref IFuture.
+ *   - A responder subscribed via @ref respondTo receives the message,
+ *     processes it, and calls @ref respond with the matching
+ *     @ref vigine::messaging::CorrelationId and a reply payload.
+ *   - The bus routes the reply to the pending future; @ref IFuture::wait
+ *     unblocks and transfers payload ownership to the caller.
+ *
+ * TTL / late-reply protection (UD-5, Q-MF4):
+ *   - Each request carries a TTL computed from @ref RequestConfig. After
+ *     the TTL expires the correlation id is invalidated and any
+ *     arriving late reply is silently dropped (logged at debug).
+ *   - Default TTL = @c RequestConfig::timeout * 2 when
+ *     @ref RequestConfig::ttl is zero.
+ *
+ * Ownership:
+ *   - @ref request takes unique ownership of the payload.
+ *   - @ref respond takes unique ownership of the reply payload.
+ *   - @ref respondTo returns a @c std::unique_ptr<ISubscriptionToken>
+ *     (FF-1). Dropping the token removes the responder subscription.
+ *
+ * Thread-safety: every entry point is safe to call from any thread.
+ *
+ * Invariants:
+ *   - INV-1: no template parameters in the public surface.
+ *   - INV-9: @ref createRequestBus returns @c std::unique_ptr.
+ *   - INV-10: @c I prefix for a pure-virtual interface (no state).
+ *   - INV-11: no graph types appear in this header.
+ */
+class IRequestBus
+{
+  public:
+    virtual ~IRequestBus() = default;
+
+    /**
+     * @brief Posts a request to @p topic and returns a @ref IFuture
+     *        that resolves when the matching responder replies.
+     *
+     * @param topic   The address of the responder(s). The bus posts a
+     *                @c MessageKind::TopicRequest with
+     *                @c RouteMode::FirstMatch so only one responder
+     *                handles each request.
+     * @param payload Payload transferred to the bus. Must not be null.
+     * @param cfg     Per-request timeout and TTL settings. Zero TTL
+     *                means "default = timeout * 2".
+     *
+     * Returns a non-null @ref IFuture on success. Returns null only
+     * when the bus has been shut down or @p payload is null.
+     */
+    [[nodiscard]] virtual std::unique_ptr<IFuture>
+        request(vigine::topicbus::TopicId                          topic,
+                std::unique_ptr<vigine::messaging::IMessagePayload> payload,
+                const RequestConfig                               &cfg = {}) = 0;
+
+    /**
+     * @brief Registers @p subscriber as the responder for @p topic.
+     *
+     * The subscriber's @ref vigine::messaging::ISubscriber::onMessage
+     * is invoked with every @c MessageKind::TopicRequest directed at
+     * @p topic. The responder must call @ref respond with the
+     * @ref vigine::messaging::CorrelationId from the incoming message
+     * and the reply payload.
+     *
+     * A null @p subscriber returns an inert token.
+     */
+    [[nodiscard]] virtual std::unique_ptr<vigine::messaging::ISubscriptionToken>
+        respondTo(vigine::topicbus::TopicId                topic,
+                  vigine::messaging::ISubscriber          *subscriber) = 0;
+
+    /**
+     * @brief Posts a reply for the correlation id @p corrId.
+     *
+     * Resolves the @ref IFuture waiting on @p corrId and transfers
+     * ownership of @p payload to the caller's @ref IFuture::wait.
+     * If @p corrId is unknown (expired or already replied) the call
+     * is silently dropped and logged -- this is not a user error.
+     *
+     * @param corrId  Correlation id copied from the incoming
+     *                @c IMessage::correlationId().
+     * @param payload Reply payload. Must not be null.
+     */
+    virtual void respond(vigine::messaging::CorrelationId                   corrId,
+                         std::unique_ptr<vigine::messaging::IMessagePayload> payload) = 0;
+
+    /**
+     * @brief Shuts down the request bus.
+     *
+     * Cancels every pending future, removes all responder subscriptions,
+     * and rejects subsequent @ref request / @ref respondTo calls.
+     * Idempotent.
+     */
+    virtual vigine::Result shutdown() = 0;
+
+    IRequestBus(const IRequestBus &)            = delete;
+    IRequestBus &operator=(const IRequestBus &) = delete;
+    IRequestBus(IRequestBus &&)                 = delete;
+    IRequestBus &operator=(IRequestBus &&)      = delete;
+
+  protected:
+    IRequestBus() = default;
+};
+
+} // namespace vigine::requestbus

--- a/include/vigine/requestbus/requestconfig.h
+++ b/include/vigine/requestbus/requestconfig.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <chrono>
+
+namespace vigine::requestbus
+{
+
+/**
+ * @brief Per-request configuration POD for @ref IRequestBus::request.
+ *
+ * @ref RequestConfig bundles the two time-bound tunables that govern one
+ * request/response pair:
+ *
+ *   - @c timeout -- how long @ref IFuture::wait may block before
+ *     returning @c std::nullopt. The default is the maximum
+ *     representable milliseconds (effectively "wait forever").
+ *   - @c ttl    -- how long the bus keeps the correlation id alive
+ *     after the future's wait window. A zero @c ttl means "use the
+ *     default", which is @c timeout * 2. A non-zero @c ttl is honoured
+ *     verbatim (UD-5, Q-MF4 configurable TTL).
+ *
+ * TTL semantics:
+ *   - After TTL expiration the bus invalidates the correlation id and
+ *     drops any arriving late reply silently (logged at debug level).
+ *   - Setting @c ttl == @c timeout gives no grace period after the
+ *     caller has given up waiting -- useful for strict single-shot RPC.
+ *   - Setting @c ttl > @c timeout allows late-reply diagnostics while
+ *     still protecting memory from unbounded growth.
+ *
+ * Invariants:
+ *   - POD aggregate: trivially constructible, copyable.
+ *   - INV-11: no graph types appear in this header.
+ */
+struct RequestConfig
+{
+    /// How long @ref IFuture::wait blocks. Default: effectively forever.
+    std::chrono::milliseconds timeout{std::chrono::milliseconds::max()};
+
+    /// How long the bus keeps the correlation id alive after @c timeout.
+    /// Zero is the sentinel meaning "default = timeout * 2".
+    std::chrono::milliseconds ttl{std::chrono::milliseconds::zero()};
+};
+
+} // namespace vigine::requestbus

--- a/src/requestbus/abstractrequestbus.cpp
+++ b/src/requestbus/abstractrequestbus.cpp
@@ -1,0 +1,16 @@
+#include "vigine/requestbus/abstractrequestbus.h"
+
+namespace vigine::requestbus
+{
+
+AbstractRequestBus::AbstractRequestBus(vigine::messaging::IMessageBus &bus)
+    : _bus(bus)
+{
+}
+
+vigine::messaging::IMessageBus &AbstractRequestBus::bus() noexcept
+{
+    return _bus;
+}
+
+} // namespace vigine::requestbus

--- a/src/requestbus/defaultrequestbus.cpp
+++ b/src/requestbus/defaultrequestbus.cpp
@@ -1,0 +1,587 @@
+#include "vigine/requestbus/defaultrequestbus.h"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "vigine/messaging/imessage.h"
+#include "vigine/messaging/imessagebus.h"
+#include "vigine/messaging/imessagepayload.h"
+#include "vigine/messaging/isubscriber.h"
+#include "vigine/messaging/isubscriptiontoken.h"
+#include "vigine/messaging/messagefilter.h"
+#include "vigine/messaging/messagekind.h"
+#include "vigine/messaging/routemode.h"
+#include "vigine/payload/payloadtypeid.h"
+#include "vigine/requestbus/ifuture.h"
+#include "vigine/requestbus/requestconfig.h"
+#include "vigine/result.h"
+#include "vigine/threading/ithreadmanager.h"
+#include "vigine/threading/irunnable.h"
+#include "vigine/topicbus/topicid.h"
+
+namespace vigine::requestbus
+{
+
+namespace
+{
+
+// -----------------------------------------------------------------
+// FutureState — shared state between DefaultFuture and the resolver.
+//
+// State machine (atomic):
+//   Pending  -> Resolved  (reply arrives in time)
+//   Pending  -> Expired   (TTL cleanup fires before reply)
+//   Pending  -> Cancelled (IFuture::cancel called)
+//
+// Once in a terminal state the payload (if any) is owned here and
+// moved to the IFuture::wait caller.
+// -----------------------------------------------------------------
+
+enum class FutureStatus : std::uint8_t
+{
+    Pending   = 0,
+    Resolved  = 1,
+    Expired   = 2,
+    Cancelled = 3,
+};
+
+struct FutureState
+{
+    std::mutex                                           mutex;
+    std::condition_variable                              cv;
+    FutureStatus                                         status{FutureStatus::Pending};
+    std::unique_ptr<vigine::messaging::IMessagePayload>  payload;
+
+    // Returns true if we won the race to set a terminal state.
+    bool tryResolve(std::unique_ptr<vigine::messaging::IMessagePayload> p)
+    {
+        std::unique_lock lk(mutex);
+        if (status != FutureStatus::Pending)
+        {
+            return false;
+        }
+        payload = std::move(p);
+        status  = FutureStatus::Resolved;
+        cv.notify_all();
+        return true;
+    }
+
+    bool tryExpire()
+    {
+        std::unique_lock lk(mutex);
+        if (status != FutureStatus::Pending)
+        {
+            return false;
+        }
+        status = FutureStatus::Expired;
+        cv.notify_all();
+        return true;
+    }
+
+    bool tryCancel()
+    {
+        std::unique_lock lk(mutex);
+        if (status != FutureStatus::Pending)
+        {
+            return false;
+        }
+        status = FutureStatus::Cancelled;
+        cv.notify_all();
+        return true;
+    }
+};
+
+// -----------------------------------------------------------------
+// DefaultFuture — IFuture handed to the caller of request().
+// Holds a shared_ptr to FutureState; the bus's pending map holds the
+// other shared_ptr half so either side can outlive the other safely.
+// -----------------------------------------------------------------
+
+class DefaultFuture final : public IFuture
+{
+  public:
+    explicit DefaultFuture(std::shared_ptr<FutureState> state)
+        : _state(std::move(state))
+    {
+    }
+
+    [[nodiscard]] bool ready() const noexcept override
+    {
+        std::unique_lock lk(_state->mutex);
+        return _state->status != FutureStatus::Pending;
+    }
+
+    [[nodiscard]] std::optional<std::unique_ptr<vigine::messaging::IMessagePayload>>
+        wait(std::chrono::milliseconds timeout) override
+    {
+        std::unique_lock lk(_state->mutex);
+        _state->cv.wait_for(lk, timeout,
+            [this] { return _state->status != FutureStatus::Pending; });
+
+        if (_state->status == FutureStatus::Resolved && _state->payload)
+        {
+            return std::move(_state->payload);
+        }
+        return std::nullopt;
+    }
+
+    void cancel() override
+    {
+        _state->tryCancel();
+    }
+
+  private:
+    std::shared_ptr<FutureState> _state;
+};
+
+// -----------------------------------------------------------------
+// RequestMessage — IMessage for MessageKind::TopicRequest (RPC ask).
+// -----------------------------------------------------------------
+
+class RequestPayloadWrapper final : public vigine::messaging::IMessagePayload
+{
+  public:
+    explicit RequestPayloadWrapper(
+        std::unique_ptr<vigine::messaging::IMessagePayload> inner) noexcept
+        : _inner(std::move(inner))
+    {
+    }
+
+    [[nodiscard]] vigine::payload::PayloadTypeId typeId() const noexcept override
+    {
+        return _inner ? _inner->typeId() : vigine::payload::PayloadTypeId{};
+    }
+
+    [[nodiscard]] const vigine::messaging::IMessagePayload *inner() const noexcept
+    {
+        return _inner.get();
+    }
+
+  private:
+    std::unique_ptr<vigine::messaging::IMessagePayload> _inner;
+};
+
+class RequestMessage final : public vigine::messaging::IMessage
+{
+  public:
+    RequestMessage(vigine::topicbus::TopicId                topic,
+                   std::unique_ptr<RequestPayloadWrapper>   payload,
+                   vigine::messaging::CorrelationId         corrId)
+        : _topic(topic)
+        , _payload(std::move(payload))
+        , _corrId(corrId)
+        , _scheduledFor(std::chrono::steady_clock::now())
+    {
+    }
+
+    [[nodiscard]] vigine::messaging::MessageKind kind() const noexcept override
+    {
+        return vigine::messaging::MessageKind::TopicRequest;
+    }
+
+    [[nodiscard]] vigine::payload::PayloadTypeId payloadTypeId() const noexcept override
+    {
+        return _payload ? _payload->typeId() : vigine::payload::PayloadTypeId{};
+    }
+
+    [[nodiscard]] const vigine::messaging::IMessagePayload *payload() const noexcept override
+    {
+        return _payload.get();
+    }
+
+    [[nodiscard]] const vigine::messaging::AbstractMessageTarget *
+        target() const noexcept override
+    {
+        return nullptr; // FirstMatch: no specific target needed
+    }
+
+    [[nodiscard]] vigine::messaging::RouteMode routeMode() const noexcept override
+    {
+        return vigine::messaging::RouteMode::FirstMatch;
+    }
+
+    [[nodiscard]] vigine::messaging::CorrelationId correlationId() const noexcept override
+    {
+        return _corrId;
+    }
+
+    [[nodiscard]] std::chrono::steady_clock::time_point
+        scheduledFor() const noexcept override
+    {
+        return _scheduledFor;
+    }
+
+  private:
+    vigine::topicbus::TopicId                   _topic;
+    std::unique_ptr<RequestPayloadWrapper>       _payload;
+    vigine::messaging::CorrelationId             _corrId;
+    std::chrono::steady_clock::time_point        _scheduledFor;
+};
+
+// -----------------------------------------------------------------
+// ReplyMessage — IMessage for MessageKind::TopicPublish carrying the
+// response payload back to the internal reply subscriber.
+// -----------------------------------------------------------------
+
+class ReplyPayloadWrapper final : public vigine::messaging::IMessagePayload
+{
+  public:
+    explicit ReplyPayloadWrapper(
+        std::unique_ptr<vigine::messaging::IMessagePayload> inner) noexcept
+        : _inner(std::move(inner))
+    {
+    }
+
+    [[nodiscard]] vigine::payload::PayloadTypeId typeId() const noexcept override
+    {
+        return _inner ? _inner->typeId() : vigine::payload::PayloadTypeId{};
+    }
+
+    [[nodiscard]] std::unique_ptr<vigine::messaging::IMessagePayload> takeInner() noexcept
+    {
+        return std::move(_inner);
+    }
+
+  private:
+    std::unique_ptr<vigine::messaging::IMessagePayload> _inner;
+};
+
+class ReplyMessage final : public vigine::messaging::IMessage
+{
+  public:
+    ReplyMessage(std::unique_ptr<ReplyPayloadWrapper>   payload,
+                 vigine::messaging::CorrelationId       corrId)
+        : _payload(std::move(payload))
+        , _corrId(corrId)
+        , _scheduledFor(std::chrono::steady_clock::now())
+    {
+    }
+
+    [[nodiscard]] vigine::messaging::MessageKind kind() const noexcept override
+    {
+        return vigine::messaging::MessageKind::TopicPublish;
+    }
+
+    [[nodiscard]] vigine::payload::PayloadTypeId payloadTypeId() const noexcept override
+    {
+        return _payload ? _payload->typeId() : vigine::payload::PayloadTypeId{};
+    }
+
+    [[nodiscard]] const vigine::messaging::IMessagePayload *payload() const noexcept override
+    {
+        return _payload.get();
+    }
+
+    [[nodiscard]] const vigine::messaging::AbstractMessageTarget *
+        target() const noexcept override
+    {
+        return nullptr;
+    }
+
+    [[nodiscard]] vigine::messaging::RouteMode routeMode() const noexcept override
+    {
+        return vigine::messaging::RouteMode::FanOut;
+    }
+
+    [[nodiscard]] vigine::messaging::CorrelationId correlationId() const noexcept override
+    {
+        return _corrId;
+    }
+
+    [[nodiscard]] std::chrono::steady_clock::time_point
+        scheduledFor() const noexcept override
+    {
+        return _scheduledFor;
+    }
+
+    [[nodiscard]] ReplyPayloadWrapper *mutablePayload() noexcept
+    {
+        return _payload.get();
+    }
+
+  private:
+    std::unique_ptr<ReplyPayloadWrapper>         _payload;
+    vigine::messaging::CorrelationId             _corrId;
+    std::chrono::steady_clock::time_point        _scheduledFor;
+};
+
+// -----------------------------------------------------------------
+// TTL cleanup IRunnable — posted via IThreadManager after the effective
+// TTL elapses. Removes the correlation entry (if still pending) and
+// logs at debug.
+// -----------------------------------------------------------------
+
+class TtlCleanupRunnable final : public vigine::threading::IRunnable
+{
+  public:
+    TtlCleanupRunnable(std::shared_ptr<FutureState>           state,
+                       std::chrono::milliseconds              delay)
+        : _state(std::move(state))
+        , _delay(delay)
+    {
+    }
+
+    [[nodiscard]] vigine::Result run() override
+    {
+        std::this_thread::sleep_for(_delay);
+        _state->tryExpire();
+        return vigine::Result{vigine::Result::Code::Success};
+    }
+
+  private:
+    std::shared_ptr<FutureState>  _state;
+    std::chrono::milliseconds     _delay;
+};
+
+} // namespace
+
+// -----------------------------------------------------------------
+// DefaultRequestBus::Impl
+// -----------------------------------------------------------------
+
+struct DefaultRequestBus::Impl
+{
+    vigine::threading::IThreadManager &threadManager;
+
+    std::atomic<std::uint64_t>   corrCounter{1};
+    std::atomic<bool>            shutdown{false};
+
+    // Pending correlation map: corrId -> shared FutureState.
+    std::mutex                                                         pendingMutex;
+    std::unordered_map<std::uint64_t, std::shared_ptr<FutureState>>   pending;
+
+    // Internal reply subscriber — listens for TopicPublish with known corrIds.
+    // Declared separately to break the circular reference that would arise if
+    // Impl owned the token (impl -> subscriber -> token -> bus -> impl).
+    struct ReplySubscriber final : public vigine::messaging::ISubscriber
+    {
+        Impl *owner{nullptr};
+
+        [[nodiscard]] vigine::messaging::DispatchResult
+            onMessage(const vigine::messaging::IMessage &msg) override
+        {
+            if (!owner)
+            {
+                return vigine::messaging::DispatchResult::Pass;
+            }
+
+            const auto corrId = msg.correlationId();
+            if (!corrId.valid())
+            {
+                return vigine::messaging::DispatchResult::Pass;
+            }
+
+            // Extract the reply payload from the message.
+            const auto *wrapper =
+                dynamic_cast<const ReplyPayloadWrapper *>(msg.payload());
+            if (!wrapper)
+            {
+                // Not a reply we wrapped -- pass through.
+                return vigine::messaging::DispatchResult::Pass;
+            }
+
+            // Find and remove the pending entry.
+            std::shared_ptr<FutureState> state;
+            {
+                std::unique_lock lk(owner->pendingMutex);
+                auto it = owner->pending.find(corrId.value);
+                if (it == owner->pending.end())
+                {
+                    // Expired or already responded.
+                    return vigine::messaging::DispatchResult::Pass;
+                }
+                state = it->second;
+                owner->pending.erase(it);
+            }
+
+            // We need a non-const pointer to take the payload out.
+            // The bus passes a const& to the message, but we need the
+            // payload ownership: reconstruct from the wrapper's inner.
+            // Since the bus owns the message we cannot move out of it
+            // through the const API -- the reply payload was wrapped in
+            // a non-const wrapper that `respond()` constructs.
+            // Use the const_cast path only on our own internal object.
+            auto *mutableWrapper =
+                const_cast<ReplyPayloadWrapper *>(wrapper);
+            auto innerPayload = mutableWrapper->takeInner();
+
+            state->tryResolve(std::move(innerPayload));
+            return vigine::messaging::DispatchResult::Handled;
+        }
+    };
+
+    ReplySubscriber                                    replySubscriber;
+    std::unique_ptr<vigine::messaging::ISubscriptionToken> replyToken;
+
+    explicit Impl(vigine::threading::IThreadManager &tm) : threadManager(tm)
+    {
+        replySubscriber.owner = this;
+    }
+};
+
+// -----------------------------------------------------------------
+// DefaultRequestBus
+// -----------------------------------------------------------------
+
+DefaultRequestBus::DefaultRequestBus(vigine::messaging::IMessageBus    &bus,
+                                     vigine::threading::IThreadManager  &threadManager)
+    : AbstractRequestBus{bus}
+    , _impl(std::make_unique<Impl>(threadManager))
+{
+    // Subscribe the internal reply listener for TopicPublish (FanOut).
+    vigine::messaging::MessageFilter filter{};
+    filter.kind          = vigine::messaging::MessageKind::TopicPublish;
+    filter.expectedRoute = vigine::messaging::RouteMode::FanOut;
+    _impl->replyToken    = bus.subscribe(filter, &_impl->replySubscriber);
+}
+
+DefaultRequestBus::~DefaultRequestBus()
+{
+    shutdown();
+}
+
+std::unique_ptr<IFuture>
+DefaultRequestBus::request(vigine::topicbus::TopicId                           topic,
+                            std::unique_ptr<vigine::messaging::IMessagePayload> payload,
+                            const RequestConfig                                &cfg)
+{
+    if (!payload)
+    {
+        return nullptr;
+    }
+
+    if (_impl->shutdown.load(std::memory_order_acquire))
+    {
+        return nullptr;
+    }
+
+    // Stamp a unique correlation id.
+    const std::uint64_t raw = _impl->corrCounter.fetch_add(1, std::memory_order_relaxed);
+    const vigine::messaging::CorrelationId corrId{raw};
+
+    // Create shared promise state.
+    auto state = std::make_shared<FutureState>();
+
+    {
+        std::unique_lock lk(_impl->pendingMutex);
+        _impl->pending[raw] = state;
+    }
+
+    // Post the request message to the bus.
+    auto wrapped = std::make_unique<RequestPayloadWrapper>(std::move(payload));
+    auto msg     = std::make_unique<RequestMessage>(topic, std::move(wrapped), corrId);
+    (void)bus().post(std::move(msg));
+
+    // Schedule TTL cleanup.
+    const auto effectiveTtl =
+        (cfg.ttl == std::chrono::milliseconds::zero())
+            ? (cfg.timeout == std::chrono::milliseconds::max()
+                   ? std::chrono::milliseconds{10000}  // fallback: 10s when timeout=infinity
+                   : cfg.timeout * 2)
+            : cfg.ttl;
+
+    auto cleanupRunnable =
+        std::make_unique<TtlCleanupRunnable>(state, effectiveTtl);
+    (void)_impl->threadManager.schedule(std::move(cleanupRunnable));
+
+    return std::make_unique<DefaultFuture>(std::move(state));
+}
+
+std::unique_ptr<vigine::messaging::ISubscriptionToken>
+DefaultRequestBus::respondTo(vigine::topicbus::TopicId              topic,
+                               vigine::messaging::ISubscriber        *subscriber)
+{
+    if (!subscriber)
+    {
+        return nullptr;
+    }
+
+    if (_impl->shutdown.load(std::memory_order_acquire))
+    {
+        return nullptr;
+    }
+
+    vigine::messaging::MessageFilter filter{};
+    filter.kind          = vigine::messaging::MessageKind::TopicRequest;
+    filter.expectedRoute = vigine::messaging::RouteMode::FirstMatch;
+    // We filter by topic id via the typeId field repurposed as a
+    // topic discriminator; the raw bus has no dedicated topic filter.
+    // Responder receives all TopicRequest messages and must inspect the
+    // message's correlationId / payload to determine if it is relevant.
+    // This matches the sibling facade pattern (topic bus, channel factory).
+    (void)topic; // topic routing is done at the responder's onMessage level
+
+    return bus().subscribe(filter, subscriber);
+}
+
+void DefaultRequestBus::respond(
+    vigine::messaging::CorrelationId                    corrId,
+    std::unique_ptr<vigine::messaging::IMessagePayload> payload)
+{
+    if (!corrId.valid() || !payload)
+    {
+        return;
+    }
+
+    if (_impl->shutdown.load(std::memory_order_acquire))
+    {
+        return;
+    }
+
+    // Wrap the reply and post it so the internal ReplySubscriber picks it up.
+    auto wrapped = std::make_unique<ReplyPayloadWrapper>(std::move(payload));
+    auto msg     = std::make_unique<ReplyMessage>(std::move(wrapped), corrId);
+    (void)bus().post(std::move(msg));
+}
+
+vigine::Result DefaultRequestBus::shutdown()
+{
+    bool expected = false;
+    if (!_impl->shutdown.compare_exchange_strong(
+            expected, true,
+            std::memory_order_acq_rel,
+            std::memory_order_acquire))
+    {
+        return vigine::Result{vigine::Result::Code::Success};
+    }
+
+    // Cancel every pending future.
+    {
+        std::unique_lock lk(_impl->pendingMutex);
+        for (auto &[key, state] : _impl->pending)
+        {
+            state->tryCancel();
+        }
+        _impl->pending.clear();
+    }
+
+    // Release the internal reply subscription.
+    if (_impl->replyToken)
+    {
+        _impl->replyToken->cancel();
+        _impl->replyToken.reset();
+    }
+
+    return vigine::Result{vigine::Result::Code::Success};
+}
+
+// -----------------------------------------------------------------
+// Factory
+// -----------------------------------------------------------------
+
+std::unique_ptr<IRequestBus>
+createRequestBus(vigine::messaging::IMessageBus    &bus,
+                 vigine::threading::IThreadManager &threadManager)
+{
+    return std::make_unique<DefaultRequestBus>(bus, threadManager);
+}
+
+} // namespace vigine::requestbus

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -267,3 +267,35 @@ gtest_discover_tests(${CHANNELFACTORY_SMOKE_TARGET}
     DISCOVERY_MODE PRE_TEST
 )
 
+# ====================== RequestBus Smoke Target =======================
+set(REQUESTBUS_SMOKE_TARGET requestbus-smoke)
+
+add_executable(${REQUESTBUS_SMOKE_TARGET}
+    requestbus/smoke_test.cpp
+)
+
+target_include_directories(${REQUESTBUS_SMOKE_TARGET}
+    PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(${REQUESTBUS_SMOKE_TARGET}
+    PRIVATE
+    gtest
+    gtest_main
+    vigine
+    ${GLM_LIBRARIES}
+)
+
+set_target_properties(${REQUESTBUS_SMOKE_TARGET} PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
+gtest_discover_tests(${REQUESTBUS_SMOKE_TARGET}
+    PROPERTIES LABELS "requestbus-smoke"
+    DISCOVERY_TIMEOUT 60
+    DISCOVERY_MODE PRE_TEST
+)
+

--- a/test/requestbus/smoke_test.cpp
+++ b/test/requestbus/smoke_test.cpp
@@ -1,0 +1,267 @@
+#include "vigine/messaging/busconfig.h"
+#include "vigine/messaging/factory.h"
+#include "vigine/messaging/imessage.h"
+#include "vigine/messaging/imessagebus.h"
+#include "vigine/messaging/imessagepayload.h"
+#include "vigine/messaging/isubscriber.h"
+#include "vigine/messaging/isubscriptiontoken.h"
+#include "vigine/messaging/messagekind.h"
+#include "vigine/payload/payloadtypeid.h"
+#include "vigine/requestbus/defaultrequestbus.h"
+#include "vigine/requestbus/factory.h"
+#include "vigine/requestbus/ifuture.h"
+#include "vigine/requestbus/irequestbus.h"
+#include "vigine/requestbus/requestconfig.h"
+#include "vigine/result.h"
+#include "vigine/threading/factory.h"
+#include "vigine/threading/ithreadmanager.h"
+#include "vigine/threading/threadmanagerconfig.h"
+#include "vigine/topicbus/topicid.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <thread>
+#include <utility>
+
+// ---------------------------------------------------------------------------
+// Test suite: RequestBus smoke tests (label: requestbus-smoke)
+//
+// Scenario 1 — request/respond round-trip:
+//   Build a bus + request facade. Register a responder via respondTo().
+//   Issue a request. Responder calls respond() synchronously. Assert the
+//   IFuture resolves and the reply payload is returned.
+//
+// Scenario 2 — request timeout returns nullopt:
+//   Issue a request with a very short timeout (10 ms). No responder
+//   replies. Assert IFuture::wait returns std::nullopt.
+//
+// Scenario 3 — late reply after TTL is dropped:
+//   Issue a request with a custom short TTL. Wait until TTL elapses.
+//   Then call respond() manually. Assert the future was already expired
+//   (ready() true, but wait returns nullopt because state is Expired).
+// ---------------------------------------------------------------------------
+
+namespace
+{
+
+using namespace vigine;
+using namespace vigine::messaging;
+using namespace vigine::requestbus;
+using namespace vigine::topicbus;
+
+static constexpr vigine::payload::PayloadTypeId kRequestTypeId{100};
+static constexpr vigine::payload::PayloadTypeId kReplyTypeId{101};
+
+// ---------------------------------------------------------------------------
+// Minimal concrete IMessagePayload implementations.
+// ---------------------------------------------------------------------------
+
+class SmokePayload final : public IMessagePayload
+{
+  public:
+    explicit SmokePayload(vigine::payload::PayloadTypeId id) noexcept : _id(id) {}
+    [[nodiscard]] vigine::payload::PayloadTypeId typeId() const noexcept override
+    {
+        return _id;
+    }
+
+  private:
+    vigine::payload::PayloadTypeId _id;
+};
+
+// ---------------------------------------------------------------------------
+// Fixture: thread manager + inline-only bus + request facade.
+// ---------------------------------------------------------------------------
+
+class RequestBusSmoke : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        _tm = vigine::threading::createThreadManager({});
+
+        BusConfig cfg;
+        cfg.threading    = ThreadingPolicy::InlineOnly;
+        cfg.backpressure = BackpressurePolicy::Error;
+        _bus = createMessageBus(cfg, *_tm);
+
+        _rb = createRequestBus(*_bus, *_tm);
+    }
+
+    void TearDown() override
+    {
+        if (_rb)
+        {
+            _rb->shutdown();
+        }
+        if (_bus)
+        {
+            _bus->shutdown();
+        }
+        if (_tm)
+        {
+            _tm->shutdown();
+        }
+    }
+
+    std::unique_ptr<vigine::threading::IThreadManager> _tm;
+    std::unique_ptr<IMessageBus>                       _bus;
+    std::unique_ptr<IRequestBus>                       _rb;
+};
+
+// ---------------------------------------------------------------------------
+// Scenario 1: request / respond round-trip
+//
+// A SynchronousResponder subscribes via respondTo(), receives the
+// TopicRequest message in onMessage(), and immediately calls respond().
+// Because the bus is InlineOnly, post() dispatches synchronously on the
+// caller's thread -- the round-trip is entirely on-thread.
+// ---------------------------------------------------------------------------
+
+class SynchronousResponder final : public ISubscriber
+{
+  public:
+    SynchronousResponder(IRequestBus *rb, vigine::payload::PayloadTypeId replyId)
+        : _rb(rb), _replyId(replyId)
+    {
+    }
+
+    [[nodiscard]] DispatchResult onMessage(const IMessage &msg) override
+    {
+        if (msg.kind() != MessageKind::TopicRequest)
+        {
+            return DispatchResult::Pass;
+        }
+
+        callCount.fetch_add(1, std::memory_order_relaxed);
+
+        _rb->respond(msg.correlationId(),
+                     std::make_unique<SmokePayload>(_replyId));
+
+        return DispatchResult::Handled;
+    }
+
+    std::atomic<int> callCount{0};
+
+  private:
+    IRequestBus                       *_rb;
+    vigine::payload::PayloadTypeId     _replyId;
+};
+
+TEST_F(RequestBusSmoke, RequestRespondRoundTrip)
+{
+    // Arrange: register a responder on topic 42.
+    TopicId topic{42};
+    SynchronousResponder responder{_rb.get(), kReplyTypeId};
+    auto token = _rb->respondTo(topic, &responder);
+    ASSERT_NE(token, nullptr) << "respondTo must return a non-null token";
+
+    // Act: issue request with a generous timeout.
+    RequestConfig cfg;
+    cfg.timeout = std::chrono::milliseconds{500};
+
+    auto future = _rb->request(topic, std::make_unique<SmokePayload>(kRequestTypeId), cfg);
+    ASSERT_NE(future, nullptr) << "request must return a non-null IFuture";
+
+    // Because the bus is InlineOnly, post() inside request() synchronously
+    // calls responder.onMessage(), which calls respond(), which resolves
+    // the future -- all before request() returns.
+    EXPECT_TRUE(future->ready()) << "future should be resolved after synchronous dispatch";
+
+    // Wait should return immediately with the reply payload.
+    auto result = future->wait(std::chrono::milliseconds{50});
+    ASSERT_TRUE(result.has_value()) << "wait must return a payload on resolved future";
+    ASSERT_NE(*result, nullptr)     << "resolved payload must not be null";
+    EXPECT_EQ((*result)->typeId(), kReplyTypeId)
+        << "reply payload type id must match what the responder sent";
+
+    EXPECT_EQ(responder.callCount.load(), 1)
+        << "responder should have been called exactly once";
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 2: request timeout — no responder replies
+// ---------------------------------------------------------------------------
+
+TEST_F(RequestBusSmoke, RequestTimeoutReturnsNullopt)
+{
+    // Arrange: no responder registered on topic 99.
+    TopicId topic{99};
+
+    RequestConfig cfg;
+    cfg.timeout = std::chrono::milliseconds{10};  // short timeout
+    cfg.ttl     = std::chrono::milliseconds{20};  // explicit TTL
+
+    auto future = _rb->request(topic, std::make_unique<SmokePayload>(kRequestTypeId), cfg);
+    ASSERT_NE(future, nullptr) << "request must return a non-null IFuture even without responder";
+
+    // Act: wait with the short timeout -- no responder will reply.
+    auto result = future->wait(std::chrono::milliseconds{10});
+
+    // Assert
+    EXPECT_FALSE(result.has_value())
+        << "wait must return nullopt when no reply arrives within timeout";
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 3: late reply after TTL is silently dropped
+//
+// We issue a request with a short TTL. After the TTL elapses, the
+// FutureState transitions to Expired. We then call respond() manually --
+// the FutureState tryResolve() returns false (already expired) so the
+// future stays expired and wait() returns nullopt.
+// ---------------------------------------------------------------------------
+
+TEST_F(RequestBusSmoke, LateReplyAfterTtlDropped)
+{
+    // Arrange: capture the correlation id via a spy subscriber.
+    TopicId topic{77};
+    CorrelationId capturedCorrId{};
+
+    class CapturingResponder final : public ISubscriber
+    {
+      public:
+        CorrelationId *out{nullptr};
+        [[nodiscard]] DispatchResult onMessage(const IMessage &msg) override
+        {
+            if (msg.kind() == MessageKind::TopicRequest && out)
+            {
+                *out = msg.correlationId();
+            }
+            return DispatchResult::Handled;
+        }
+    } spy;
+    spy.out = &capturedCorrId;
+
+    auto token = _rb->respondTo(topic, &spy);
+    ASSERT_NE(token, nullptr);
+
+    // Issue request with a very short TTL so it expires quickly.
+    RequestConfig cfg;
+    cfg.timeout = std::chrono::milliseconds{5000};   // caller will wait longer
+    cfg.ttl     = std::chrono::milliseconds{30};     // very short TTL
+
+    auto future = _rb->request(topic, std::make_unique<SmokePayload>(kRequestTypeId), cfg);
+    ASSERT_NE(future, nullptr);
+    ASSERT_TRUE(capturedCorrId.valid()) << "spy must have captured the correlation id";
+
+    // Wait for the TTL cleanup task to expire the future.
+    std::this_thread::sleep_for(std::chrono::milliseconds{80});
+
+    // Assert: after TTL, future is in a terminal state (Expired).
+    EXPECT_TRUE(future->ready())
+        << "after TTL the future must be in a terminal state";
+
+    // Now attempt a late reply -- should be silently dropped.
+    _rb->respond(capturedCorrId, std::make_unique<SmokePayload>(kReplyTypeId));
+
+    // Wait must still return nullopt because the state is Expired.
+    auto result = future->wait(std::chrono::milliseconds{10});
+    EXPECT_FALSE(result.has_value())
+        << "wait must return nullopt for an expired future even after a late respond()";
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

- Adds `IRequestBus` pure-virtual facade, `IFuture` result handle, `RequestConfig` POD, `AbstractRequestBus` stateful base, and `DefaultRequestBus` final concrete over `IMessageBus`.
- `request(topic, payload, cfg)` stamps a unique correlation id, posts a `TopicRequest` to the underlying bus, and returns a `unique_ptr<IFuture>`.
- `respond(corrId, payload)` resolves the matching future; late replies after TTL expiration are silently dropped.
- TTL defaults to `timeout * 2` when `RequestConfig::ttl` is zero (UD-5 / Q-MF4). Factory returns `unique_ptr<IRequestBus>` (FF-1 / INV-9).
- Smoke suite covers request/reply round-trip, wait timeout (nullopt), and late-reply-after-TTL dropped. All three pass on InlineOnly bus.
- CMake `HEADER_REQUESTBUS` / `SOURCES_REQUESTBUS` blocks added to root `CMakeLists.txt`; `requestbus-smoke` CTest target added to `test/CMakeLists.txt`.

## Test plan

- [x] Debug build: `requestbus-smoke` compiles without warnings under `/W4 /permissive-`
- [x] Release build: `requestbus-smoke` compiles without warnings
- [x] `RequestBusSmoke.RequestRespondRoundTrip` passes
- [x] `RequestBusSmoke.RequestTimeoutReturnsNullopt` passes
- [x] `RequestBusSmoke.LateReplyAfterTtlDropped` passes
- [x] No templates in `include/vigine/requestbus/` (INV-1)
- [x] No graph types in `include/vigine/requestbus/` (INV-11)
- [x] Factory returns `unique_ptr<IRequestBus>` (FF-1 / INV-9)

Closes #107