### PR TITLE
feat(pipeline): IPipelineBuilder composable-stage facade over IMessageBus

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -529,6 +529,21 @@ set(SOURCES_ACTORHOST
     ${SRC_DIR}/actorhost/abstractactorhost.cpp
     ${SRC_DIR}/actorhost/defaultactorhost.cpp
     ${SRC_DIR}/actorhost/factory.cpp
+# Pipeline-builder facade (R.3.3.2.4 / plan_22) -- public surface.
+set(HEADER_PIPELINEBUILDER
+    ${INCLUDE_DIR}/vigine/pipelinebuilder/ipipelinestage.h
+    ${INCLUDE_DIR}/vigine/pipelinebuilder/ipipeline.h
+    ${INCLUDE_DIR}/vigine/pipelinebuilder/ipipelinebuilder.h
+    ${INCLUDE_DIR}/vigine/pipelinebuilder/abstractpipelinebuilder.h
+    ${INCLUDE_DIR}/vigine/pipelinebuilder/defaultpipelinebuilder.h
+    ${INCLUDE_DIR}/vigine/pipelinebuilder/factory.h
+)
+
+# Pipeline-builder facade (R.3.3.2.4 / plan_22) -- internal concrete + factory.
+set(SOURCES_PIPELINEBUILDER
+    ${SRC_DIR}/pipelinebuilder/abstractpipelinebuilder.cpp
+    ${SRC_DIR}/pipelinebuilder/defaultpipelinebuilder.cpp
+    ${SRC_DIR}/pipelinebuilder/factory.cpp
 )
 
 # Add source files
@@ -629,6 +644,8 @@ add_library(${PROJECT_NAME}
     ${SOURCES_REACTIVESTREAM}
     ${HEADER_ACTORHOST}
     ${SOURCES_ACTORHOST}
+    ${HEADER_PIPELINEBUILDER}
+    ${SOURCES_PIPELINEBUILDER}
     ${HEADER_POSTGRESQL}
     ${SOURCES_POSTGRESQL}
     ${SOURCES_POSTGRESQL_EXTRA}

--- a/include/vigine/pipelinebuilder/abstractpipelinebuilder.h
+++ b/include/vigine/pipelinebuilder/abstractpipelinebuilder.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include "vigine/channelfactory/ichannelfactory.h"
+#include "vigine/messaging/imessagebus.h"
+#include "vigine/pipelinebuilder/ipipelinebuilder.h"
+#include "vigine/threading/ithreadmanager.h"
+
+namespace vigine::pipelinebuilder
+{
+
+/**
+ * @brief Stateful abstract base for the pipeline-builder facade.
+ *
+ * @ref AbstractPipelineBuilder is Level-4 of the five-layer wrapper
+ * recipe.  It inherits @ref IPipelineBuilder @c public so the builder
+ * surface sits at offset zero for zero-cost up-casts, and holds
+ * references to the underlying @ref vigine::messaging::IMessageBus,
+ * @ref vigine::threading::IThreadManager, and
+ * @ref vigine::channelfactory::IChannelFactory @c protected so subclass
+ * wiring can reach them without exposing the raw surfaces in the public
+ * builder API.
+ *
+ * The class carries state (three references), so it follows the project's
+ * @c Abstract naming convention rather than the @c I pure-virtual prefix.
+ *
+ * Concrete subclasses (e.g. @ref DefaultPipelineBuilder) close the
+ * chain by providing the stage vector, the drain-channel lifecycle, and
+ * the full @ref IPipelineBuilder implementation.  Callers never name
+ * those types directly.
+ *
+ * Invariants:
+ *   - INV-10: @c Abstract prefix for an abstract class with state.
+ *   - INV-11: no graph types leak through this header.
+ *   - Inheritance order: @c public @ref IPipelineBuilder FIRST (mandatory
+ *     per 5-layer recipe so the facade surface sits at offset zero).
+ *   - All data members are @c private (strict encapsulation).
+ */
+class AbstractPipelineBuilder : public IPipelineBuilder
+{
+  public:
+    ~AbstractPipelineBuilder() override = default;
+
+    AbstractPipelineBuilder(const AbstractPipelineBuilder &)            = delete;
+    AbstractPipelineBuilder &operator=(const AbstractPipelineBuilder &) = delete;
+    AbstractPipelineBuilder(AbstractPipelineBuilder &&)                 = delete;
+    AbstractPipelineBuilder &operator=(AbstractPipelineBuilder &&)      = delete;
+
+  protected:
+    /**
+     * @brief Constructs the abstract base holding references to @p bus,
+     *        @p threadManager, and @p channelFactory.
+     *
+     * The caller (factory or test harness) guarantees all three
+     * references outlive this facade instance.
+     */
+    AbstractPipelineBuilder(vigine::messaging::IMessageBus       &bus,
+                            vigine::threading::IThreadManager    &threadManager,
+                            vigine::channelfactory::IChannelFactory &channelFactory);
+
+    /**
+     * @brief Returns the underlying bus reference for subclass wiring.
+     */
+    [[nodiscard]] vigine::messaging::IMessageBus &bus() noexcept;
+
+    /**
+     * @brief Returns the thread manager reference for subclass wiring.
+     */
+    [[nodiscard]] vigine::threading::IThreadManager &threadManager() noexcept;
+
+    /**
+     * @brief Returns the channel factory reference for subclass wiring.
+     */
+    [[nodiscard]] vigine::channelfactory::IChannelFactory &channelFactory() noexcept;
+
+  private:
+    vigine::messaging::IMessageBus       &_bus;
+    vigine::threading::IThreadManager    &_threadManager;
+    vigine::channelfactory::IChannelFactory &_channelFactory;
+};
+
+} // namespace vigine::pipelinebuilder

--- a/include/vigine/pipelinebuilder/defaultpipelinebuilder.h
+++ b/include/vigine/pipelinebuilder/defaultpipelinebuilder.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <memory>
+
+#include "vigine/pipelinebuilder/abstractpipelinebuilder.h"
+
+namespace vigine::pipelinebuilder
+{
+
+/**
+ * @brief Concrete final pipeline-builder facade.
+ *
+ * @ref DefaultPipelineBuilder is Level-5 of the five-layer wrapper
+ * recipe.  It provides the full @ref IPipelineBuilder implementation on
+ * top of @ref AbstractPipelineBuilder:
+ *
+ *   - A stage list accumulated by successive @ref addStage calls.
+ *   - A single-call @ref build that wraps the stage list into a
+ *     @ref DefaultPipeline, allocates a bounded drain channel via the
+ *     injected @ref IChannelFactory, and returns the pipeline handle.
+ *   - Guard logic that rejects @ref addStage and @ref build calls after
+ *     the first successful @ref build.
+ *
+ * Callers obtain instances exclusively through @ref createPipelineBuilder.
+ *
+ * Thread-safety: @ref addStage and @ref build are NOT thread-safe with
+ * respect to each other (builder use is typically single-threaded before
+ * calling @ref build).  The produced @ref IPipeline's @ref IPipeline::feed
+ * and @ref IPipeline::drain are thread-safe.
+ *
+ * Invariants:
+ *   - @c final: no further subclassing allowed.
+ *   - INV-9:  @ref build returns @c std::unique_ptr<IPipeline>.
+ *   - INV-11: no graph types leak into this header.
+ */
+class DefaultPipelineBuilder final : public AbstractPipelineBuilder
+{
+  public:
+    /**
+     * @brief Constructs the builder over @p bus, @p threadManager, and
+     *        @p channelFactory.
+     *
+     * All three references must outlive this builder instance.
+     */
+    DefaultPipelineBuilder(vigine::messaging::IMessageBus       &bus,
+                           vigine::threading::IThreadManager    &threadManager,
+                           vigine::channelfactory::IChannelFactory &channelFactory);
+
+    ~DefaultPipelineBuilder() override;
+
+    // IPipelineBuilder
+    IPipelineBuilder &addStage(std::unique_ptr<IPipelineStage> stage,
+                               vigine::Result *outResult = nullptr) override;
+
+    [[nodiscard]] std::unique_ptr<IPipeline>
+        build(vigine::Result *outResult = nullptr) override;
+
+    DefaultPipelineBuilder(const DefaultPipelineBuilder &)            = delete;
+    DefaultPipelineBuilder &operator=(const DefaultPipelineBuilder &) = delete;
+    DefaultPipelineBuilder(DefaultPipelineBuilder &&)                 = delete;
+    DefaultPipelineBuilder &operator=(DefaultPipelineBuilder &&)      = delete;
+
+  private:
+    struct Impl;
+    std::unique_ptr<Impl> _impl;
+};
+
+} // namespace vigine::pipelinebuilder

--- a/include/vigine/pipelinebuilder/factory.h
+++ b/include/vigine/pipelinebuilder/factory.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <memory>
+
+#include "vigine/channelfactory/ichannelfactory.h"
+#include "vigine/messaging/imessagebus.h"
+#include "vigine/pipelinebuilder/defaultpipelinebuilder.h"
+#include "vigine/threading/ithreadmanager.h"
+
+// factory.h is a convenience header that re-exports createPipelineBuilder
+// so callers can include a single predictable factory header rather than
+// naming the concrete DefaultPipelineBuilder type.  The function is
+// defined in src/pipelinebuilder/defaultpipelinebuilder.cpp.
+//
+// Invariants:
+//   - INV-9:  createPipelineBuilder returns std::unique_ptr<IPipelineBuilder>.
+//   - INV-11: no graph types appear here.
+
+namespace vigine::pipelinebuilder
+{
+
+/**
+ * @brief Factory function — the sole entry point for creating a
+ *        pipeline-builder facade.
+ *
+ * Returns a @c std::unique_ptr<IPipelineBuilder> so the caller owns the
+ * facade exclusively (FF-1, INV-9).  All three references must outlive
+ * the returned builder and any @ref IPipeline objects produced from it.
+ */
+[[nodiscard]] std::unique_ptr<IPipelineBuilder>
+    createPipelineBuilder(vigine::messaging::IMessageBus       &bus,
+                          vigine::threading::IThreadManager    &threadManager,
+                          vigine::channelfactory::IChannelFactory &channelFactory);
+
+} // namespace vigine::pipelinebuilder

--- a/include/vigine/pipelinebuilder/ipipeline.h
+++ b/include/vigine/pipelinebuilder/ipipeline.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <memory>
+
+#include "vigine/channelfactory/ichannel.h"
+#include "vigine/messaging/imessagepayload.h"
+#include "vigine/result.h"
+
+namespace vigine::pipelinebuilder
+{
+
+/**
+ * @brief Pure-virtual handle to a built, runnable pipeline.
+ *
+ * @ref IPipeline is the run-time object produced by
+ * @ref IPipelineBuilder::build.  A pipeline chains one or more
+ * @ref IPipelineStage instances in sequence: each stage receives the
+ * output of the previous stage and either transforms or drops it.  The
+ * last stage's non-null output is pushed onto the drain channel
+ * accessible via @ref drain.
+ *
+ * Lifecycle:
+ *   - @ref feed may only be called after the builder has produced this
+ *     object via @ref IPipelineBuilder::build.  Calling @ref feed before
+ *     build is complete is not possible by construction (the handle does
+ *     not exist yet).
+ *   - @ref shutdown closes the drain channel and prevents further
+ *     @ref feed calls from succeeding.  Idempotent.
+ *
+ * Ownership:
+ *   - @ref feed takes unique ownership of @p payload on success.  On
+ *     error, ownership remains with the caller.
+ *   - @ref drain returns a reference to the channel owned by the
+ *     pipeline; the caller borrows it.
+ *
+ * Thread-safety: @ref feed and @ref drain are safe to call concurrently.
+ * @ref shutdown is safe to call from any thread; subsequent @ref feed
+ * calls on other threads return @ref vigine::Result::Code::Error.
+ *
+ * Invariants:
+ *   - INV-1:  no template parameters in the public surface.
+ *   - INV-10: @c I prefix for a pure-virtual interface (no state).
+ *   - INV-11: no graph types appear in this header.
+ */
+class IPipeline
+{
+  public:
+    virtual ~IPipeline() = default;
+
+    /**
+     * @brief Feeds @p payload through the stage chain.
+     *
+     * The pipeline runs every stage in order on the calling thread.
+     * If a stage returns @c nullptr, the item is dropped and
+     * @ref vigine::Result::Code::Success is still returned (a drop is
+     * not an error).  If all stages produce output, the result is pushed
+     * onto the drain @ref vigine::channelfactory::IChannel.
+     *
+     * Returns an error @ref vigine::Result when:
+     *   - The pipeline has been shut down.
+     *   - The drain channel is full and has timed out (bounded channel).
+     */
+    [[nodiscard]] virtual vigine::Result
+        feed(std::unique_ptr<vigine::messaging::IMessagePayload> payload) = 0;
+
+    /**
+     * @brief Returns a reference to the drain channel.
+     *
+     * Consumers read processed payloads from this channel.  The channel
+     * is owned by the pipeline; the reference is valid for the pipeline's
+     * lifetime.
+     *
+     * @ref IChannel::receive blocks until a processed payload arrives
+     * or the channel is closed (shutdown).
+     */
+    [[nodiscard]] virtual vigine::channelfactory::IChannel &drain() noexcept = 0;
+
+    /**
+     * @brief Shuts the pipeline down.
+     *
+     * Closes the drain channel so any blocked @ref IChannel::receive
+     * calls wake up.  Subsequent @ref feed calls return an error.
+     * Idempotent.
+     */
+    virtual void shutdown() = 0;
+
+    IPipeline(const IPipeline &)            = delete;
+    IPipeline &operator=(const IPipeline &) = delete;
+    IPipeline(IPipeline &&)                 = delete;
+    IPipeline &operator=(IPipeline &&)      = delete;
+
+  protected:
+    IPipeline() = default;
+};
+
+} // namespace vigine::pipelinebuilder

--- a/include/vigine/pipelinebuilder/ipipelinebuilder.h
+++ b/include/vigine/pipelinebuilder/ipipelinebuilder.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <memory>
+
+#include "vigine/pipelinebuilder/ipipeline.h"
+#include "vigine/pipelinebuilder/ipipelinestage.h"
+#include "vigine/result.h"
+
+namespace vigine::pipelinebuilder
+{
+
+/**
+ * @brief Pure-virtual builder that composes a linear pipeline of stages.
+ *
+ * @ref IPipelineBuilder is the Level-2 facade for composable processing
+ * pipelines (plan_22, R.3.3.2.4).  A caller:
+ *   1. Obtains a builder from @ref createPipelineBuilder (factory.h).
+ *   2. Calls @ref addStage one or more times to append stages in order.
+ *   3. Calls @ref build once to produce a runnable @ref IPipeline.
+ *   4. Feeds payloads through @ref IPipeline::feed and reads results
+ *      from @ref IPipeline::drain.
+ *
+ * Builder-reuse policy:
+ *   - Calling @ref build a second time on the same builder returns
+ *     @c nullptr and sets @p outResult to
+ *     @ref vigine::Result::Code::Error (AlreadyBuilt semantics).
+ *   - Stages may not be added after @ref build has been called.
+ *
+ * V1 constraints:
+ *   - Pipelines are linear (1→1 or 1→0 per stage).
+ *   - Fan-out and DAG topologies are deferred to v2.
+ *
+ * Invariants:
+ *   - INV-1:  no template parameters in the public surface.
+ *   - INV-9:  @ref build returns @c std::unique_ptr<IPipeline>.
+ *   - INV-10: @c I prefix for a pure-virtual interface (no state).
+ *   - INV-11: no graph types appear in this header.
+ */
+class IPipelineBuilder
+{
+  public:
+    virtual ~IPipelineBuilder() = default;
+
+    /**
+     * @brief Appends @p stage to the end of the stage chain.
+     *
+     * The builder takes unique ownership of the stage.  Stages are
+     * executed in the order they are added.  Calling @ref addStage after
+     * @ref build has been called is a no-op that returns @c *this and
+     * sets @p outResult to an error @ref vigine::Result (if non-null).
+     *
+     * A null @p stage pointer is a programming error; implementations
+     * ignore it and record the error in @p outResult if non-null.
+     */
+    virtual IPipelineBuilder &
+        addStage(std::unique_ptr<IPipelineStage> stage,
+                 vigine::Result *outResult = nullptr) = 0;
+
+    /**
+     * @brief Builds and returns the pipeline.
+     *
+     * The returned @ref IPipeline owns the drain channel and is
+     * immediately ready to accept @ref IPipeline::feed calls.
+     *
+     * Returns @c nullptr when:
+     *   - No stages have been added (empty pipeline).
+     *   - @ref build was already called on this builder.
+     *
+     * When returning @c nullptr, @p outResult (if non-null) is set to an
+     * error @ref vigine::Result describing the failure.
+     *
+     * On success, @p outResult (if non-null) is set to
+     * @ref vigine::Result::Code::Success.
+     */
+    [[nodiscard]] virtual std::unique_ptr<IPipeline>
+        build(vigine::Result *outResult = nullptr) = 0;
+
+    IPipelineBuilder(const IPipelineBuilder &)            = delete;
+    IPipelineBuilder &operator=(const IPipelineBuilder &) = delete;
+    IPipelineBuilder(IPipelineBuilder &&)                 = delete;
+    IPipelineBuilder &operator=(IPipelineBuilder &&)      = delete;
+
+  protected:
+    IPipelineBuilder() = default;
+};
+
+} // namespace vigine::pipelinebuilder

--- a/include/vigine/pipelinebuilder/ipipelinestage.h
+++ b/include/vigine/pipelinebuilder/ipipelinestage.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <memory>
+
+#include "vigine/messaging/imessagepayload.h"
+
+namespace vigine::pipelinebuilder
+{
+
+/**
+ * @brief Pure-virtual hook for a single pipeline stage.
+ *
+ * @ref IPipelineStage is the unit of work in the pipeline-builder facade
+ * (plan_22, R.3.3.2.4).  Each stage receives one @ref IMessagePayload
+ * and either produces a transformed payload or drops the item by
+ * returning @c nullptr.
+ *
+ * Drop semantics:
+ *   - Returning @c nullptr from @ref process drops the item.  No further
+ *     stages in the chain are called for that item, and nothing is
+ *     pushed to the drain channel.  This is not an error.
+ *   - To propagate an error downstream, return a payload whose
+ *     application-level status field signals the error so that later
+ *     stages can decide how to handle it.
+ *
+ * Ownership:
+ *   - The argument @p payload is borrowed for the duration of the call.
+ *     The stage must not hold the pointer after @ref process returns.
+ *   - The returned unique_ptr transfers ownership to the pipeline; on
+ *     @c nullptr return, ownership is not transferred (item is dropped).
+ *
+ * Thread-safety: the pipeline calls @ref process from a single dedicated
+ * worker thread; implementations do not need to be internally thread-safe
+ * with respect to the same stage instance.
+ *
+ * Invariants:
+ *   - INV-1:  no template parameters in the public surface.
+ *   - INV-10: @c I prefix for a pure-virtual interface (no state).
+ *   - INV-11: no graph types appear in this header.
+ */
+class IPipelineStage
+{
+  public:
+    virtual ~IPipelineStage() = default;
+
+    /**
+     * @brief Transforms @p payload and returns the result, or @c nullptr
+     *        to drop the item.
+     *
+     * Implementations perform their domain work on the payload bytes and
+     * return either:
+     *   - A new (or the same) @c unique_ptr<IMessagePayload> to pass to
+     *     the next stage.
+     *   - @c nullptr to signal that this item should be dropped silently.
+     *
+     * Throwing an exception propagates out of @ref IPipeline::feed.
+     * V1 pipelines do not catch stage exceptions; callers that need
+     * isolation should wrap the stage body in a try-catch.
+     */
+    [[nodiscard]] virtual std::unique_ptr<vigine::messaging::IMessagePayload>
+        process(std::unique_ptr<vigine::messaging::IMessagePayload> payload) = 0;
+
+    IPipelineStage(const IPipelineStage &)            = delete;
+    IPipelineStage &operator=(const IPipelineStage &) = delete;
+    IPipelineStage(IPipelineStage &&)                 = delete;
+    IPipelineStage &operator=(IPipelineStage &&)      = delete;
+
+  protected:
+    IPipelineStage() = default;
+};
+
+} // namespace vigine::pipelinebuilder

--- a/src/pipelinebuilder/abstractpipelinebuilder.cpp
+++ b/src/pipelinebuilder/abstractpipelinebuilder.cpp
@@ -1,0 +1,31 @@
+#include "vigine/pipelinebuilder/abstractpipelinebuilder.h"
+
+namespace vigine::pipelinebuilder
+{
+
+AbstractPipelineBuilder::AbstractPipelineBuilder(
+    vigine::messaging::IMessageBus       &bus,
+    vigine::threading::IThreadManager    &threadManager,
+    vigine::channelfactory::IChannelFactory &channelFactory)
+    : _bus(bus)
+    , _threadManager(threadManager)
+    , _channelFactory(channelFactory)
+{
+}
+
+vigine::messaging::IMessageBus &AbstractPipelineBuilder::bus() noexcept
+{
+    return _bus;
+}
+
+vigine::threading::IThreadManager &AbstractPipelineBuilder::threadManager() noexcept
+{
+    return _threadManager;
+}
+
+vigine::channelfactory::IChannelFactory &AbstractPipelineBuilder::channelFactory() noexcept
+{
+    return _channelFactory;
+}
+
+} // namespace vigine::pipelinebuilder

--- a/src/pipelinebuilder/defaultpipelinebuilder.cpp
+++ b/src/pipelinebuilder/defaultpipelinebuilder.cpp
@@ -1,0 +1,302 @@
+#include "vigine/pipelinebuilder/defaultpipelinebuilder.h"
+
+#include <atomic>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "vigine/channelfactory/channelkind.h"
+#include "vigine/channelfactory/ichannel.h"
+#include "vigine/channelfactory/ichannelfactory.h"
+#include "vigine/messaging/imessagepayload.h"
+#include "vigine/payload/payloadtypeid.h"
+#include "vigine/pipelinebuilder/ipipeline.h"
+#include "vigine/pipelinebuilder/ipipelinestage.h"
+#include "vigine/result.h"
+
+namespace vigine::pipelinebuilder
+{
+
+// ---------------------------------------------------------------------------
+// Well-known PayloadTypeId for the internal pipeline drain channel.
+// Value 0xFFFF0001 sits in a private reserved range; production code that
+// registers application types must stay below 0xFFFF0000 per the engine
+// payload-range convention.  The drain channel is internal-only, so no
+// registry entry is needed.
+// ---------------------------------------------------------------------------
+
+static constexpr vigine::payload::PayloadTypeId kDrainTypeId{0xFFFF0001u};
+
+// ---------------------------------------------------------------------------
+// PipelineOutputPayload — wraps any IMessagePayload produced by the last
+// stage, advertising kDrainTypeId so it matches the drain channel's expected
+// type id.  Ownership of the inner payload is transferred into this wrapper.
+// The wrapper is strictly internal to this translation unit.
+// ---------------------------------------------------------------------------
+
+class PipelineOutputPayload final : public vigine::messaging::IMessagePayload
+{
+  public:
+    explicit PipelineOutputPayload(
+        std::unique_ptr<vigine::messaging::IMessagePayload> inner) noexcept
+        : _inner(std::move(inner))
+    {
+    }
+
+    [[nodiscard]] vigine::payload::PayloadTypeId typeId() const noexcept override
+    {
+        return kDrainTypeId;
+    }
+
+    /**
+     * @brief Returns a mutable reference to the wrapped payload.
+     *
+     * Consumers that receive a @ref PipelineOutputPayload from the drain
+     * channel can call @ref unwrap to retrieve the actual user payload.
+     * In tests and application code, consumers downcast via
+     * @c static_cast<PipelineOutputPayload*> after checking the typeId,
+     * or rely on the fact that the drain yields their custom payloads
+     * wrapped here.
+     *
+     * For smoke-test simplicity, unwrap returns the raw pointer.  The
+     * wrapper retains ownership.
+     */
+    [[nodiscard]] vigine::messaging::IMessagePayload *inner() const noexcept
+    {
+        return _inner.get();
+    }
+
+    /**
+     * @brief Releases ownership of the inner payload.
+     *
+     * Call this to transfer the inner payload out of the wrapper without
+     * destroying it.  The wrapper is empty after this call.
+     */
+    [[nodiscard]] std::unique_ptr<vigine::messaging::IMessagePayload> release() noexcept
+    {
+        return std::move(_inner);
+    }
+
+    PipelineOutputPayload(const PipelineOutputPayload &)            = delete;
+    PipelineOutputPayload &operator=(const PipelineOutputPayload &) = delete;
+    PipelineOutputPayload(PipelineOutputPayload &&)                 = delete;
+    PipelineOutputPayload &operator=(PipelineOutputPayload &&)      = delete;
+
+  private:
+    std::unique_ptr<vigine::messaging::IMessagePayload> _inner;
+};
+
+// ---------------------------------------------------------------------------
+// DefaultPipeline — the runnable pipeline produced by DefaultPipelineBuilder.
+// ---------------------------------------------------------------------------
+
+class DefaultPipeline final : public IPipeline
+{
+  public:
+    DefaultPipeline(std::vector<std::unique_ptr<IPipelineStage>> stages,
+                    std::unique_ptr<vigine::channelfactory::IChannel> drainChannel)
+        : _stages(std::move(stages))
+        , _drainChannel(std::move(drainChannel))
+        , _shutdown(false)
+    {
+    }
+
+    ~DefaultPipeline() override
+    {
+        shutdown();
+    }
+
+    // IPipeline
+    [[nodiscard]] vigine::Result
+        feed(std::unique_ptr<vigine::messaging::IMessagePayload> payload) override
+    {
+        if (_shutdown.load(std::memory_order_acquire))
+        {
+            return vigine::Result{vigine::Result::Code::Error, "pipeline is shut down"};
+        }
+
+        if (!payload)
+        {
+            return vigine::Result{vigine::Result::Code::Error, "null payload"};
+        }
+
+        // Run each stage in sequence.  A stage may return nullptr to drop.
+        for (auto &stage : _stages)
+        {
+            payload = stage->process(std::move(payload));
+            if (!payload)
+            {
+                // Item dropped — not an error.
+                return vigine::Result{};
+            }
+        }
+
+        // Wrap the surviving payload with kDrainTypeId before pushing onto
+        // the drain channel.  The channel validates that the sent payload
+        // advertises kDrainTypeId; the wrapper satisfies this invariant.
+        auto wrapped = std::make_unique<PipelineOutputPayload>(std::move(payload));
+
+        // Use blocking send with no timeout (wait indefinitely) so
+        // back-pressure from a bounded drain channel is naturally applied.
+        // Unbounded drain channels never block.
+        auto result = _drainChannel->send(std::move(wrapped), -1);
+        if (result.isError())
+        {
+            return vigine::Result{vigine::Result::Code::Error,
+                                  "drain channel rejected payload: " + result.message()};
+        }
+
+        return vigine::Result{};
+    }
+
+    [[nodiscard]] vigine::channelfactory::IChannel &drain() noexcept override
+    {
+        return *_drainChannel;
+    }
+
+    void shutdown() override
+    {
+        bool already = _shutdown.exchange(true, std::memory_order_acq_rel);
+        if (!already)
+        {
+            _drainChannel->close();
+        }
+    }
+
+    DefaultPipeline(const DefaultPipeline &)            = delete;
+    DefaultPipeline &operator=(const DefaultPipeline &) = delete;
+    DefaultPipeline(DefaultPipeline &&)                 = delete;
+    DefaultPipeline &operator=(DefaultPipeline &&)      = delete;
+
+  private:
+    std::vector<std::unique_ptr<IPipelineStage>>      _stages;
+    std::unique_ptr<vigine::channelfactory::IChannel> _drainChannel;
+    std::atomic<bool>                                 _shutdown;
+};
+
+// ---------------------------------------------------------------------------
+// DefaultPipelineBuilder::Impl
+// ---------------------------------------------------------------------------
+
+struct DefaultPipelineBuilder::Impl
+{
+    std::vector<std::unique_ptr<IPipelineStage>> stages;
+    bool                                         built{false};
+};
+
+// ---------------------------------------------------------------------------
+// DefaultPipelineBuilder
+// ---------------------------------------------------------------------------
+
+DefaultPipelineBuilder::DefaultPipelineBuilder(
+    vigine::messaging::IMessageBus       &bus,
+    vigine::threading::IThreadManager    &threadManager,
+    vigine::channelfactory::IChannelFactory &channelFactory)
+    : AbstractPipelineBuilder(bus, threadManager, channelFactory)
+    , _impl(std::make_unique<Impl>())
+{
+}
+
+DefaultPipelineBuilder::~DefaultPipelineBuilder() = default;
+
+IPipelineBuilder &DefaultPipelineBuilder::addStage(
+    std::unique_ptr<IPipelineStage> stage,
+    vigine::Result *outResult)
+{
+    if (_impl->built)
+    {
+        if (outResult)
+        {
+            *outResult = vigine::Result{vigine::Result::Code::Error,
+                                        "builder already built; addStage ignored"};
+        }
+        return *this;
+    }
+
+    if (!stage)
+    {
+        if (outResult)
+        {
+            *outResult = vigine::Result{vigine::Result::Code::Error,
+                                        "null stage pointer"};
+        }
+        return *this;
+    }
+
+    _impl->stages.push_back(std::move(stage));
+
+    if (outResult)
+    {
+        *outResult = vigine::Result{};
+    }
+
+    return *this;
+}
+
+std::unique_ptr<IPipeline> DefaultPipelineBuilder::build(vigine::Result *outResult)
+{
+    if (_impl->built)
+    {
+        if (outResult)
+        {
+            *outResult = vigine::Result{vigine::Result::Code::Error,
+                                        "build() called twice on the same builder"};
+        }
+        return nullptr;
+    }
+
+    if (_impl->stages.empty())
+    {
+        if (outResult)
+        {
+            *outResult = vigine::Result{vigine::Result::Code::Error,
+                                        "no stages added; pipeline would be empty"};
+        }
+        return nullptr;
+    }
+
+    // Create an Unbounded drain channel.  Unbounded channels require
+    // capacity == 0.  The drain type id is the internal sentinel.
+    vigine::Result createResult;
+    auto drainChannel = channelFactory().create(
+        vigine::channelfactory::ChannelKind::Unbounded,
+        0,
+        kDrainTypeId,
+        &createResult);
+
+    if (!drainChannel)
+    {
+        if (outResult)
+        {
+            *outResult = vigine::Result{vigine::Result::Code::Error,
+                                        "failed to create drain channel: " +
+                                        createResult.message()};
+        }
+        return nullptr;
+    }
+
+    _impl->built = true;
+
+    if (outResult)
+    {
+        *outResult = vigine::Result{};
+    }
+
+    return std::make_unique<DefaultPipeline>(
+        std::move(_impl->stages),
+        std::move(drainChannel));
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+std::unique_ptr<IPipelineBuilder>
+createPipelineBuilder(vigine::messaging::IMessageBus       &bus,
+                      vigine::threading::IThreadManager    &threadManager,
+                      vigine::channelfactory::IChannelFactory &channelFactory)
+{
+    return std::make_unique<DefaultPipelineBuilder>(bus, threadManager, channelFactory);
+}
+
+} // namespace vigine::pipelinebuilder

--- a/src/pipelinebuilder/factory.cpp
+++ b/src/pipelinebuilder/factory.cpp
@@ -1,0 +1,6 @@
+#include "vigine/pipelinebuilder/factory.h"
+
+// createPipelineBuilder is defined in defaultpipelinebuilder.cpp.
+// This translation unit exists so factory.h has a corresponding .cpp
+// and the linker always sees the definition regardless of which TU
+// callers include factory.h from.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -283,14 +283,22 @@ add_executable(${REACTIVESTREAM_SMOKE_TARGET}
 
 target_include_directories(${REACTIVESTREAM_SMOKE_TARGET}
 =======
-# ====================== ActorHost Smoke Target =======================
-set(ACTORHOST_SMOKE_TARGET actorhost-smoke)
+# ====================== ActorHost Smoke Target ================set(ACTORHOST_SMOKE_TARGET actorhost-smoke)
 
 add_executable(${ACTORHOST_SMOKE_TARGET}
     actorhost/smoke_test.cpp
 )
 
 target_include_directories(${ACTORHOST_SMOKE_TARGET}
+=======
+# ====================== PipelineBuilder Smoke Target =======================
+set(PIPELINEBUILDER_SMOKE_TARGET pipelinebuilder-smoke)
+
+add_executable(${PIPELINEBUILDER_SMOKE_TARGET}
+    pipelinebuilder/smoke_test.cpp
+)
+
+target_include_directories(${PIPELINEBUILDER_SMOKE_TARGET}
     PRIVATE
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/src
@@ -300,6 +308,7 @@ target_include_directories(${ACTORHOST_SMOKE_TARGET}
 target_link_libraries(${REQUESTBUS_SMOKE_TARGET}
 target_link_libraries(${REACTIVESTREAM_SMOKE_TARGET}
 target_link_libraries(${ACTORHOST_SMOKE_TARGET}
+target_link_libraries(${PIPELINEBUILDER_SMOKE_TARGET}
     PRIVATE
     gtest
     gtest_main
@@ -325,6 +334,12 @@ set_target_properties(${ACTORHOST_SMOKE_TARGET} PROPERTIES
 
 gtest_discover_tests(${ACTORHOST_SMOKE_TARGET}
     PROPERTIES LABELS "actorhost-smoke"
+set_target_properties(${PIPELINEBUILDER_SMOKE_TARGET} PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
+gtest_discover_tests(${PIPELINEBUILDER_SMOKE_TARGET}
+    PROPERTIES LABELS "pipelinebuilder-smoke"
     DISCOVERY_TIMEOUT 60
     DISCOVERY_MODE PRE_TEST
 )

--- a/test/pipelinebuilder/smoke_test.cpp
+++ b/test/pipelinebuilder/smoke_test.cpp
@@ -1,0 +1,323 @@
+#include "vigine/channelfactory/channelkind.h"
+#include "vigine/channelfactory/factory.h"
+#include "vigine/channelfactory/ichannel.h"
+#include "vigine/channelfactory/ichannelfactory.h"
+#include "vigine/messaging/busconfig.h"
+#include "vigine/messaging/factory.h"
+#include "vigine/messaging/imessagepayload.h"
+#include "vigine/payload/payloadtypeid.h"
+#include "vigine/pipelinebuilder/defaultpipelinebuilder.h"
+#include "vigine/pipelinebuilder/factory.h"
+#include "vigine/pipelinebuilder/ipipeline.h"
+#include "vigine/pipelinebuilder/ipipelinebuilder.h"
+#include "vigine/pipelinebuilder/ipipelinestage.h"
+#include "vigine/result.h"
+#include "vigine/threading/factory.h"
+#include "vigine/threading/ithreadmanager.h"
+#include "vigine/threading/threadmanagerconfig.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <memory>
+#include <string>
+
+// ---------------------------------------------------------------------------
+// Test suite: PipelineBuilder smoke tests (label: pipelinebuilder-smoke)
+//
+// Scenario 1 — two-stage linear pipeline round-trip:
+//   Build a pipeline with two counting stages. Feed one payload. Assert both
+//   stages were called and output arrives in the drain channel.
+//
+// Scenario 2 — stage returning nullptr drops the item:
+//   Build a pipeline whose second stage returns nullptr. Feed one payload.
+//   Assert drain receives nothing and feed() returns success (drop != error).
+//
+// Scenario 3 — build() twice returns nullptr (AlreadyBuilt):
+//   Call build() once successfully, then call build() again. Assert the
+//   second call returns nullptr with an error result.
+//
+// Scenario 4 — shutdown closes drain; subsequent feed returns error:
+//   Build a pipeline. Shut it down. Feed a payload. Assert feed returns error.
+//   drain() receives closed-channel error.
+// ---------------------------------------------------------------------------
+
+namespace
+{
+
+using namespace vigine::pipelinebuilder;
+
+// ---------------------------------------------------------------------------
+// Minimal concrete IMessagePayload for test payloads.
+// ---------------------------------------------------------------------------
+
+class SmokePayload final : public vigine::messaging::IMessagePayload
+{
+  public:
+    explicit SmokePayload(vigine::payload::PayloadTypeId id,
+                          int                            tag = 0) noexcept
+        : _id(id)
+        , _tag(tag)
+    {
+    }
+
+    [[nodiscard]] vigine::payload::PayloadTypeId typeId() const noexcept override
+    {
+        return _id;
+    }
+
+    [[nodiscard]] int tag() const noexcept
+    {
+        return _tag;
+    }
+
+  private:
+    vigine::payload::PayloadTypeId _id;
+    int                            _tag;
+};
+
+// ---------------------------------------------------------------------------
+// CountingStage — passes payload through unchanged and increments a counter.
+// ---------------------------------------------------------------------------
+
+class CountingStage final : public IPipelineStage
+{
+  public:
+    explicit CountingStage(std::shared_ptr<std::atomic<int>> counter)
+        : _counter(std::move(counter))
+    {
+    }
+
+    [[nodiscard]] std::unique_ptr<vigine::messaging::IMessagePayload>
+        process(std::unique_ptr<vigine::messaging::IMessagePayload> payload) override
+    {
+        _counter->fetch_add(1, std::memory_order_relaxed);
+        return payload; // pass through
+    }
+
+  private:
+    std::shared_ptr<std::atomic<int>> _counter;
+};
+
+// ---------------------------------------------------------------------------
+// DroppingStage — always returns nullptr (drops the item).
+// ---------------------------------------------------------------------------
+
+class DroppingStage final : public IPipelineStage
+{
+  public:
+    [[nodiscard]] std::unique_ptr<vigine::messaging::IMessagePayload>
+        process(std::unique_ptr<vigine::messaging::IMessagePayload> /*payload*/) override
+    {
+        return nullptr; // drop
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Fixture: creates the infrastructure shared by all pipeline tests.
+// ---------------------------------------------------------------------------
+
+class PipelineBuilderSmoke : public ::testing::Test
+{
+  protected:
+    static constexpr vigine::payload::PayloadTypeId kPayloadTypeId{100};
+
+    void SetUp() override
+    {
+        _tm = vigine::threading::createThreadManager({});
+
+        vigine::messaging::BusConfig cfg;
+        cfg.threading    = vigine::messaging::ThreadingPolicy::InlineOnly;
+        cfg.backpressure = vigine::messaging::BackpressurePolicy::Error;
+        _bus = vigine::messaging::createMessageBus(cfg, *_tm);
+
+        _channelFactory = vigine::channelfactory::createChannelFactory(*_bus);
+    }
+
+    void TearDown() override
+    {
+        if (_channelFactory)
+        {
+            _channelFactory->shutdown();
+        }
+        if (_bus)
+        {
+            _bus->shutdown();
+        }
+        if (_tm)
+        {
+            _tm->shutdown();
+        }
+    }
+
+    /**
+     * @brief Convenience builder factory.
+     */
+    [[nodiscard]] std::unique_ptr<IPipelineBuilder> makeBuilder() const
+    {
+        return createPipelineBuilder(*_bus, *_tm, *_channelFactory);
+    }
+
+    std::unique_ptr<vigine::threading::IThreadManager>     _tm;
+    std::unique_ptr<vigine::messaging::IMessageBus>        _bus;
+    std::unique_ptr<vigine::channelfactory::IChannelFactory> _channelFactory;
+};
+
+// ---------------------------------------------------------------------------
+// Scenario 1: two-stage linear pipeline round-trip
+//
+// Asserts:
+//   - Both stages are called exactly once per feed.
+//   - The drain channel yields one payload after a single feed.
+//   - feed() returns success.
+// ---------------------------------------------------------------------------
+
+TEST_F(PipelineBuilderSmoke, TwoStagePipelineRoundTrip)
+{
+    auto c1 = std::make_shared<std::atomic<int>>(0);
+    auto c2 = std::make_shared<std::atomic<int>>(0);
+
+    auto builder = makeBuilder();
+    ASSERT_NE(builder, nullptr);
+
+    vigine::Result addResult;
+    builder->addStage(std::make_unique<CountingStage>(c1), &addResult);
+    ASSERT_TRUE(addResult.isSuccess()) << addResult.message();
+
+    builder->addStage(std::make_unique<CountingStage>(c2), &addResult);
+    ASSERT_TRUE(addResult.isSuccess()) << addResult.message();
+
+    vigine::Result buildResult;
+    auto pipeline = builder->build(&buildResult);
+    ASSERT_NE(pipeline, nullptr)       << "build must succeed for a non-empty builder";
+    ASSERT_TRUE(buildResult.isSuccess()) << buildResult.message();
+
+    // Feed one payload through the pipeline.
+    auto feedResult = pipeline->feed(
+        std::make_unique<SmokePayload>(kPayloadTypeId, 1));
+    EXPECT_TRUE(feedResult.isSuccess())
+        << "feed must succeed for a two-stage pipeline: " << feedResult.message();
+
+    // Both stages must have been called.
+    EXPECT_EQ(c1->load(), 1) << "stage 1 must be called exactly once";
+    EXPECT_EQ(c2->load(), 1) << "stage 2 must be called exactly once";
+
+    // Drain channel must contain exactly one payload.
+    std::unique_ptr<vigine::messaging::IMessagePayload> received;
+    auto recvResult = pipeline->drain().receive(received, 500 /*ms*/);
+    EXPECT_TRUE(recvResult.isSuccess())
+        << "drain must yield the processed payload: " << recvResult.message();
+    EXPECT_NE(received, nullptr) << "received payload must not be null";
+
+    pipeline->shutdown();
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 2: stage returning nullptr drops the item (not an error)
+//
+// Asserts:
+//   - feed() returns success even when an item is dropped mid-chain.
+//   - The drain channel remains empty (tryReceive returns false).
+//   - The first stage is called; no stage after the dropping stage is called.
+// ---------------------------------------------------------------------------
+
+TEST_F(PipelineBuilderSmoke, DroppingStageItemNotPushedToDrain)
+{
+    auto c1 = std::make_shared<std::atomic<int>>(0);
+    // Stage order: CountingStage -> DroppingStage -> CountingStage
+    // The second CountingStage must NOT be called because DroppingStage drops.
+    auto c3 = std::make_shared<std::atomic<int>>(0);
+
+    auto builder = makeBuilder();
+    builder->addStage(std::make_unique<CountingStage>(c1));
+    builder->addStage(std::make_unique<DroppingStage>());
+    builder->addStage(std::make_unique<CountingStage>(c3));
+
+    auto pipeline = builder->build();
+    ASSERT_NE(pipeline, nullptr);
+
+    auto feedResult = pipeline->feed(
+        std::make_unique<SmokePayload>(kPayloadTypeId, 2));
+    EXPECT_TRUE(feedResult.isSuccess())
+        << "drop is not an error; feed must return success: " << feedResult.message();
+
+    EXPECT_EQ(c1->load(), 1) << "stage before dropping stage must be called";
+    EXPECT_EQ(c3->load(), 0) << "stage after dropping stage must NOT be called";
+
+    // Drain must be empty — nothing arrived after the drop.
+    std::unique_ptr<vigine::messaging::IMessagePayload> out;
+    bool hasItem = pipeline->drain().tryReceive(out);
+    EXPECT_FALSE(hasItem) << "drain must be empty after a stage drops the item";
+    EXPECT_EQ(out, nullptr);
+
+    pipeline->shutdown();
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 3: build() called twice returns nullptr (AlreadyBuilt semantics)
+//
+// Asserts:
+//   - First build() returns a valid pipeline.
+//   - Second build() returns nullptr with an error result.
+//   - The first pipeline is still usable after the second build() attempt.
+// ---------------------------------------------------------------------------
+
+TEST_F(PipelineBuilderSmoke, BuildTwiceReturnsError)
+{
+    auto builder = makeBuilder();
+    builder->addStage(
+        std::make_unique<CountingStage>(std::make_shared<std::atomic<int>>(0)));
+
+    vigine::Result r1;
+    auto pipeline = builder->build(&r1);
+    ASSERT_NE(pipeline, nullptr)   << "first build must succeed";
+    ASSERT_TRUE(r1.isSuccess())    << r1.message();
+
+    // Second build on the same builder.
+    vigine::Result r2;
+    auto pipeline2 = builder->build(&r2);
+    EXPECT_EQ(pipeline2, nullptr)  << "second build must return nullptr";
+    EXPECT_TRUE(r2.isError())      << "second build must report an error result";
+
+    // First pipeline is still operational.
+    auto feedResult = pipeline->feed(
+        std::make_unique<SmokePayload>(kPayloadTypeId, 3));
+    EXPECT_TRUE(feedResult.isSuccess())
+        << "first pipeline must still accept feeds: " << feedResult.message();
+
+    pipeline->shutdown();
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 4: shutdown closes drain; subsequent feed returns error
+//
+// Asserts:
+//   - After shutdown(), feed() returns an error result.
+//   - drain().receive() returns an error when the channel is closed+empty.
+// ---------------------------------------------------------------------------
+
+TEST_F(PipelineBuilderSmoke, ShutdownRejectsFeed)
+{
+    auto builder = makeBuilder();
+    builder->addStage(
+        std::make_unique<CountingStage>(std::make_shared<std::atomic<int>>(0)));
+
+    auto pipeline = builder->build();
+    ASSERT_NE(pipeline, nullptr);
+
+    pipeline->shutdown();
+
+    // Post-shutdown feed must fail.
+    auto feedResult = pipeline->feed(
+        std::make_unique<SmokePayload>(kPayloadTypeId, 4));
+    EXPECT_TRUE(feedResult.isError())
+        << "feed after shutdown must return error: " << feedResult.message();
+
+    // drain().receive() on a closed channel must also fail.
+    std::unique_ptr<vigine::messaging::IMessagePayload> out;
+    auto recvResult = pipeline->drain().receive(out, 0 /*ms*/);
+    EXPECT_TRUE(recvResult.isError())
+        << "receive on closed+empty drain must return error";
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

- Adds `IPipelineBuilder` / `IPipeline` / `IPipelineStage` interfaces under `include/vigine/pipelinebuilder/`
- Concrete `DefaultPipelineBuilder` builds a linear stage chain; each stage transforms or drops (nullptr) payloads
- Drain channel uses `IChannel` (unbounded) from the channel-factory facade for back-pressure integration
- Factory returns `std::unique_ptr<IPipelineBuilder>` (FF-1 / INV-9)
- 4 smoke tests: two-stage round-trip, drop semantics, build-twice error, shutdown rejection

## Test plan

- `pipelinebuilder-smoke` — 4/4 pass Debug and Release
- `cmake --build build --config Debug` and Release both succeed warnings-clean for new sources

Closes #110