### PR TITLE
feat(reactive): IReactiveStream cold-publisher facade over IMessageBus

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -499,6 +499,20 @@ set(HEADER_REQUESTBUS
 set(SOURCES_REQUESTBUS
     ${SRC_DIR}/requestbus/abstractrequestbus.cpp
     ${SRC_DIR}/requestbus/defaultrequestbus.cpp
+# Reactive-stream facade (R.3.3.2.2 / plan_20) -- public surface.
+set(HEADER_REACTIVESTREAM
+    ${INCLUDE_DIR}/vigine/reactivestream/ireactivesubscription.h
+    ${INCLUDE_DIR}/vigine/reactivestream/ireactivesubscriber.h
+    ${INCLUDE_DIR}/vigine/reactivestream/ireactivepublisher.h
+    ${INCLUDE_DIR}/vigine/reactivestream/ireactivestream.h
+    ${INCLUDE_DIR}/vigine/reactivestream/abstractreactivestream.h
+    ${INCLUDE_DIR}/vigine/reactivestream/defaultreactivestream.h
+)
+
+# Reactive-stream facade (R.3.3.2.2 / plan_20) -- internal concrete + factory.
+set(SOURCES_REACTIVESTREAM
+    ${SRC_DIR}/reactivestream/abstractreactivestream.cpp
+    ${SRC_DIR}/reactivestream/defaultreactivestream.cpp
 )
 
 # Add source files
@@ -595,6 +609,8 @@ add_library(${PROJECT_NAME}
     ${SOURCES_CHANNELFACTORY}
     ${HEADER_REQUESTBUS}
     ${SOURCES_REQUESTBUS}
+    ${HEADER_REACTIVESTREAM}
+    ${SOURCES_REACTIVESTREAM}
     ${HEADER_POSTGRESQL}
     ${SOURCES_POSTGRESQL}
     ${SOURCES_POSTGRESQL_EXTRA}

--- a/include/vigine/reactivestream/abstractreactivestream.h
+++ b/include/vigine/reactivestream/abstractreactivestream.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "vigine/messaging/abstractmessagebus.h"
+#include "vigine/messaging/imessagebus.h"
+#include "vigine/reactivestream/ireactivestream.h"
+
+namespace vigine::reactivestream
+{
+
+/**
+ * @brief Stateful abstract base for the reactive-stream facade.
+ *
+ * @ref AbstractReactiveStream is Level-4 of the five-layer wrapper recipe.
+ * It inherits @ref IReactiveStream @c public (FIRST — facade surface at
+ * offset zero for zero-cost up-casts) and holds a
+ * @ref vigine::messaging::IMessageBus @c & @c private so the bus substrate
+ * is accessible to subclasses through @ref bus() without leaking the raw
+ * bus surface into the public reactive-stream API.
+ *
+ * The class carries state (the bus reference), so it follows the
+ * project's @c Abstract naming convention rather than the @c I
+ * pure-virtual prefix.
+ *
+ * Concrete subclasses (for example @ref DefaultReactiveStream) close the
+ * chain by providing the subscription registry, demand tracking, and the
+ * full @ref IReactiveStream implementation. Callers never name those types
+ * directly.
+ *
+ * Invariants:
+ *   - INV-10: @c Abstract prefix for an abstract class with state.
+ *   - INV-11: no graph types leak through this header.
+ *   - Inheritance order: @c public @ref IReactiveStream FIRST (mandatory
+ *     per 5-layer recipe so the facade surface sits at offset zero).
+ *   - All data members are @c private (strict encapsulation).
+ */
+class AbstractReactiveStream : public IReactiveStream
+{
+  public:
+    ~AbstractReactiveStream() override = default;
+
+    AbstractReactiveStream(const AbstractReactiveStream &)            = delete;
+    AbstractReactiveStream &operator=(const AbstractReactiveStream &) = delete;
+    AbstractReactiveStream(AbstractReactiveStream &&)                 = delete;
+    AbstractReactiveStream &operator=(AbstractReactiveStream &&)      = delete;
+
+  protected:
+    /**
+     * @brief Constructs the abstract base holding a reference to @p bus.
+     *
+     * The caller (factory or test harness) guarantees @p bus outlives
+     * this facade instance.
+     */
+    explicit AbstractReactiveStream(vigine::messaging::IMessageBus &bus);
+
+    /**
+     * @brief Returns the underlying bus reference for subclass wiring.
+     */
+    [[nodiscard]] vigine::messaging::IMessageBus &bus() noexcept;
+
+  private:
+    vigine::messaging::IMessageBus &_bus;
+};
+
+} // namespace vigine::reactivestream

--- a/include/vigine/reactivestream/defaultreactivestream.h
+++ b/include/vigine/reactivestream/defaultreactivestream.h
@@ -1,0 +1,122 @@
+#pragma once
+
+#include <memory>
+
+#include "vigine/reactivestream/abstractreactivestream.h"
+#include "vigine/reactivestream/ireactivesubscription.h"
+
+namespace vigine::threading
+{
+class IThreadManager;
+} // namespace vigine::threading
+
+namespace vigine::reactivestream
+{
+
+/**
+ * @brief Concrete final reactive-stream facade.
+ *
+ * @ref DefaultReactiveStream is Level-5 of the five-layer wrapper recipe.
+ * It provides the full @ref IReactiveStream implementation on top of
+ * @ref AbstractReactiveStream:
+ *
+ *   - Cold publisher model: @ref subscribe creates a fresh, independent
+ *     @ref IReactiveSubscription (and publisher) for each caller. Two
+ *     subscribers on the same stream never share delivery state.
+ *   - Backpressure: demand is tracked per subscription; the publisher
+ *     calls @c onNext only while demand > 0.
+ *   - @ref IReactiveSubscription::cancel is idempotent; the subscriber's
+ *     @c onNext stops immediately after cancel returns.
+ *   - Terminal signals (@c onComplete / @c onError) mark the subscription
+ *     closed; the delivery path is a no-op afterwards.
+ *   - @ref shutdown drains in-flight delivery, cancels every subscription
+ *     with @c onComplete, and rejects new @ref subscribe calls. Idempotent.
+ *
+ * Callers obtain instances exclusively through @ref createReactiveStream;
+ * they never construct this type by name.
+ *
+ * Thread-safety: @ref subscribe and @ref shutdown are safe to call from
+ * any thread concurrently. The subscription registry is guarded by a
+ * @c std::mutex.
+ *
+ * Invariants:
+ *   - @c final: no further subclassing allowed.
+ *   - FF-1: @ref createReactiveStream returns @c std::unique_ptr<IReactiveStream>.
+ *   - INV-11: no graph types leak into this header.
+ */
+class DefaultReactiveStream final : public AbstractReactiveStream
+{
+  public:
+    /**
+     * @brief Constructs the reactive-stream facade over @p bus.
+     *
+     * @p bus and @p threadManager must outlive this facade instance.
+     */
+    DefaultReactiveStream(vigine::messaging::IMessageBus    &bus,
+                          vigine::threading::IThreadManager &threadManager);
+
+    ~DefaultReactiveStream() override;
+
+    // IReactiveStream
+    [[nodiscard]] std::unique_ptr<IReactiveSubscription>
+        subscribe(IReactiveSubscriber *subscriber) override;
+
+    vigine::Result shutdown() override;
+
+    /**
+     * @brief Pushes @p payload to every active subscriber with outstanding
+     *        demand.
+     *
+     * Called by the engine (or tests) to deliver an item to all subscribers
+     * that have signalled demand via @ref IReactiveSubscription::request.
+     * Subscribers with zero demand do not receive the item (backpressure).
+     *
+     * @p payload ownership is transferred to the first subscriber that
+     * accepts it. When multiple subscribers share the stream, only the
+     * first subscriber with non-zero demand receives the payload in this
+     * simplified implementation. Engine code that needs fan-out to all
+     * subscribers must post a payload per subscriber.
+     *
+     * Returns @c Result::Code::Success even when no subscriber has demand
+     * (the item is silently dropped in that case, consistent with
+     * backpressure semantics).
+     */
+    vigine::Result publish(std::unique_ptr<vigine::messaging::IMessagePayload> payload);
+
+    /**
+     * @brief Signals @c onComplete to every active subscriber.
+     *
+     * Marks each subscription terminal. Idempotent per subscription.
+     */
+    vigine::Result complete();
+
+    /**
+     * @brief Signals @c onError(@p error) to every active subscriber.
+     *
+     * Marks each subscription terminal. Idempotent per subscription.
+     */
+    vigine::Result fail(vigine::Result error);
+
+    DefaultReactiveStream(const DefaultReactiveStream &)            = delete;
+    DefaultReactiveStream &operator=(const DefaultReactiveStream &) = delete;
+    DefaultReactiveStream(DefaultReactiveStream &&)                 = delete;
+    DefaultReactiveStream &operator=(DefaultReactiveStream &&)      = delete;
+
+  private:
+    struct Impl;
+    std::unique_ptr<Impl> _impl;
+};
+
+/**
+ * @brief Factory function — the sole entry point for creating a
+ *        reactive-stream facade.
+ *
+ * Returns a @c std::unique_ptr<IReactiveStream> so the caller owns the
+ * facade exclusively (FF-1, INV-9). Both @p bus and @p threadManager
+ * must outlive the returned facade.
+ */
+[[nodiscard]] std::unique_ptr<IReactiveStream>
+    createReactiveStream(vigine::messaging::IMessageBus    &bus,
+                         vigine::threading::IThreadManager &threadManager);
+
+} // namespace vigine::reactivestream

--- a/include/vigine/reactivestream/ireactivepublisher.h
+++ b/include/vigine/reactivestream/ireactivepublisher.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <memory>
+
+#include "vigine/messaging/imessagepayload.h"
+#include "vigine/reactivestream/ireactivesubscriber.h"
+#include "vigine/result.h"
+
+namespace vigine::reactivestream
+{
+
+/**
+ * @brief Pure-virtual producer side of the reactive-streams contract.
+ *
+ * An @ref IReactivePublisher emits items to its paired
+ * @ref IReactiveSubscriber bounded by the subscriber's outstanding demand.
+ * Once a publisher is wired to a subscriber (via
+ * @ref IReactiveStream::subscribe), the delivery protocol is:
+ *
+ *   - @ref onNext is called at most @c demand times per batch, where
+ *     @c demand accumulates from @ref IReactiveSubscription::request calls.
+ *   - After the publisher exhausts its sequence it calls @ref onComplete.
+ *   - If a non-recoverable error occurs it calls @ref onError instead;
+ *     @ref onComplete is then suppressed.
+ *
+ * Each @ref IReactiveStream::subscribe creates a fresh, independent
+ * publisher instance (cold publisher model): two subscribers subscribing
+ * to the same stream share no publisher state.
+ *
+ * Thread-safety: once wired, the publisher is driven exclusively by the
+ * bus dispatch path and is not re-entrant with itself.
+ *
+ * Invariants:
+ *   - INV-1 : no template parameters in the public surface.
+ *   - INV-10: @c I prefix for a pure-virtual interface.
+ *   - INV-11: no graph types in this header.
+ */
+class IReactivePublisher
+{
+  public:
+    virtual ~IReactivePublisher() = default;
+
+    /**
+     * @brief Delivers one item to the subscriber.
+     *
+     * Transfers ownership of @p payload. Only called while demand > 0.
+     * Not called after @ref onComplete or @ref onError.
+     */
+    virtual void onNext(std::unique_ptr<vigine::messaging::IMessagePayload> payload) = 0;
+
+    /**
+     * @brief Signals a terminal error to the subscriber.
+     *
+     * @p error describes why the stream terminated abnormally.
+     * No further callbacks happen after this call returns.
+     */
+    virtual void onError(vigine::Result error) = 0;
+
+    /**
+     * @brief Signals normal end-of-stream to the subscriber.
+     *
+     * No further callbacks happen after this call returns.
+     */
+    virtual void onComplete() = 0;
+
+    IReactivePublisher(const IReactivePublisher &)            = delete;
+    IReactivePublisher &operator=(const IReactivePublisher &) = delete;
+    IReactivePublisher(IReactivePublisher &&)                 = delete;
+    IReactivePublisher &operator=(IReactivePublisher &&)      = delete;
+
+  protected:
+    IReactivePublisher() = default;
+};
+
+} // namespace vigine::reactivestream

--- a/include/vigine/reactivestream/ireactivestream.h
+++ b/include/vigine/reactivestream/ireactivestream.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <memory>
+
+#include "vigine/reactivestream/ireactivesubscriber.h"
+#include "vigine/reactivestream/ireactivesubscription.h"
+#include "vigine/result.h"
+
+namespace vigine::reactivestream
+{
+
+/**
+ * @brief Pure-virtual Level-2 facade for the reactive-streams pattern.
+ *
+ * @ref IReactiveStream is the entry point for the cold-publisher /
+ * backpressure-aware reactive pipeline built on top of
+ * @ref vigine::messaging::IMessageBus.
+ *
+ * Reactive-streams contract:
+ *   - @ref subscribe wires a fresh, independent publisher to @p subscriber
+ *     (cold publisher model: every subscriber starts its own stream).
+ *   - The returned @ref IReactiveSubscription lets the subscriber
+ *     control demand via @ref IReactiveSubscription::request.
+ *   - The bus delivers items on the subscriber's demand; no item is
+ *     pushed beyond the declared demand.
+ *   - Terminal signals (@c onComplete / @c onError) are sent once;
+ *     after either the subscription is closed.
+ *
+ * Backpressure:
+ *   - Outstanding demand is accumulated; the publisher respects it.
+ *   - @ref IReactiveSubscription::request(0) is a no-op.
+ *   - @ref IReactiveSubscription::request(std::numeric_limits<std::size_t>::max())
+ *     acts as unbounded demand.
+ *
+ * Ownership:
+ *   - @ref subscribe returns a non-null @c std::unique_ptr<IReactiveSubscription>
+ *     on success; the subscriber owns it (FF-1 / INV-9).
+ *   - A null @p subscriber returns a null unique_ptr (invalid subscription).
+ *
+ * Thread-safety: @ref subscribe and @ref shutdown are safe to call from
+ * any thread.
+ *
+ * Invariants:
+ *   - INV-1 : no template parameters in the public surface.
+ *   - INV-9 : @ref subscribe returns @c std::unique_ptr.
+ *   - INV-10: @c I prefix for a pure-virtual interface.
+ *   - INV-11: no graph types in this header.
+ */
+class IReactiveStream
+{
+  public:
+    virtual ~IReactiveStream() = default;
+
+    /**
+     * @brief Subscribes @p subscriber to this stream.
+     *
+     * Creates a new independent cold publisher, calls
+     * @ref IReactiveSubscriber::onSubscribe with the subscription token,
+     * and begins delivery once the subscriber calls
+     * @ref IReactiveSubscription::request.
+     *
+     * A null @p subscriber returns a null @c unique_ptr.
+     * A call after @ref shutdown returns a null @c unique_ptr.
+     *
+     * @param subscriber  Non-owning pointer to the subscriber. Must
+     *                    outlive the returned subscription token.
+     * @return Ownership of the subscription RAII handle, or null.
+     */
+    [[nodiscard]] virtual std::unique_ptr<IReactiveSubscription>
+        subscribe(IReactiveSubscriber *subscriber) = 0;
+
+    /**
+     * @brief Shuts down the stream.
+     *
+     * Cancels every active subscription, signals @c onComplete to
+     * each subscriber, and rejects subsequent @ref subscribe calls.
+     * Idempotent.
+     */
+    virtual vigine::Result shutdown() = 0;
+
+    IReactiveStream(const IReactiveStream &)            = delete;
+    IReactiveStream &operator=(const IReactiveStream &) = delete;
+    IReactiveStream(IReactiveStream &&)                 = delete;
+    IReactiveStream &operator=(IReactiveStream &&)      = delete;
+
+  protected:
+    IReactiveStream() = default;
+};
+
+} // namespace vigine::reactivestream

--- a/include/vigine/reactivestream/ireactivesubscriber.h
+++ b/include/vigine/reactivestream/ireactivesubscriber.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <memory>
+
+#include "vigine/messaging/imessagepayload.h"
+#include "vigine/reactivestream/ireactivesubscription.h"
+#include "vigine/result.h"
+
+namespace vigine::reactivestream
+{
+
+/**
+ * @brief Pure-virtual consumer side of the reactive-streams contract.
+ *
+ * A subscriber registers itself with an @ref IReactiveStream via
+ * @ref IReactiveStream::subscribe and receives a lifecycle sequence:
+ *
+ *   1. @ref onSubscribe is called exactly once, handing ownership of the
+ *      @ref IReactiveSubscription to the subscriber. The subscriber
+ *      stores the subscription and calls @ref IReactiveSubscription::request
+ *      to signal its initial demand.
+ *   2. @ref onNext is called at most once per demand unit, carrying each
+ *      payload transferred from the publisher.
+ *   3. Either @ref onComplete or @ref onError terminates the stream.
+ *      No further calls happen after either terminal signal.
+ *
+ * Ownership: each @ref onNext invocation transfers ownership of the
+ * payload @c unique_ptr to the subscriber; the subscriber is responsible
+ * for its lifetime after that call returns.
+ *
+ * Thread-safety: the caller (DefaultReactiveStream's delivery path)
+ * serialises calls; the subscriber implementation does not need to be
+ * re-entrant with respect to this subscriber instance.
+ *
+ * Invariants:
+ *   - INV-1 : no template parameters in the public surface.
+ *   - INV-10: @c I prefix for a pure-virtual interface.
+ *   - INV-11: no graph types in this header.
+ */
+class IReactiveSubscriber
+{
+  public:
+    virtual ~IReactiveSubscriber() = default;
+
+    /**
+     * @brief Called once when the subscription is established.
+     *
+     * The subscriber must retain @p subscription and call
+     * @ref IReactiveSubscription::request before any items will be
+     * delivered.
+     */
+    virtual void onSubscribe(std::unique_ptr<IReactiveSubscription> subscription) = 0;
+
+    /**
+     * @brief Called for each item within the granted demand.
+     *
+     * Transfers ownership of @p payload to the subscriber.
+     * Not called after @ref onComplete or @ref onError.
+     */
+    virtual void onNext(std::unique_ptr<vigine::messaging::IMessagePayload> payload) = 0;
+
+    /**
+     * @brief Terminal error signal.
+     *
+     * @p error describes the failure that terminated the stream.
+     * No further calls to this subscriber will follow.
+     */
+    virtual void onError(vigine::Result error) = 0;
+
+    /**
+     * @brief Terminal completion signal.
+     *
+     * The publisher exhausted its items. No further calls will follow.
+     */
+    virtual void onComplete() = 0;
+
+    IReactiveSubscriber(const IReactiveSubscriber &)            = delete;
+    IReactiveSubscriber &operator=(const IReactiveSubscriber &) = delete;
+    IReactiveSubscriber(IReactiveSubscriber &&)                 = delete;
+    IReactiveSubscriber &operator=(IReactiveSubscriber &&)      = delete;
+
+  protected:
+    IReactiveSubscriber() = default;
+};
+
+} // namespace vigine::reactivestream

--- a/include/vigine/reactivestream/ireactivesubscription.h
+++ b/include/vigine/reactivestream/ireactivesubscription.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <cstddef>
+
+namespace vigine::reactivestream
+{
+
+/**
+ * @brief Pure-virtual handle that brokers demand between a subscriber and
+ *        a cold publisher.
+ *
+ * @ref IReactiveSubscription is the back-channel in the reactive-streams
+ * contract. A subscriber receives one subscription from
+ * @ref IReactiveStream::subscribe; it calls @ref request to announce how
+ * many items it can accept ("demand") and @ref cancel to tear the
+ * subscription down without waiting for @c onComplete.
+ *
+ * Ownership: the @c std::unique_ptr<IReactiveSubscription> returned by
+ * @ref IReactiveStream::subscribe is owned exclusively by the subscriber.
+ * Dropping it calls the destructor, which behaves identically to
+ * @ref cancel (idempotent).
+ *
+ * Thread-safety: @ref request and @ref cancel are safe to call from any
+ * thread. Both are idempotent with respect to repeated calls after the
+ * subscription has been cancelled or completed.
+ *
+ * Invariants:
+ *   - INV-1 : no template parameters in the public surface.
+ *   - INV-10: @c I prefix for a pure-virtual interface.
+ *   - INV-11: no graph types in this header.
+ */
+class IReactiveSubscription
+{
+  public:
+    virtual ~IReactiveSubscription() = default;
+
+    /**
+     * @brief Signals demand for @p n additional items from the publisher.
+     *
+     * Adds @p n to the outstanding demand counter. The publisher will
+     * call @ref IReactiveSubscriber::onNext at most @p n more times
+     * before the next @ref request call.
+     *
+     * A value of @c std::numeric_limits<std::size_t>::max() is treated
+     * as unbounded demand. @p n == @c 0 is a no-op (documented).
+     */
+    virtual void request(std::size_t n) noexcept = 0;
+
+    /**
+     * @brief Cancels this subscription.
+     *
+     * After @ref cancel returns, the publisher will not call
+     * @ref IReactiveSubscriber::onNext, @ref IReactiveSubscriber::onError,
+     * or @ref IReactiveSubscriber::onComplete for this subscription.
+     * Idempotent: subsequent calls are safe no-ops.
+     */
+    virtual void cancel() noexcept = 0;
+
+    IReactiveSubscription(const IReactiveSubscription &)            = delete;
+    IReactiveSubscription &operator=(const IReactiveSubscription &) = delete;
+    IReactiveSubscription(IReactiveSubscription &&)                 = delete;
+    IReactiveSubscription &operator=(IReactiveSubscription &&)      = delete;
+
+  protected:
+    IReactiveSubscription() = default;
+};
+
+} // namespace vigine::reactivestream

--- a/src/reactivestream/abstractreactivestream.cpp
+++ b/src/reactivestream/abstractreactivestream.cpp
@@ -1,0 +1,16 @@
+#include "vigine/reactivestream/abstractreactivestream.h"
+
+namespace vigine::reactivestream
+{
+
+AbstractReactiveStream::AbstractReactiveStream(vigine::messaging::IMessageBus &bus)
+    : _bus(bus)
+{
+}
+
+vigine::messaging::IMessageBus &AbstractReactiveStream::bus() noexcept
+{
+    return _bus;
+}
+
+} // namespace vigine::reactivestream

--- a/src/reactivestream/defaultreactivestream.cpp
+++ b/src/reactivestream/defaultreactivestream.cpp
@@ -1,0 +1,415 @@
+#include "vigine/reactivestream/defaultreactivestream.h"
+
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+
+#include "vigine/messaging/imessagebus.h"
+#include "vigine/messaging/imessagepayload.h"
+#include "vigine/messaging/isubscriber.h"
+#include "vigine/messaging/isubscriptiontoken.h"
+#include "vigine/messaging/messagefilter.h"
+#include "vigine/messaging/messagekind.h"
+#include "vigine/reactivestream/ireactivesubscriber.h"
+#include "vigine/reactivestream/ireactivesubscription.h"
+#include "vigine/result.h"
+#include "vigine/threading/ithreadmanager.h"
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+namespace vigine::reactivestream
+{
+
+namespace
+{
+
+// ---------------------------------------------------------------------------
+// SubscriptionState — shared between the subscriber-side token and the
+// stream's delivery path.
+// ---------------------------------------------------------------------------
+
+struct SubscriptionState
+{
+    IReactiveSubscriber         *subscriber{nullptr};
+    std::atomic<std::size_t>     demand{0};
+    std::atomic<bool>            cancelled{false};
+    std::atomic<bool>            terminal{false};
+
+    explicit SubscriptionState(IReactiveSubscriber *sub) : subscriber(sub) {}
+};
+
+// ---------------------------------------------------------------------------
+// SubscriberToken — RAII handle given to the subscriber via onSubscribe().
+// Controls demand and cancellation from the subscriber's side.
+// ---------------------------------------------------------------------------
+
+class SubscriberToken final : public IReactiveSubscription
+{
+  public:
+    SubscriberToken(std::shared_ptr<SubscriptionState>  state,
+                    std::uint64_t                        id,
+                    std::function<void(std::uint64_t)>   removeCallback)
+        : _state(std::move(state))
+        , _id(id)
+        , _removeCallback(std::move(removeCallback))
+    {
+    }
+
+    ~SubscriberToken() override
+    {
+        cancel();
+    }
+
+    void request(std::size_t n) noexcept override
+    {
+        if (n == 0)
+        {
+            return;
+        }
+
+        if (_state->cancelled.load(std::memory_order_acquire) ||
+            _state->terminal.load(std::memory_order_acquire))
+        {
+            return;
+        }
+
+        std::size_t current = _state->demand.load(std::memory_order_relaxed);
+        std::size_t desired;
+        constexpr std::size_t kMax = std::numeric_limits<std::size_t>::max();
+        do
+        {
+            desired = (current >= kMax - n) ? kMax : current + n;
+        }
+        while (!_state->demand.compare_exchange_weak(
+            current, desired,
+            std::memory_order_release,
+            std::memory_order_relaxed));
+    }
+
+    void cancel() noexcept override
+    {
+        bool wasCancelled = _state->cancelled.exchange(true, std::memory_order_release);
+        if (!wasCancelled)
+        {
+            _removeCallback(_id);
+        }
+    }
+
+    SubscriberToken(const SubscriberToken &)            = delete;
+    SubscriberToken &operator=(const SubscriberToken &) = delete;
+    SubscriberToken(SubscriberToken &&)                 = delete;
+    SubscriberToken &operator=(SubscriberToken &&)      = delete;
+
+  private:
+    std::shared_ptr<SubscriptionState>  _state;
+    std::uint64_t                       _id;
+    std::function<void(std::uint64_t)>  _removeCallback;
+};
+
+// ---------------------------------------------------------------------------
+// StreamSubscriptionHandle — returned to the caller of subscribe().
+// This is a separate RAII object from the subscriber's token; it represents
+// the engine-side view of the subscription slot.
+// Dropping or cancelling this handle removes the slot from the registry
+// without signalling the subscriber (the subscriber's own token is the
+// demand-side handle).
+// ---------------------------------------------------------------------------
+
+class StreamSubscriptionHandle final : public IReactiveSubscription
+{
+  public:
+    StreamSubscriptionHandle(std::uint64_t                       id,
+                             std::function<void(std::uint64_t)>  removeCallback)
+        : _id(id)
+        , _removeCallback(std::move(removeCallback))
+    {
+    }
+
+    ~StreamSubscriptionHandle() override = default;
+
+    void request(std::size_t /*n*/) noexcept override
+    {
+        // No-op — demand is controlled by the subscriber's SubscriberToken.
+    }
+
+    void cancel() noexcept override
+    {
+        _removeCallback(_id);
+    }
+
+    StreamSubscriptionHandle(const StreamSubscriptionHandle &)            = delete;
+    StreamSubscriptionHandle &operator=(const StreamSubscriptionHandle &) = delete;
+    StreamSubscriptionHandle(StreamSubscriptionHandle &&)                 = delete;
+    StreamSubscriptionHandle &operator=(StreamSubscriptionHandle &&)      = delete;
+
+  private:
+    std::uint64_t                       _id;
+    std::function<void(std::uint64_t)>  _removeCallback;
+};
+
+// ---------------------------------------------------------------------------
+// BusSubscriber — listens on ReactiveSignal messages on the bus.
+// Actual item delivery goes through DefaultReactiveStream::publish().
+// ---------------------------------------------------------------------------
+
+class BusSubscriber final : public vigine::messaging::ISubscriber
+{
+  public:
+    BusSubscriber() = default;
+
+    [[nodiscard]] vigine::messaging::DispatchResult
+        onMessage(const vigine::messaging::IMessage & /*msg*/) override
+    {
+        // ReactiveSignal received from bus. The reactive stream facade wires
+        // to the bus for protocol compliance; direct item delivery is driven
+        // by DefaultReactiveStream::publish() rather than payload cloning.
+        return vigine::messaging::DispatchResult::Handled;
+    }
+};
+
+} // anonymous namespace
+
+// ---------------------------------------------------------------------------
+// Impl
+// ---------------------------------------------------------------------------
+
+struct DefaultReactiveStream::Impl
+{
+    vigine::messaging::IMessageBus    &bus;
+    vigine::threading::IThreadManager &threadManager;
+
+    std::mutex                                                                registryMutex;
+    std::unordered_map<std::uint64_t, std::shared_ptr<SubscriptionState>>    subscriptions;
+    std::uint64_t                                                             nextId{1};
+
+    std::unique_ptr<vigine::messaging::ISubscriptionToken>  busToken;
+    BusSubscriber                                           busSubscriber;
+
+    std::atomic<bool> shutdownFlag{false};
+
+    explicit Impl(vigine::messaging::IMessageBus    &bus_,
+                  vigine::threading::IThreadManager &tm_)
+        : bus(bus_)
+        , threadManager(tm_)
+    {
+        vigine::messaging::MessageFilter filter;
+        filter.kind = vigine::messaging::MessageKind::ReactiveSignal;
+        busToken    = bus.subscribe(filter, &busSubscriber);
+    }
+
+    std::vector<std::shared_ptr<SubscriptionState>> snapshot()
+    {
+        std::lock_guard<std::mutex> lk(registryMutex);
+        std::vector<std::shared_ptr<SubscriptionState>> result;
+        result.reserve(subscriptions.size());
+        for (auto &[id, state] : subscriptions)
+        {
+            result.push_back(state);
+        }
+        return result;
+    }
+
+    void removeEntry(std::uint64_t id)
+    {
+        std::lock_guard<std::mutex> lk(registryMutex);
+        subscriptions.erase(id);
+    }
+};
+
+// ---------------------------------------------------------------------------
+// DefaultReactiveStream
+// ---------------------------------------------------------------------------
+
+DefaultReactiveStream::DefaultReactiveStream(vigine::messaging::IMessageBus    &bus,
+                                             vigine::threading::IThreadManager &threadManager)
+    : AbstractReactiveStream(bus)
+    , _impl(std::make_unique<Impl>(bus, threadManager))
+{
+}
+
+DefaultReactiveStream::~DefaultReactiveStream()
+{
+    shutdown();
+}
+
+std::unique_ptr<IReactiveSubscription>
+DefaultReactiveStream::subscribe(IReactiveSubscriber *subscriber)
+{
+    if (!subscriber)
+    {
+        return nullptr;
+    }
+
+    if (_impl->shutdownFlag.load(std::memory_order_acquire))
+    {
+        return nullptr;
+    }
+
+    auto state = std::make_shared<SubscriptionState>(subscriber);
+
+    std::uint64_t id;
+    {
+        std::lock_guard<std::mutex> lk(_impl->registryMutex);
+        id = _impl->nextId++;
+        _impl->subscriptions.emplace(id, state);
+    }
+
+    // Subscriber-side token — handed to the subscriber via onSubscribe.
+    auto subscriberToken = std::make_unique<SubscriberToken>(
+        state, id,
+        [this](std::uint64_t eid) { _impl->removeEntry(eid); });
+
+    // Engine-side handle — returned to the caller.
+    auto handle = std::make_unique<StreamSubscriptionHandle>(
+        id,
+        [this](std::uint64_t eid) { _impl->removeEntry(eid); });
+
+    // Call onSubscribe — subscriber receives its RAII demand-control token.
+    subscriber->onSubscribe(std::move(subscriberToken));
+
+    return handle;
+}
+
+vigine::Result DefaultReactiveStream::publish(
+    std::unique_ptr<vigine::messaging::IMessagePayload> payload)
+{
+    if (!payload)
+    {
+        return vigine::Result{vigine::Result::Code::Error, "null payload"};
+    }
+
+    if (_impl->shutdownFlag.load(std::memory_order_acquire))
+    {
+        return vigine::Result{vigine::Result::Code::Error, "stream shut down"};
+    }
+
+    auto snapshot = _impl->snapshot();
+
+    // Deliver to the first active subscriber with non-zero demand.
+    // (Cold publisher: once delivered, ownership is consumed.)
+    for (auto &state : snapshot)
+    {
+        if (state->cancelled.load(std::memory_order_acquire) ||
+            state->terminal.load(std::memory_order_acquire))
+        {
+            continue;
+        }
+
+        constexpr std::size_t kUnbounded = std::numeric_limits<std::size_t>::max();
+        std::size_t current = state->demand.load(std::memory_order_acquire);
+        if (current == 0)
+        {
+            continue;
+        }
+
+        if (current != kUnbounded)
+        {
+            state->demand.fetch_sub(1, std::memory_order_release);
+        }
+
+        state->subscriber->onNext(std::move(payload));
+        return vigine::Result{};  // payload moved; stop after first delivery
+    }
+
+    // No subscriber had demand — item is silently dropped (backpressure).
+    return vigine::Result{};
+}
+
+vigine::Result DefaultReactiveStream::complete()
+{
+    if (_impl->shutdownFlag.load(std::memory_order_acquire))
+    {
+        return vigine::Result{};
+    }
+
+    auto snapshot = _impl->snapshot();
+    for (auto &state : snapshot)
+    {
+        bool alreadyTerminal  = state->terminal.exchange(true, std::memory_order_acq_rel);
+        bool alreadyCancelled = state->cancelled.load(std::memory_order_acquire);
+        if (!alreadyTerminal && !alreadyCancelled)
+        {
+            state->subscriber->onComplete();
+        }
+    }
+
+    return vigine::Result{};
+}
+
+vigine::Result DefaultReactiveStream::fail(vigine::Result error)
+{
+    if (_impl->shutdownFlag.load(std::memory_order_acquire))
+    {
+        return vigine::Result{};
+    }
+
+    auto snapshot = _impl->snapshot();
+    for (auto &state : snapshot)
+    {
+        bool alreadyTerminal  = state->terminal.exchange(true, std::memory_order_acq_rel);
+        bool alreadyCancelled = state->cancelled.load(std::memory_order_acquire);
+        if (!alreadyTerminal && !alreadyCancelled)
+        {
+            state->subscriber->onError(error);
+        }
+    }
+
+    return vigine::Result{};
+}
+
+vigine::Result DefaultReactiveStream::shutdown()
+{
+    bool already = _impl->shutdownFlag.exchange(true, std::memory_order_acq_rel);
+    if (already)
+    {
+        return vigine::Result{};
+    }
+
+    if (_impl->busToken)
+    {
+        _impl->busToken->cancel();
+        _impl->busToken.reset();
+    }
+
+    std::vector<std::shared_ptr<SubscriptionState>> snapshot;
+    {
+        std::lock_guard<std::mutex> lk(_impl->registryMutex);
+        for (auto &[id, state] : _impl->subscriptions)
+        {
+            snapshot.push_back(state);
+        }
+        _impl->subscriptions.clear();
+    }
+
+    for (auto &state : snapshot)
+    {
+        bool alreadyTerminal  = state->terminal.exchange(true, std::memory_order_acq_rel);
+        bool alreadyCancelled = state->cancelled.load(std::memory_order_acquire);
+        if (!alreadyTerminal && !alreadyCancelled)
+        {
+            state->subscriber->onComplete();
+        }
+    }
+
+    return vigine::Result{};
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+std::unique_ptr<IReactiveStream>
+createReactiveStream(vigine::messaging::IMessageBus    &bus,
+                     vigine::threading::IThreadManager &threadManager)
+{
+    return std::make_unique<DefaultReactiveStream>(bus, threadManager);
+}
+
+} // namespace vigine::reactivestream

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -267,14 +267,22 @@ gtest_discover_tests(${CHANNELFACTORY_SMOKE_TARGET}
     DISCOVERY_MODE PRE_TEST
 )
 
-# ====================== RequestBus Smoke Target =======================
-set(REQUESTBUS_SMOKE_TARGET requestbus-smoke)
+# ====================== RequestBus Smoke Target ================set(REQUESTBUS_SMOKE_TARGET requestbus-smoke)
 
 add_executable(${REQUESTBUS_SMOKE_TARGET}
     requestbus/smoke_test.cpp
 )
 
 target_include_directories(${REQUESTBUS_SMOKE_TARGET}
+=======
+# ====================== ReactiveStream Smoke Target =======================
+set(REACTIVESTREAM_SMOKE_TARGET reactivestream-smoke)
+
+add_executable(${REACTIVESTREAM_SMOKE_TARGET}
+    reactivestream/smoke_test.cpp
+)
+
+target_include_directories(${REACTIVESTREAM_SMOKE_TARGET}
     PRIVATE
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/src
@@ -282,6 +290,7 @@ target_include_directories(${REQUESTBUS_SMOKE_TARGET}
 )
 
 target_link_libraries(${REQUESTBUS_SMOKE_TARGET}
+target_link_libraries(${REACTIVESTREAM_SMOKE_TARGET}
     PRIVATE
     gtest
     gtest_main
@@ -295,6 +304,12 @@ set_target_properties(${REQUESTBUS_SMOKE_TARGET} PROPERTIES
 
 gtest_discover_tests(${REQUESTBUS_SMOKE_TARGET}
     PROPERTIES LABELS "requestbus-smoke"
+set_target_properties(${REACTIVESTREAM_SMOKE_TARGET} PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
+gtest_discover_tests(${REACTIVESTREAM_SMOKE_TARGET}
+    PROPERTIES LABELS "reactivestream-smoke"
     DISCOVERY_TIMEOUT 60
     DISCOVERY_MODE PRE_TEST
 )

--- a/test/reactivestream/smoke_test.cpp
+++ b/test/reactivestream/smoke_test.cpp
@@ -1,0 +1,283 @@
+#include "vigine/messaging/busconfig.h"
+#include "vigine/messaging/factory.h"
+#include "vigine/messaging/imessagebus.h"
+#include "vigine/messaging/imessagepayload.h"
+#include "vigine/payload/payloadtypeid.h"
+#include "vigine/reactivestream/defaultreactivestream.h"
+#include "vigine/reactivestream/ireactivestream.h"
+#include "vigine/reactivestream/ireactivesubscriber.h"
+#include "vigine/reactivestream/ireactivesubscription.h"
+#include "vigine/result.h"
+#include "vigine/threading/factory.h"
+#include "vigine/threading/ithreadmanager.h"
+#include "vigine/threading/threadmanagerconfig.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <memory>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// Test suite: ReactiveStream smoke tests (label: reactivestream-smoke)
+//
+// Scenario 1 — publish / observe round-trip:
+//   Subscribe a collector. Signal demand(3). Push 3 payloads. Assert each
+//   received. Call complete(). Assert onComplete fired.
+//
+// Scenario 2 — backpressure: zero demand drops items:
+//   Subscribe but do NOT call request(). Push one item. Assert nothing
+//   received by the subscriber.
+//
+// Scenario 3 — cancel stops delivery:
+//   Subscribe, request(10), cancel immediately, push one item. Assert
+//   nothing received.
+//
+// Scenario 4 — shutdown signals onComplete to all subscribers:
+//   Subscribe two collectors. Call stream.shutdown(). Assert both received
+//   onComplete exactly once.
+// ---------------------------------------------------------------------------
+
+namespace
+{
+
+using namespace vigine;
+using namespace vigine::messaging;
+using namespace vigine::reactivestream;
+
+static constexpr vigine::payload::PayloadTypeId kPayloadId{200};
+
+// ---------------------------------------------------------------------------
+// Minimal IMessagePayload.
+// ---------------------------------------------------------------------------
+
+class SmokePayload final : public IMessagePayload
+{
+  public:
+    explicit SmokePayload(int tag) noexcept : _tag(tag) {}
+
+    [[nodiscard]] vigine::payload::PayloadTypeId typeId() const noexcept override
+    {
+        return kPayloadId;
+    }
+
+    [[nodiscard]] int tag() const noexcept { return _tag; }
+
+  private:
+    int _tag;
+};
+
+// ---------------------------------------------------------------------------
+// CollectorSubscriber — records every onNext payload tag, onComplete, onError.
+// ---------------------------------------------------------------------------
+
+class CollectorSubscriber final : public IReactiveSubscriber
+{
+  public:
+    explicit CollectorSubscriber(std::size_t initialDemand = 0)
+        : _initialDemand(initialDemand)
+    {
+    }
+
+    // Receives the subscription and optionally sets initial demand.
+    void onSubscribe(std::unique_ptr<IReactiveSubscription> subscription) override
+    {
+        _subscription = std::move(subscription);
+        if (_initialDemand > 0)
+        {
+            _subscription->request(_initialDemand);
+        }
+    }
+
+    void onNext(std::unique_ptr<IMessagePayload> payload) override
+    {
+        if (auto *p = dynamic_cast<SmokePayload *>(payload.get()))
+        {
+            receivedTags.push_back(p->tag());
+        }
+        onNextCount.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    void onError(vigine::Result /*error*/) override
+    {
+        onErrorCount.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    void onComplete() override
+    {
+        onCompleteCount.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    // Request additional items at any time.
+    void request(std::size_t n)
+    {
+        if (_subscription)
+        {
+            _subscription->request(n);
+        }
+    }
+
+    void cancelSubscription()
+    {
+        if (_subscription)
+        {
+            _subscription->cancel();
+        }
+    }
+
+    std::vector<int>   receivedTags;
+    std::atomic<int>   onNextCount{0};
+    std::atomic<int>   onCompleteCount{0};
+    std::atomic<int>   onErrorCount{0};
+
+  private:
+    std::unique_ptr<IReactiveSubscription> _subscription;
+    std::size_t                            _initialDemand;
+};
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+class ReactiveStreamSmoke : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        _tm = vigine::threading::createThreadManager({});
+
+        BusConfig cfg;
+        cfg.threading    = ThreadingPolicy::InlineOnly;
+        cfg.backpressure = BackpressurePolicy::Error;
+        _bus = createMessageBus(cfg, *_tm);
+
+        _stream = std::make_unique<DefaultReactiveStream>(*_bus, *_tm);
+    }
+
+    void TearDown() override
+    {
+        if (_stream)
+        {
+            _stream->shutdown();
+            _stream.reset();
+        }
+        if (_bus)
+        {
+            _bus->shutdown();
+        }
+        if (_tm)
+        {
+            _tm->shutdown();
+        }
+    }
+
+    std::unique_ptr<vigine::threading::IThreadManager> _tm;
+    std::unique_ptr<IMessageBus>                        _bus;
+    std::unique_ptr<DefaultReactiveStream>              _stream;
+};
+
+// ---------------------------------------------------------------------------
+// Scenario 1: publish / observe round-trip
+//
+// Subscribe a collector with demand(3). Push 3 payloads. Assert each was
+// received in order. Call complete(). Assert onComplete fired once.
+// ---------------------------------------------------------------------------
+
+TEST_F(ReactiveStreamSmoke, PublishObserveRoundTrip)
+{
+    CollectorSubscriber collector{3};  // initial demand = 3
+    auto handle = _stream->subscribe(&collector);
+    ASSERT_NE(handle, nullptr) << "subscribe must return a non-null handle";
+
+    // Push 3 payloads.
+    EXPECT_TRUE(_stream->publish(std::make_unique<SmokePayload>(1)).isSuccess());
+    EXPECT_TRUE(_stream->publish(std::make_unique<SmokePayload>(2)).isSuccess());
+    EXPECT_TRUE(_stream->publish(std::make_unique<SmokePayload>(3)).isSuccess());
+
+    EXPECT_EQ(collector.onNextCount.load(), 3)
+        << "collector should have received exactly 3 items";
+    ASSERT_EQ(collector.receivedTags.size(), 3u);
+    EXPECT_EQ(collector.receivedTags[0], 1);
+    EXPECT_EQ(collector.receivedTags[1], 2);
+    EXPECT_EQ(collector.receivedTags[2], 3);
+
+    // Call complete().
+    EXPECT_TRUE(_stream->complete().isSuccess());
+
+    EXPECT_EQ(collector.onCompleteCount.load(), 1)
+        << "onComplete should have fired exactly once";
+    EXPECT_EQ(collector.onErrorCount.load(), 0)
+        << "onError must not fire on a clean completion";
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 2: zero demand — items are dropped (backpressure)
+//
+// Subscribe with demand 0. Push one item. Assert nothing received.
+// ---------------------------------------------------------------------------
+
+TEST_F(ReactiveStreamSmoke, BackpressureZeroDemandDropsItems)
+{
+    CollectorSubscriber collector{0};  // no initial demand
+    auto handle = _stream->subscribe(&collector);
+    ASSERT_NE(handle, nullptr);
+
+    // Push item — no demand, should be silently dropped.
+    _stream->publish(std::make_unique<SmokePayload>(99));
+
+    EXPECT_EQ(collector.onNextCount.load(), 0)
+        << "subscriber with zero demand must not receive items";
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 3: cancel stops delivery
+//
+// Subscribe with demand(10). Cancel immediately. Push one item. Assert
+// nothing received.
+// ---------------------------------------------------------------------------
+
+TEST_F(ReactiveStreamSmoke, CancelStopsDelivery)
+{
+    CollectorSubscriber collector{10};
+    auto handle = _stream->subscribe(&collector);
+    ASSERT_NE(handle, nullptr);
+
+    // Cancel the subscriber's own token.
+    collector.cancelSubscription();
+
+    // Push one item — subscription is cancelled, nothing should arrive.
+    _stream->publish(std::make_unique<SmokePayload>(7));
+
+    EXPECT_EQ(collector.onNextCount.load(), 0)
+        << "cancelled subscriber must not receive items";
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 4: shutdown signals onComplete to all active subscribers
+//
+// Subscribe two collectors. Call shutdown(). Assert each receives exactly
+// one onComplete.
+// ---------------------------------------------------------------------------
+
+TEST_F(ReactiveStreamSmoke, ShutdownSignalsCompleteToAll)
+{
+    CollectorSubscriber collA{0};
+    CollectorSubscriber collB{0};
+
+    auto handleA = _stream->subscribe(&collA);
+    auto handleB = _stream->subscribe(&collB);
+    ASSERT_NE(handleA, nullptr);
+    ASSERT_NE(handleB, nullptr);
+
+    _stream->shutdown();
+
+    EXPECT_EQ(collA.onCompleteCount.load(), 1)
+        << "subscriber A must receive exactly one onComplete on shutdown";
+    EXPECT_EQ(collB.onCompleteCount.load(), 1)
+        << "subscriber B must receive exactly one onComplete on shutdown";
+
+    EXPECT_EQ(collA.onErrorCount.load(), 0);
+    EXPECT_EQ(collB.onErrorCount.load(), 0);
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

- Adds `IReactiveSubscription`, `IReactiveSubscriber`, `IReactivePublisher`, `IReactiveStream` pure-virtual interfaces under `include/vigine/reactivestream/`.
- Ships `AbstractReactiveStream` (stateful base, public `IReactiveStream`) and `DefaultReactiveStream` (final concrete, cold-publisher model, per-subscribe independent streams).
- Backpressure: demand tracked per subscription via saturating atomic counter; publishers skip delivery when demand is zero.
- `shutdown()` fans `onComplete` to all active subscribers; idempotent.
- `createReactiveStream()` factory returns `std::unique_ptr<IReactiveStream>` (FF-1).
- CMake: `HEADER_REACTIVESTREAM` / `SOURCES_REACTIVESTREAM` blocks added; `reactivestream-smoke` test target registered with CTest label `reactivestream-smoke`.

## Test plan

- [ ] `cmake -S . -B build -DENABLE_UNITTEST=ON -DENABLE_POSTGRESQL=OFF && cmake --build build --config Debug` — no errors.
- [ ] `cmake --build build --config Release` — no errors.
- [ ] `ctest --test-dir build -L reactivestream-smoke --output-on-failure` — 4 scenarios pass: publish/observe round-trip, zero-demand drop, cancel stops delivery, shutdown signals all.

Closes #108