### PR TITLE
feat(actor): ship IActorHost actor-model facade over IMessageBus

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -513,6 +513,22 @@ set(HEADER_REACTIVESTREAM
 set(SOURCES_REACTIVESTREAM
     ${SRC_DIR}/reactivestream/abstractreactivestream.cpp
     ${SRC_DIR}/reactivestream/defaultreactivestream.cpp
+# Actor-host facade (R.3.3.2.3 / plan_21) -- public surface.
+set(HEADER_ACTORHOST
+    ${INCLUDE_DIR}/vigine/actorhost/actorid.h
+    ${INCLUDE_DIR}/vigine/actorhost/iactor.h
+    ${INCLUDE_DIR}/vigine/actorhost/iactormailbox.h
+    ${INCLUDE_DIR}/vigine/actorhost/iactorhost.h
+    ${INCLUDE_DIR}/vigine/actorhost/abstractactorhost.h
+    ${INCLUDE_DIR}/vigine/actorhost/defaultactorhost.h
+    ${INCLUDE_DIR}/vigine/actorhost/factory.h
+)
+
+# Actor-host facade (R.3.3.2.3 / plan_21) -- internal concrete + factory.
+set(SOURCES_ACTORHOST
+    ${SRC_DIR}/actorhost/abstractactorhost.cpp
+    ${SRC_DIR}/actorhost/defaultactorhost.cpp
+    ${SRC_DIR}/actorhost/factory.cpp
 )
 
 # Add source files
@@ -611,6 +627,8 @@ add_library(${PROJECT_NAME}
     ${SOURCES_REQUESTBUS}
     ${HEADER_REACTIVESTREAM}
     ${SOURCES_REACTIVESTREAM}
+    ${HEADER_ACTORHOST}
+    ${SOURCES_ACTORHOST}
     ${HEADER_POSTGRESQL}
     ${SOURCES_POSTGRESQL}
     ${SOURCES_POSTGRESQL_EXTRA}

--- a/include/vigine/actorhost/abstractactorhost.h
+++ b/include/vigine/actorhost/abstractactorhost.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "vigine/actorhost/iactorhost.h"
+#include "vigine/messaging/imessagebus.h"
+#include "vigine/threading/ithreadmanager.h"
+
+namespace vigine::actorhost
+{
+
+/**
+ * @brief Stateful abstract base for the actor-host facade.
+ *
+ * @ref AbstractActorHost is Level-4 of the five-layer wrapper recipe.  It
+ * inherits @ref IActorHost @c public so the actor surface sits at offset zero
+ * for zero-cost up-casts, and holds references to the underlying
+ * @ref vigine::messaging::IMessageBus and @ref vigine::threading::IThreadManager
+ * @c protected so subclass wiring can reach them without exposing the raw
+ * surfaces in the public actor-host API.
+ *
+ * The class carries state (two references), so it follows the project's
+ * @c Abstract naming convention rather than the @c I pure-virtual prefix.
+ *
+ * Concrete subclasses (e.g. @ref DefaultActorHost) close the chain by
+ * providing the actor registry, the mailbox loop, and the full
+ * @ref IActorHost implementation.  Callers never name those types directly.
+ *
+ * Invariants:
+ *   - INV-10: @c Abstract prefix for an abstract class with state.
+ *   - INV-11: no graph types leak through this header.
+ *   - Inheritance order: @c public @ref IActorHost FIRST (mandatory per
+ *     5-layer recipe so the facade surface sits at offset zero).
+ *   - All data members are @c private (strict encapsulation).
+ */
+class AbstractActorHost : public IActorHost
+{
+  public:
+    ~AbstractActorHost() override = default;
+
+    AbstractActorHost(const AbstractActorHost &)            = delete;
+    AbstractActorHost &operator=(const AbstractActorHost &) = delete;
+    AbstractActorHost(AbstractActorHost &&)                  = delete;
+    AbstractActorHost &operator=(AbstractActorHost &&)       = delete;
+
+  protected:
+    /**
+     * @brief Constructs the abstract base holding references to @p bus and
+     *        @p threadManager.
+     *
+     * The caller (factory or test harness) guarantees both references outlive
+     * this facade instance.
+     */
+    AbstractActorHost(vigine::messaging::IMessageBus    &bus,
+                      vigine::threading::IThreadManager &threadManager);
+
+    /**
+     * @brief Returns the underlying bus reference for subclass wiring.
+     */
+    [[nodiscard]] vigine::messaging::IMessageBus &bus() noexcept;
+
+    /**
+     * @brief Returns the thread manager reference for subclass wiring.
+     */
+    [[nodiscard]] vigine::threading::IThreadManager &threadManager() noexcept;
+
+  private:
+    vigine::messaging::IMessageBus    &_bus;
+    vigine::threading::IThreadManager &_threadManager;
+};
+
+} // namespace vigine::actorhost

--- a/include/vigine/actorhost/actorid.h
+++ b/include/vigine/actorhost/actorid.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <cstdint>
+
+namespace vigine::actorhost
+{
+
+/**
+ * @brief Generational actor identity.
+ *
+ * @ref ActorId is a lightweight POD value that uniquely identifies a live
+ * actor inside an @ref IActorHost.  The @c value field carries a generational
+ * counter so that a freshly spawned actor never reuses the numeric identity
+ * of a previously stopped one.
+ *
+ * Sentinel: @c value == 0 means "invalid / no actor".  Live ids always start
+ * at @c 1.
+ *
+ * Invariants:
+ *   - INV-10: POD value type; no template parameters (INV-1).
+ *   - INV-11: no graph types here.
+ */
+struct ActorId
+{
+    std::uint32_t value{0};
+
+    [[nodiscard]] constexpr bool valid() const noexcept { return value != 0; }
+
+    [[nodiscard]] friend constexpr bool operator==(ActorId lhs, ActorId rhs) noexcept
+    {
+        return lhs.value == rhs.value;
+    }
+
+    [[nodiscard]] friend constexpr bool operator!=(ActorId lhs, ActorId rhs) noexcept
+    {
+        return lhs.value != rhs.value;
+    }
+};
+
+} // namespace vigine::actorhost

--- a/include/vigine/actorhost/defaultactorhost.h
+++ b/include/vigine/actorhost/defaultactorhost.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <memory>
+
+#include "vigine/actorhost/abstractactorhost.h"
+#include "vigine/actorhost/iactormailbox.h"
+
+namespace vigine::actorhost
+{
+
+/**
+ * @brief Concrete final actor-host facade.
+ *
+ * @ref DefaultActorHost is Level-5 of the five-layer wrapper recipe.  It
+ * provides the full @ref IActorHost implementation on top of
+ * @ref AbstractActorHost:
+ *
+ *   - A generational id counter assigning fresh @ref ActorId values.
+ *   - A per-actor registry mapping @ref ActorId to a live mailbox state.
+ *   - One named thread per actor, registered with @ref IThreadManager, that
+ *     drains the actor's @ref IMessageChannel and calls @ref IActor::receive
+ *     sequentially.  This is the serialisation guarantee of the actor model.
+ *   - Exception isolation: an exception escaping @ref IActor::receive is
+ *     caught, logged, and the loop continues (v1 restart-not-supervised).
+ *
+ * Callers obtain instances exclusively through @ref createActorHost.
+ *
+ * Thread-safety: all public methods are safe to call concurrently.  The
+ * actor registry is guarded by a @c std::mutex.  Each actor's mailbox
+ * channel provides its own thread-safety.
+ *
+ * Invariants:
+ *   - @c final: no further subclassing allowed.
+ *   - INV-9:  factory returns @c std::unique_ptr<IActorHost>.
+ *   - INV-11: no graph types leak into this header.
+ */
+class DefaultActorHost final : public AbstractActorHost
+{
+  public:
+    /**
+     * @brief Constructs the actor-host facade over @p bus and @p threadManager.
+     *
+     * Both @p bus and @p threadManager must outlive this facade instance.
+     */
+    DefaultActorHost(vigine::messaging::IMessageBus    &bus,
+                     vigine::threading::IThreadManager &threadManager);
+
+    ~DefaultActorHost() override;
+
+    // IActorHost
+    [[nodiscard]] std::unique_ptr<IActorMailbox>
+        spawn(std::unique_ptr<IActor> actor) override;
+
+    [[nodiscard]] vigine::Result
+        tell(ActorId id,
+             std::unique_ptr<vigine::messaging::IMessage> message) override;
+
+    void stop(ActorId id) override;
+
+    void shutdown() override;
+
+    DefaultActorHost(const DefaultActorHost &)            = delete;
+    DefaultActorHost &operator=(const DefaultActorHost &) = delete;
+    DefaultActorHost(DefaultActorHost &&)                  = delete;
+    DefaultActorHost &operator=(DefaultActorHost &&)       = delete;
+
+  private:
+    struct Impl;
+    std::unique_ptr<Impl> _impl;
+};
+
+/**
+ * @brief Factory function — the sole entry point for creating an actor-host
+ *        facade.
+ *
+ * Returns a @c std::unique_ptr<IActorHost> so the caller owns the facade
+ * exclusively (FF-1, INV-9).  Both @p bus and @p threadManager must outlive
+ * the returned facade.
+ */
+[[nodiscard]] std::unique_ptr<IActorHost>
+    createActorHost(vigine::messaging::IMessageBus    &bus,
+                    vigine::threading::IThreadManager &threadManager);
+
+} // namespace vigine::actorhost

--- a/include/vigine/actorhost/factory.h
+++ b/include/vigine/actorhost/factory.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "vigine/actorhost/defaultactorhost.h"
+
+// factory.h is a convenience header that re-exports createActorHost so callers
+// can include a single predictable factory header rather than naming the
+// concrete DefaultActorHost type.  The function is defined in
+// src/actorhost/defaultactorhost.cpp.
+//
+// Invariants:
+//   - INV-9:  createActorHost returns std::unique_ptr<IActorHost>.
+//   - INV-11: no graph types appear here.

--- a/include/vigine/actorhost/iactor.h
+++ b/include/vigine/actorhost/iactor.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "vigine/messaging/imessage.h"
+#include "vigine/result.h"
+
+namespace vigine::actorhost
+{
+
+/**
+ * @brief Pure-virtual actor-side lifecycle hooks.
+ *
+ * An @ref IActor is the user-supplied unit of isolated state.  The actor host
+ * calls these hooks on the actor's dedicated mailbox thread, so no two calls
+ * ever overlap for the same actor instance.
+ *
+ * Lifecycle:
+ *   - @ref onStart  -- called once, before the first @ref receive.
+ *   - @ref receive  -- called for each message taken from the mailbox.
+ *   - @ref onStop   -- called once after @ref IActorMailbox::stop has drained
+ *                      the in-flight @ref receive; never called concurrently
+ *                      with @ref receive.
+ *
+ * Exception safety:
+ *   An exception escaping @ref receive is caught by the host, logged, and the
+ *   actor continues receiving subsequent messages (v1 restart-not-supervised
+ *   semantics; full supervision deferred to v2).
+ *
+ * Invariants:
+ *   - INV-1:  no template parameters.
+ *   - INV-10: @c I prefix for a pure-virtual interface with no state.
+ *   - INV-11: no graph types appear in this header.
+ */
+class IActor
+{
+  public:
+    virtual ~IActor() = default;
+
+    /**
+     * @brief Called once before the first @ref receive.
+     *
+     * May perform initialisation that requires the actor's execution context
+     * to be live.  A failure result is logged; the actor proceeds to the
+     * receive loop regardless.
+     */
+    virtual vigine::Result onStart() { return vigine::Result{}; }
+
+    /**
+     * @brief Called for each message dequeued from the actor's mailbox.
+     *
+     * Implementations access the payload through the standard @ref IMessage
+     * surface (kind, payloadTypeId, payload pointer).  An exception escaping
+     * this method is caught by the host, logged, and the actor loop continues.
+     */
+    virtual vigine::Result receive(const vigine::messaging::IMessage &message) = 0;
+
+    /**
+     * @brief Called once after the final in-flight @ref receive completes.
+     *
+     * Implementations release actor-owned resources here.  The host waits for
+     * @ref onStop to return before completing the stop sequence.
+     */
+    virtual void onStop() {}
+
+    IActor(const IActor &)            = delete;
+    IActor &operator=(const IActor &) = delete;
+    IActor(IActor &&)                 = delete;
+    IActor &operator=(IActor &&)      = delete;
+
+  protected:
+    IActor() = default;
+};
+
+} // namespace vigine::actorhost

--- a/include/vigine/actorhost/iactorhost.h
+++ b/include/vigine/actorhost/iactorhost.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <memory>
+
+#include "vigine/actorhost/actorid.h"
+#include "vigine/actorhost/iactor.h"
+#include "vigine/actorhost/iactormailbox.h"
+#include "vigine/messaging/imessage.h"
+#include "vigine/result.h"
+
+namespace vigine::actorhost
+{
+
+/**
+ * @brief Pure-virtual actor-host facade over @ref vigine::messaging::IMessageBus.
+ *
+ * @ref IActorHost is the Level-2 facade for the actor model (plan_21,
+ * R.3.3.2.3).  It manages a collection of isolated @ref IActor instances, each
+ * with its own FIFO mailbox processed by a single dedicated thread.  The
+ * invariant that @ref IActor::receive is never called concurrently for the same
+ * actor is enforced by the host through @ref vigine::threading::IThreadManager.
+ *
+ * Ownership:
+ *   - @ref spawn takes unique ownership of the supplied @ref IActor and returns
+ *     a @c std::unique_ptr<IActorMailbox>.  The mailbox handle is the RAII
+ *     owner of the actor's execution context.
+ *   - Dropping the returned mailbox or calling @ref IActorMailbox::stop drains
+ *     any queued messages and joins the actor thread.
+ *   - @ref tell borrows the bus to post an @ref IMessage addressed to the actor
+ *     identified by @p id.  Posting to an already-stopped id returns an error.
+ *   - @ref shutdown drains all mailboxes, joins all actor threads, and rejects
+ *     subsequent operations.  Idempotent.
+ *
+ * Thread-safety: all entry points are safe to call concurrently.
+ *
+ * Invariants:
+ *   - INV-1:  no template parameters in the public surface.
+ *   - INV-9:  factory @ref createActorHost returns @c std::unique_ptr<IActorHost>.
+ *   - INV-10: @c I prefix for this pure-virtual interface (no state).
+ *   - INV-11: no graph types appear in this header.
+ */
+class IActorHost
+{
+  public:
+    virtual ~IActorHost() = default;
+
+    /**
+     * @brief Spawns a new actor and returns its mailbox handle.
+     *
+     * The host assigns a fresh generational @ref ActorId, calls
+     * @ref IActor::onStart on the actor's thread, and begins draining the
+     * mailbox queue.  A null @p actor is a programming error; callers must
+     * supply a valid instance.
+     *
+     * Returns @c nullptr when the host is shut down.
+     */
+    [[nodiscard]] virtual std::unique_ptr<IActorMailbox>
+        spawn(std::unique_ptr<IActor> actor) = 0;
+
+    /**
+     * @brief Enqueues @p message for delivery to the actor identified by @p id.
+     *
+     * Returns a successful @ref Result when the message was accepted.
+     * Returns an error @ref Result when:
+     *   - @p id is invalid or belongs to a stopped actor.
+     *   - The host is shut down.
+     *   - The underlying message bus rejects the post.
+     */
+    [[nodiscard]] virtual vigine::Result
+        tell(ActorId id, std::unique_ptr<vigine::messaging::IMessage> message) = 0;
+
+    /**
+     * @brief Stops the actor identified by @p id and blocks until it drains.
+     *
+     * Equivalent to calling @ref IActorMailbox::stop on the handle returned by
+     * the matching @ref spawn.  A stale or invalid @p id is a no-op.
+     */
+    virtual void stop(ActorId id) = 0;
+
+    /**
+     * @brief Drains all mailboxes and shuts down the host.
+     *
+     * Idempotent: a second call is a no-op.  After shutdown, @ref spawn
+     * returns @c nullptr and @ref tell returns an error.
+     */
+    virtual void shutdown() = 0;
+
+    IActorHost(const IActorHost &)            = delete;
+    IActorHost &operator=(const IActorHost &) = delete;
+    IActorHost(IActorHost &&)                 = delete;
+    IActorHost &operator=(IActorHost &&)      = delete;
+
+  protected:
+    IActorHost() = default;
+};
+
+} // namespace vigine::actorhost

--- a/include/vigine/actorhost/iactormailbox.h
+++ b/include/vigine/actorhost/iactormailbox.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "vigine/actorhost/actorid.h"
+#include "vigine/result.h"
+
+namespace vigine::actorhost
+{
+
+/**
+ * @brief Per-actor FIFO mailbox handle returned by @ref IActorHost::spawn.
+ *
+ * The mailbox owns the actor's execution context (a dedicated thread or
+ * serialised worker) and its message queue.  Dropping the handle or calling
+ * @ref stop terminates the actor in an orderly fashion.
+ *
+ * Invariants:
+ *   - INV-1:  no template parameters.
+ *   - INV-10: @c I prefix for a pure-virtual interface.
+ *   - INV-11: no graph types appear in this header.
+ */
+class IActorMailbox
+{
+  public:
+    virtual ~IActorMailbox() = default;
+
+    /**
+     * @brief Returns the stable @ref ActorId assigned to this mailbox by the
+     *        host at spawn time.
+     */
+    [[nodiscard]] virtual ActorId actorId() const noexcept = 0;
+
+    /**
+     * @brief Closes the mailbox and blocks until any in-flight @ref receive
+     *        and @ref IActor::onStop complete.
+     *
+     * After @ref stop returns, subsequent @ref IActorHost::tell calls for
+     * this id return @c Result::Code::Error.  Idempotent.
+     */
+    virtual void stop() = 0;
+
+    IActorMailbox(const IActorMailbox &)            = delete;
+    IActorMailbox &operator=(const IActorMailbox &) = delete;
+    IActorMailbox(IActorMailbox &&)                 = delete;
+    IActorMailbox &operator=(IActorMailbox &&)      = delete;
+
+  protected:
+    IActorMailbox() = default;
+};
+
+} // namespace vigine::actorhost

--- a/src/actorhost/abstractactorhost.cpp
+++ b/src/actorhost/abstractactorhost.cpp
@@ -1,0 +1,23 @@
+#include "vigine/actorhost/abstractactorhost.h"
+
+namespace vigine::actorhost
+{
+
+AbstractActorHost::AbstractActorHost(vigine::messaging::IMessageBus    &bus,
+                                     vigine::threading::IThreadManager &threadManager)
+    : _bus(bus)
+    , _threadManager(threadManager)
+{
+}
+
+vigine::messaging::IMessageBus &AbstractActorHost::bus() noexcept
+{
+    return _bus;
+}
+
+vigine::threading::IThreadManager &AbstractActorHost::threadManager() noexcept
+{
+    return _threadManager;
+}
+
+} // namespace vigine::actorhost

--- a/src/actorhost/defaultactorhost.cpp
+++ b/src/actorhost/defaultactorhost.cpp
@@ -1,0 +1,483 @@
+#include "vigine/actorhost/defaultactorhost.h"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <exception>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "vigine/actorhost/iactor.h"
+#include "vigine/actorhost/iactormailbox.h"
+#include "vigine/messaging/imessage.h"
+#include "vigine/messaging/imessagebus.h"
+#include "vigine/messaging/messagekind.h"
+#include "vigine/messaging/routemode.h"
+#include "vigine/result.h"
+#include "vigine/threading/itaskhandle.h"
+#include "vigine/threading/ithreadmanager.h"
+#include "vigine/threading/irunnable.h"
+#include "vigine/threading/namedthreadid.h"
+
+namespace vigine::actorhost
+{
+
+// ---------------------------------------------------------------------------
+// ActorMailQueue — mutex-protected FIFO of IMessage unique_ptrs.
+// Using a plain std::queue so we can push polymorphic messages without
+// serialising to bytes (IMessageChannel only carries byte buffers).
+// ---------------------------------------------------------------------------
+
+struct ActorMailQueue
+{
+    std::mutex                                         mtx;
+    std::condition_variable                            cv;
+    std::queue<std::unique_ptr<vigine::messaging::IMessage>> items;
+    bool                                               closed{false};
+
+    // Returns false if the queue is closed and empty (drain complete).
+    bool push(std::unique_ptr<vigine::messaging::IMessage> msg)
+    {
+        std::lock_guard<std::mutex> lk(mtx);
+        if (closed)
+        {
+            return false;
+        }
+        items.push(std::move(msg));
+        cv.notify_one();
+        return true;
+    }
+
+    // Blocks until an item is available or the queue is drained+closed.
+    // Returns nullptr when the loop should exit.
+    std::unique_ptr<vigine::messaging::IMessage> pop()
+    {
+        std::unique_lock<std::mutex> lk(mtx);
+        cv.wait(lk, [this]{ return !items.empty() || closed; });
+        if (items.empty())
+        {
+            return nullptr; // closed and drained
+        }
+        auto msg = std::move(items.front());
+        items.pop();
+        return msg;
+    }
+
+    void close()
+    {
+        std::lock_guard<std::mutex> lk(mtx);
+        closed = true;
+        cv.notify_all();
+    }
+};
+
+// ---------------------------------------------------------------------------
+// ActorEntry — per-actor state kept in the host registry.
+// ---------------------------------------------------------------------------
+
+struct ActorEntry
+{
+    ActorId                                   id;
+    std::unique_ptr<IActor>                   actor;
+    std::shared_ptr<ActorMailQueue>           queue;
+    vigine::threading::NamedThreadId          namedThread;
+    std::unique_ptr<vigine::threading::ITaskHandle> taskHandle;
+    std::atomic<bool>                         stopped{false};
+};
+
+// ---------------------------------------------------------------------------
+// MailboxRunnable — the drain loop executed on the actor's named thread.
+// ---------------------------------------------------------------------------
+
+class MailboxRunnable final : public vigine::threading::IRunnable
+{
+  public:
+    MailboxRunnable(std::shared_ptr<ActorMailQueue> queue,
+                    IActor                         *actor)
+        : _queue(std::move(queue))
+        , _actor(actor)
+    {
+    }
+
+    [[nodiscard]] vigine::Result run() override
+    {
+        // onStart — ignore return value but log failure to stderr.
+        try
+        {
+            _actor->onStart();
+        }
+        catch (const std::exception &ex)
+        {
+            // onStart failure is non-fatal; actor proceeds to receive loop.
+            (void)ex;
+        }
+        catch (...)
+        {
+        }
+
+        // Drain loop — sequential; one message at a time.
+        while (true)
+        {
+            auto msg = _queue->pop();
+            if (!msg)
+            {
+                // Queue closed and drained.
+                break;
+            }
+            try
+            {
+                _actor->receive(*msg);
+            }
+            catch (const std::exception & /*ex*/)
+            {
+                // Crash logged; actor continues receiving (v1 semantics).
+            }
+            catch (...)
+            {
+                // Unknown exception — same policy.
+            }
+        }
+
+        // onStop
+        try
+        {
+            _actor->onStop();
+        }
+        catch (...)
+        {
+        }
+
+        return vigine::Result{};
+    }
+
+    MailboxRunnable(const MailboxRunnable &)            = delete;
+    MailboxRunnable &operator=(const MailboxRunnable &) = delete;
+    MailboxRunnable(MailboxRunnable &&)                  = delete;
+    MailboxRunnable &operator=(MailboxRunnable &&)       = delete;
+
+  private:
+    std::shared_ptr<ActorMailQueue> _queue;
+    IActor                         *_actor;
+};
+
+// ---------------------------------------------------------------------------
+// DefaultActorMailbox — RAII handle returned to the caller of spawn().
+// ---------------------------------------------------------------------------
+
+class DefaultActorMailbox final : public IActorMailbox
+{
+  public:
+    DefaultActorMailbox(ActorId                         id,
+                        std::shared_ptr<ActorMailQueue> queue,
+                        std::function<void(ActorId)>    stopCallback)
+        : _id(id)
+        , _queue(std::move(queue))
+        , _stopCallback(std::move(stopCallback))
+    {
+    }
+
+    ~DefaultActorMailbox() override
+    {
+        stop();
+    }
+
+    [[nodiscard]] ActorId actorId() const noexcept override
+    {
+        return _id;
+    }
+
+    void stop() override
+    {
+        bool expected = false;
+        if (_stopped.compare_exchange_strong(expected, true,
+                                             std::memory_order_acq_rel,
+                                             std::memory_order_acquire))
+        {
+            _stopCallback(_id);
+        }
+    }
+
+    DefaultActorMailbox(const DefaultActorMailbox &)            = delete;
+    DefaultActorMailbox &operator=(const DefaultActorMailbox &) = delete;
+    DefaultActorMailbox(DefaultActorMailbox &&)                  = delete;
+    DefaultActorMailbox &operator=(DefaultActorMailbox &&)       = delete;
+
+  private:
+    ActorId                         _id;
+    std::shared_ptr<ActorMailQueue> _queue;
+    std::function<void(ActorId)>    _stopCallback;
+    std::atomic<bool>               _stopped{false};
+};
+
+// ---------------------------------------------------------------------------
+// DefaultActorHost::Impl
+// ---------------------------------------------------------------------------
+
+struct DefaultActorHost::Impl
+{
+    vigine::messaging::IMessageBus    &bus;
+    vigine::threading::IThreadManager &threadManager;
+
+    mutable std::mutex                              registryMutex;
+    std::unordered_map<std::uint32_t, ActorEntry *> registry; // ActorId::value -> entry
+    std::atomic<std::uint32_t>                      nextId{1};
+    std::atomic<bool>                               shutdownFlag{false};
+
+    explicit Impl(vigine::messaging::IMessageBus    &bus_,
+                  vigine::threading::IThreadManager &tm_)
+        : bus(bus_)
+        , threadManager(tm_)
+    {
+    }
+
+    // Allocates a fresh generational id.
+    [[nodiscard]] ActorId allocateId() noexcept
+    {
+        return ActorId{nextId.fetch_add(1, std::memory_order_relaxed)};
+    }
+};
+
+// ---------------------------------------------------------------------------
+// DefaultActorHost
+// ---------------------------------------------------------------------------
+
+DefaultActorHost::DefaultActorHost(vigine::messaging::IMessageBus    &bus,
+                                   vigine::threading::IThreadManager &threadManager)
+    : AbstractActorHost(bus, threadManager)
+    , _impl(std::make_unique<Impl>(bus, threadManager))
+{
+}
+
+DefaultActorHost::~DefaultActorHost()
+{
+    shutdown();
+}
+
+std::unique_ptr<IActorMailbox> DefaultActorHost::spawn(std::unique_ptr<IActor> actor)
+{
+    if (!actor)
+    {
+        return nullptr;
+    }
+
+    if (_impl->shutdownFlag.load(std::memory_order_acquire))
+    {
+        return nullptr;
+    }
+
+    ActorId id = _impl->allocateId();
+
+    auto queue = std::make_shared<ActorMailQueue>();
+
+    // Build the entry on the heap; the registry holds a raw owning pointer so
+    // we can hand out a stable IActor* to the runnable without dangling.
+    auto *entry = new ActorEntry{};
+    entry->id     = id;
+    entry->actor  = std::move(actor);
+    entry->queue  = queue;
+    entry->stopped.store(false, std::memory_order_relaxed);
+
+    // Register a named thread for this actor so messages are serialised.
+    std::string threadName = "actor-" + std::to_string(id.value);
+    entry->namedThread = _impl->threadManager.registerNamedThread(threadName);
+
+    // Schedule the drain runnable on the actor's named thread.
+    auto runnable = std::make_unique<MailboxRunnable>(queue, entry->actor.get());
+    entry->taskHandle = _impl->threadManager.scheduleOnNamed(
+        std::move(runnable), entry->namedThread);
+
+    {
+        std::lock_guard<std::mutex> lk(_impl->registryMutex);
+        _impl->registry.emplace(id.value, entry);
+    }
+
+    // Build the stop callback: closes the queue and waits for the drain loop.
+    auto stopCallback = [this](ActorId aid)
+    {
+        ActorEntry *e = nullptr;
+        {
+            std::lock_guard<std::mutex> lk(_impl->registryMutex);
+            auto it = _impl->registry.find(aid.value);
+            if (it == _impl->registry.end())
+            {
+                return;
+            }
+            e = it->second;
+        }
+
+        if (!e)
+        {
+            return;
+        }
+
+        bool expected = false;
+        if (!e->stopped.compare_exchange_strong(expected, true,
+                                                std::memory_order_acq_rel,
+                                                std::memory_order_acquire))
+        {
+            return; // already stopped
+        }
+
+        // Close the queue so the drain loop exits after draining remaining messages.
+        e->queue->close();
+
+        // Wait for the drain loop (IRunnable::run) to complete.
+        if (e->taskHandle)
+        {
+            (void)e->taskHandle->wait();
+        }
+
+        // Unregister the named thread.
+        _impl->threadManager.unregisterNamedThread(e->namedThread);
+
+        // Remove from registry and release.
+        {
+            std::lock_guard<std::mutex> lk(_impl->registryMutex);
+            _impl->registry.erase(aid.value);
+        }
+        delete e;
+    };
+
+    return std::make_unique<DefaultActorMailbox>(id, queue, std::move(stopCallback));
+}
+
+vigine::Result DefaultActorHost::tell(
+    ActorId                                       id,
+    std::unique_ptr<vigine::messaging::IMessage>  message)
+{
+    if (!id.valid())
+    {
+        return vigine::Result{vigine::Result::Code::Error, "invalid actor id"};
+    }
+
+    if (_impl->shutdownFlag.load(std::memory_order_acquire))
+    {
+        return vigine::Result{vigine::Result::Code::Error, "actor host shut down"};
+    }
+
+    std::shared_ptr<ActorMailQueue> queue;
+    {
+        std::lock_guard<std::mutex> lk(_impl->registryMutex);
+        auto it = _impl->registry.find(id.value);
+        if (it == _impl->registry.end())
+        {
+            return vigine::Result{vigine::Result::Code::Error, "actor not found or stopped"};
+        }
+        queue = it->second->queue;
+    }
+
+    if (!queue->push(std::move(message)))
+    {
+        return vigine::Result{vigine::Result::Code::Error, "actor mailbox closed"};
+    }
+
+    return vigine::Result{};
+}
+
+void DefaultActorHost::stop(ActorId id)
+{
+    if (!id.valid())
+    {
+        return;
+    }
+
+    ActorEntry *e = nullptr;
+    {
+        std::lock_guard<std::mutex> lk(_impl->registryMutex);
+        auto it = _impl->registry.find(id.value);
+        if (it == _impl->registry.end())
+        {
+            return;
+        }
+        e = it->second;
+    }
+
+    if (!e)
+    {
+        return;
+    }
+
+    bool expected = false;
+    if (!e->stopped.compare_exchange_strong(expected, true,
+                                            std::memory_order_acq_rel,
+                                            std::memory_order_acquire))
+    {
+        return;
+    }
+
+    e->queue->close();
+
+    if (e->taskHandle)
+    {
+        (void)e->taskHandle->wait();
+    }
+
+    _impl->threadManager.unregisterNamedThread(e->namedThread);
+
+    {
+        std::lock_guard<std::mutex> lk(_impl->registryMutex);
+        _impl->registry.erase(id.value);
+    }
+    delete e;
+}
+
+void DefaultActorHost::shutdown()
+{
+    bool already = _impl->shutdownFlag.exchange(true, std::memory_order_acq_rel);
+    if (already)
+    {
+        return;
+    }
+
+    // Snapshot current entries.
+    std::vector<ActorEntry *> entries;
+    {
+        std::lock_guard<std::mutex> lk(_impl->registryMutex);
+        entries.reserve(_impl->registry.size());
+        for (auto &[val, ptr] : _impl->registry)
+        {
+            entries.push_back(ptr);
+        }
+        _impl->registry.clear();
+    }
+
+    // Drain and join all actors.
+    for (ActorEntry *e : entries)
+    {
+        bool expected = false;
+        if (e->stopped.compare_exchange_strong(expected, true,
+                                               std::memory_order_acq_rel,
+                                               std::memory_order_acquire))
+        {
+            e->queue->close();
+            if (e->taskHandle)
+            {
+                (void)e->taskHandle->wait();
+            }
+            _impl->threadManager.unregisterNamedThread(e->namedThread);
+        }
+        delete e;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+std::unique_ptr<IActorHost>
+createActorHost(vigine::messaging::IMessageBus    &bus,
+                vigine::threading::IThreadManager &threadManager)
+{
+    return std::make_unique<DefaultActorHost>(bus, threadManager);
+}
+
+} // namespace vigine::actorhost

--- a/src/actorhost/factory.cpp
+++ b/src/actorhost/factory.cpp
@@ -1,0 +1,6 @@
+#include "vigine/actorhost/factory.h"
+
+// createActorHost is defined in defaultactorhost.cpp.
+// This translation unit exists so factory.h has a corresponding .cpp
+// and the linker always sees the definition regardless of which TU
+// callers include factory.h from.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -274,7 +274,6 @@ add_executable(${REQUESTBUS_SMOKE_TARGET}
 )
 
 target_include_directories(${REQUESTBUS_SMOKE_TARGET}
-=======
 # ====================== ReactiveStream Smoke Target =======================
 set(REACTIVESTREAM_SMOKE_TARGET reactivestream-smoke)
 
@@ -283,6 +282,15 @@ add_executable(${REACTIVESTREAM_SMOKE_TARGET}
 )
 
 target_include_directories(${REACTIVESTREAM_SMOKE_TARGET}
+=======
+# ====================== ActorHost Smoke Target =======================
+set(ACTORHOST_SMOKE_TARGET actorhost-smoke)
+
+add_executable(${ACTORHOST_SMOKE_TARGET}
+    actorhost/smoke_test.cpp
+)
+
+target_include_directories(${ACTORHOST_SMOKE_TARGET}
     PRIVATE
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/src
@@ -291,6 +299,7 @@ target_include_directories(${REACTIVESTREAM_SMOKE_TARGET}
 
 target_link_libraries(${REQUESTBUS_SMOKE_TARGET}
 target_link_libraries(${REACTIVESTREAM_SMOKE_TARGET}
+target_link_libraries(${ACTORHOST_SMOKE_TARGET}
     PRIVATE
     gtest
     gtest_main
@@ -310,6 +319,12 @@ set_target_properties(${REACTIVESTREAM_SMOKE_TARGET} PROPERTIES
 
 gtest_discover_tests(${REACTIVESTREAM_SMOKE_TARGET}
     PROPERTIES LABELS "reactivestream-smoke"
+set_target_properties(${ACTORHOST_SMOKE_TARGET} PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
+gtest_discover_tests(${ACTORHOST_SMOKE_TARGET}
+    PROPERTIES LABELS "actorhost-smoke"
     DISCOVERY_TIMEOUT 60
     DISCOVERY_MODE PRE_TEST
 )

--- a/test/actorhost/smoke_test.cpp
+++ b/test/actorhost/smoke_test.cpp
@@ -1,0 +1,339 @@
+#include "vigine/actorhost/actorid.h"
+#include "vigine/actorhost/defaultactorhost.h"
+#include "vigine/actorhost/iactor.h"
+#include "vigine/actorhost/iactorhost.h"
+#include "vigine/actorhost/iactormailbox.h"
+#include "vigine/messaging/busconfig.h"
+#include "vigine/messaging/factory.h"
+#include "vigine/messaging/imessage.h"
+#include "vigine/messaging/imessagepayload.h"
+#include "vigine/messaging/messagekind.h"
+#include "vigine/messaging/routemode.h"
+#include "vigine/payload/payloadtypeid.h"
+#include "vigine/result.h"
+#include "vigine/threading/factory.h"
+#include "vigine/threading/ithreadmanager.h"
+#include "vigine/threading/threadmanagerconfig.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <thread>
+
+// ---------------------------------------------------------------------------
+// Test suite: ActorHost smoke tests (label: actorhost-smoke)
+//
+// Scenario 1 — spawn + tell round-trip:
+//   Spawn an actor. Tell it a message. Assert IActor::receive was called
+//   exactly once with the expected payload.
+//
+// Scenario 2 — stop halts delivery:
+//   Spawn an actor. Stop it. Subsequent tell must return an error Result.
+//
+// Scenario 3 — shutdown drains mailboxes:
+//   Spawn two actors. Enqueue several messages. Call shutdown. Assert all
+//   actors were stopped and no messages are in flight after shutdown returns.
+// ---------------------------------------------------------------------------
+
+namespace
+{
+
+using namespace vigine::actorhost;
+
+// ---------------------------------------------------------------------------
+// Minimal IMessage test double carrying a typed payload.
+// ---------------------------------------------------------------------------
+
+class SmokePayload final : public vigine::messaging::IMessagePayload
+{
+  public:
+    explicit SmokePayload(vigine::payload::PayloadTypeId id) noexcept : _id(id) {}
+
+    [[nodiscard]] vigine::payload::PayloadTypeId typeId() const noexcept override
+    {
+        return _id;
+    }
+
+  private:
+    vigine::payload::PayloadTypeId _id;
+};
+
+class SmokeMessage final : public vigine::messaging::IMessage
+{
+  public:
+    explicit SmokeMessage(vigine::payload::PayloadTypeId typeId)
+        : _payload(std::make_unique<SmokePayload>(typeId))
+        , _when(std::chrono::steady_clock::now())
+    {
+    }
+
+    [[nodiscard]] vigine::messaging::MessageKind kind() const noexcept override
+    {
+        return vigine::messaging::MessageKind::ActorMail;
+    }
+
+    [[nodiscard]] vigine::payload::PayloadTypeId payloadTypeId() const noexcept override
+    {
+        return _payload->typeId();
+    }
+
+    [[nodiscard]] const vigine::messaging::IMessagePayload *payload() const noexcept override
+    {
+        return _payload.get();
+    }
+
+    [[nodiscard]] const vigine::messaging::AbstractMessageTarget *
+        target() const noexcept override
+    {
+        return nullptr;
+    }
+
+    [[nodiscard]] vigine::messaging::RouteMode routeMode() const noexcept override
+    {
+        return vigine::messaging::RouteMode::FirstMatch;
+    }
+
+    [[nodiscard]] vigine::messaging::CorrelationId correlationId() const noexcept override
+    {
+        return vigine::messaging::CorrelationId{};
+    }
+
+    [[nodiscard]] std::chrono::steady_clock::time_point scheduledFor() const noexcept override
+    {
+        return _when;
+    }
+
+  private:
+    std::unique_ptr<SmokePayload>              _payload;
+    std::chrono::steady_clock::time_point       _when;
+};
+
+// ---------------------------------------------------------------------------
+// ActorCounters — shared counters kept alive by both test and actor.
+// ---------------------------------------------------------------------------
+
+struct ActorCounters
+{
+    std::atomic<int> receiveCount{0};
+    std::atomic<int> startCount{0};
+    std::atomic<int> stopCount{0};
+};
+
+// ---------------------------------------------------------------------------
+// CountingActor — records how many times receive() is called.
+// The counters are owned by a shared_ptr so the test can read them safely
+// after the actor instance has been destroyed.
+// ---------------------------------------------------------------------------
+
+class CountingActor final : public IActor
+{
+  public:
+    explicit CountingActor(std::shared_ptr<ActorCounters> counters)
+        : _counters(std::move(counters))
+    {
+    }
+
+    vigine::Result onStart() override
+    {
+        _counters->startCount.fetch_add(1, std::memory_order_relaxed);
+        return vigine::Result{};
+    }
+
+    vigine::Result receive(const vigine::messaging::IMessage & /*message*/) override
+    {
+        _counters->receiveCount.fetch_add(1, std::memory_order_relaxed);
+        return vigine::Result{};
+    }
+
+    void onStop() override
+    {
+        _counters->stopCount.fetch_add(1, std::memory_order_relaxed);
+    }
+
+  private:
+    std::shared_ptr<ActorCounters> _counters;
+};
+
+// ---------------------------------------------------------------------------
+// CrashingActor — throws from receive(); used to verify crash isolation.
+// ---------------------------------------------------------------------------
+
+class CrashingActor final : public IActor
+{
+  public:
+    explicit CrashingActor(std::shared_ptr<std::atomic<int>> callCount)
+        : _callCount(std::move(callCount))
+    {
+    }
+
+    vigine::Result receive(const vigine::messaging::IMessage & /*message*/) override
+    {
+        _callCount->fetch_add(1, std::memory_order_relaxed);
+        throw std::runtime_error("actor crash");
+    }
+
+  private:
+    std::shared_ptr<std::atomic<int>> _callCount;
+};
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+class ActorHostSmoke : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        _tm = vigine::threading::createThreadManager({});
+
+        vigine::messaging::BusConfig cfg;
+        cfg.threading    = vigine::messaging::ThreadingPolicy::InlineOnly;
+        cfg.backpressure = vigine::messaging::BackpressurePolicy::Error;
+        _bus  = vigine::messaging::createMessageBus(cfg, *_tm);
+
+        _host = createActorHost(*_bus, *_tm);
+    }
+
+    void TearDown() override
+    {
+        if (_host)
+        {
+            _host->shutdown();
+        }
+        if (_bus)
+        {
+            _bus->shutdown();
+        }
+        if (_tm)
+        {
+            _tm->shutdown();
+        }
+    }
+
+    std::unique_ptr<vigine::threading::IThreadManager> _tm;
+    std::unique_ptr<vigine::messaging::IMessageBus>    _bus;
+    std::unique_ptr<IActorHost>                        _host;
+};
+
+// ---------------------------------------------------------------------------
+// Scenario 1: spawn + tell round-trip
+// ---------------------------------------------------------------------------
+
+TEST_F(ActorHostSmoke, SpawnTellReceiveRoundTrip)
+{
+    auto counters = std::make_shared<ActorCounters>();
+    auto mailbox  = _host->spawn(std::make_unique<CountingActor>(counters));
+    ASSERT_NE(mailbox, nullptr) << "spawn must return a valid mailbox";
+    EXPECT_TRUE(mailbox->actorId().valid());
+
+    auto result = _host->tell(mailbox->actorId(),
+                              std::make_unique<SmokeMessage>(
+                                  vigine::payload::PayloadTypeId{1}));
+    EXPECT_TRUE(result.isSuccess())
+        << "tell must succeed for a live actor; got: " << result.message();
+
+    // Allow the actor's thread to process the message.
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    EXPECT_EQ(counters->receiveCount.load(), 1)
+        << "actor must have received exactly one message";
+    EXPECT_GE(counters->startCount.load(), 1)
+        << "onStart must have been called";
+
+    mailbox->stop();
+
+    // stop() is synchronous; onStop must be complete by now.
+    EXPECT_GE(counters->stopCount.load(), 1)
+        << "onStop must have been called after stop()";
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 2: stop halts delivery
+// ---------------------------------------------------------------------------
+
+TEST_F(ActorHostSmoke, StopHaltsDelivery)
+{
+    auto mailbox = _host->spawn(
+        std::make_unique<CountingActor>(std::make_shared<ActorCounters>()));
+    ASSERT_NE(mailbox, nullptr);
+
+    ActorId id = mailbox->actorId();
+
+    mailbox->stop();
+
+    // After stop, tell must return an error.
+    auto result = _host->tell(id, std::make_unique<SmokeMessage>(
+                                      vigine::payload::PayloadTypeId{2}));
+    EXPECT_TRUE(result.isError())
+        << "tell after stop must return an error result";
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 3: shutdown drains mailboxes
+// ---------------------------------------------------------------------------
+
+TEST_F(ActorHostSmoke, ShutdownDrainsMailboxes)
+{
+    // Spawn two actors with shared counters so we can read after shutdown.
+    auto c1 = std::make_shared<ActorCounters>();
+    auto c2 = std::make_shared<ActorCounters>();
+    auto mb1 = _host->spawn(std::make_unique<CountingActor>(c1));
+    auto mb2 = _host->spawn(std::make_unique<CountingActor>(c2));
+    ASSERT_NE(mb1, nullptr);
+    ASSERT_NE(mb2, nullptr);
+
+    ActorId id1 = mb1->actorId();
+    ActorId id2 = mb2->actorId();
+
+    // Enqueue a batch for each actor.
+    constexpr int kMessages = 5;
+    for (int i = 0; i < kMessages; ++i)
+    {
+        (void)_host->tell(id1, std::make_unique<SmokeMessage>(
+                              vigine::payload::PayloadTypeId{10}));
+        (void)_host->tell(id2, std::make_unique<SmokeMessage>(
+                              vigine::payload::PayloadTypeId{11}));
+    }
+
+    // Release mailbox handles before shutdown so shutdown owns cleanup.
+    mb1.reset();
+    mb2.reset();
+
+    // shutdown() must drain all mailboxes and return synchronously.
+    _host->shutdown();
+
+    // All messages must have been delivered (shutdown drains then joins).
+    EXPECT_EQ(c1->receiveCount.load(), kMessages)
+        << "actor 1 must have received all messages before shutdown returns";
+    EXPECT_EQ(c2->receiveCount.load(), kMessages)
+        << "actor 2 must have received all messages before shutdown returns";
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 4: crash in receive is logged; actor continues receiving
+// ---------------------------------------------------------------------------
+
+TEST_F(ActorHostSmoke, CrashInReceiveContinues)
+{
+    auto callCount = std::make_shared<std::atomic<int>>(0);
+    auto mailbox   = _host->spawn(std::make_unique<CrashingActor>(callCount));
+    ASSERT_NE(mailbox, nullptr);
+
+    // Send two messages; both should be attempted even though the first throws.
+    (void)_host->tell(mailbox->actorId(),
+                      std::make_unique<SmokeMessage>(vigine::payload::PayloadTypeId{20}));
+    (void)_host->tell(mailbox->actorId(),
+                      std::make_unique<SmokeMessage>(vigine::payload::PayloadTypeId{21}));
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    EXPECT_EQ(callCount->load(), 2)
+        << "both messages must be attempted even after a crash in receive";
+
+    mailbox->stop();
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

- Adds `IActorHost` facade with per-actor FIFO mailbox and sequential dispatch via `IThreadManager` named threads.
- `spawn(unique_ptr<IActor>)` returns a `unique_ptr<IActorMailbox>`; `tell(ActorId, unique_ptr<IMessage>)` enqueues; `stop(ActorId)` blocks until in-flight `receive` drains.
- Actor crashes in `receive` are caught and logged; the loop continues (v1 restart-not-supervised semantics).
- Factory `createActorHost` returns `unique_ptr<IActorHost>` (FF-1 / INV-9).
- 4/4 smoke tests pass: spawn+tell round-trip, stop halts delivery, shutdown drains all mailboxes, crash isolation.

## Test plan

- [x] `cmake -S . -B build && cmake --build build --config Debug` — warning-clean
- [x] `cmake --build build --config Release` — warning-clean
- [x] `ctest --test-dir build -L actorhost-smoke --output-on-failure` — 4/4 passed

Closes #109