### PR TITLE
build(ci): add ASAN / UBSAN / TSAN sanitizer matrix jobs

### DIFF
--- a/.github/workflows/sanitizer-matrix.yml
+++ b/.github/workflows/sanitizer-matrix.yml
@@ -1,0 +1,178 @@
+name: Sanitizer matrix
+
+on:
+  push:
+    branches: ["main", "feat/**"]
+  pull_request:
+    branches: ["main"]
+
+# All sanitizer jobs run on ubuntu-22.04 + Clang. Three cells cover
+# address safety (ASAN), undefined behaviour (UBSAN), and data races
+# (TSAN). Jobs are continue-on-error until the known-flaky sleep_for-
+# based tests are rewritten around condition-variables (FF-102 backlog).
+
+jobs:
+  sanitizer-asan:
+    name: ASAN (ubuntu-22.04, Debug)
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    env:
+      CC: clang
+      CXX: clang++
+      ASAN_OPTIONS: "detect_leaks=1:halt_on_error=1:suppressions=${{ github.workspace }}/sanitizer/asan.supp"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Clang + build dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            clang \
+            libxcb1-dev \
+            libxcb-xfixes0-dev \
+            libxcb-randr0-dev \
+            libvulkan-dev \
+            vulkan-validationlayers-dev \
+            glslang-tools \
+            libglm-dev
+
+      - name: Cache vcpkg
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ github.workspace }}/vcpkg
+            ${{ github.workspace }}/build/vcpkg_installed
+          key: vcpkg-ubuntu-22.04-${{ hashFiles('vcpkg.json') }}
+          restore-keys: |
+            vcpkg-ubuntu-22.04-
+
+      - name: Configure (ASAN)
+        run: >
+          cmake -S . -B build
+          -DCMAKE_BUILD_TYPE=Debug
+          -DCMAKE_C_COMPILER=clang
+          -DCMAKE_CXX_COMPILER=clang++
+          -DVIGINE_SANITIZER=asan
+          -DENABLE_UNITTEST=ON
+          -DENABLE_EXAMPLE=OFF
+
+      - name: Build vigine + test targets
+        run: cmake --build build --config Debug --parallel
+
+      - name: Run contract + smoke tests (ASAN)
+        working-directory: build
+        run: >
+          ctest --output-on-failure
+          -L "graph-contract|messaging-smoke|eventscheduler-smoke|topicbus-smoke|channelfactory-smoke|requestbus-smoke|reactivestream-smoke|actorhost-smoke|pipelinebuilder-smoke"
+
+  sanitizer-ubsan:
+    name: UBSAN (ubuntu-22.04, Debug)
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    env:
+      CC: clang
+      CXX: clang++
+      UBSAN_OPTIONS: "halt_on_error=1:print_stacktrace=1"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Clang + build dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            clang \
+            libxcb1-dev \
+            libxcb-xfixes0-dev \
+            libxcb-randr0-dev \
+            libvulkan-dev \
+            vulkan-validationlayers-dev \
+            glslang-tools \
+            libglm-dev
+
+      - name: Cache vcpkg
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ github.workspace }}/vcpkg
+            ${{ github.workspace }}/build/vcpkg_installed
+          key: vcpkg-ubuntu-22.04-${{ hashFiles('vcpkg.json') }}
+          restore-keys: |
+            vcpkg-ubuntu-22.04-
+
+      - name: Configure (UBSAN)
+        run: >
+          cmake -S . -B build
+          -DCMAKE_BUILD_TYPE=Debug
+          -DCMAKE_C_COMPILER=clang
+          -DCMAKE_CXX_COMPILER=clang++
+          -DVIGINE_SANITIZER=ubsan
+          -DENABLE_UNITTEST=ON
+          -DENABLE_EXAMPLE=OFF
+
+      - name: Build vigine + test targets
+        run: cmake --build build --config Debug --parallel
+
+      - name: Run contract + smoke tests (UBSAN)
+        working-directory: build
+        run: >
+          ctest --output-on-failure
+          -L "graph-contract|messaging-smoke|eventscheduler-smoke|topicbus-smoke|channelfactory-smoke|requestbus-smoke|reactivestream-smoke|actorhost-smoke|pipelinebuilder-smoke"
+
+  sanitizer-tsan:
+    name: TSAN (ubuntu-22.04, Debug)
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    env:
+      CC: clang
+      CXX: clang++
+      TSAN_OPTIONS: "halt_on_error=1:suppressions=${{ github.workspace }}/sanitizer/tsan.supp"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Clang + build dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            clang \
+            libxcb1-dev \
+            libxcb-xfixes0-dev \
+            libxcb-randr0-dev \
+            libvulkan-dev \
+            vulkan-validationlayers-dev \
+            glslang-tools \
+            libglm-dev
+
+      - name: Cache vcpkg
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ github.workspace }}/vcpkg
+            ${{ github.workspace }}/build/vcpkg_installed
+          key: vcpkg-ubuntu-22.04-${{ hashFiles('vcpkg.json') }}
+          restore-keys: |
+            vcpkg-ubuntu-22.04-
+
+      - name: Configure (TSAN)
+        run: >
+          cmake -S . -B build
+          -DCMAKE_BUILD_TYPE=Debug
+          -DCMAKE_C_COMPILER=clang
+          -DCMAKE_CXX_COMPILER=clang++
+          -DVIGINE_SANITIZER=tsan
+          -DENABLE_UNITTEST=ON
+          -DENABLE_EXAMPLE=OFF
+
+      - name: Build vigine + test targets
+        run: cmake --build build --config Debug --parallel
+
+      - name: Run threading-sensitive tests (TSAN)
+        working-directory: build
+        run: >
+          ctest --output-on-failure
+          -L "graph-contract|messaging-smoke|topicbus-smoke|channelfactory-smoke|requestbus-smoke|reactivestream-smoke|actorhost-smoke|eventscheduler-smoke"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,15 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # sources like FreeType do not inherit /W4 / -Wpedantic.
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/VigineCompileOptions.cmake)
 
+# Optional sanitizer support (Linux + Clang only).
+# Pass -DVIGINE_SANITIZER=asan|ubsan|tsan to enable. MSVC builds must
+# leave this unset (the helper aborts with a clear error if called on MSVC).
+set(VIGINE_SANITIZER "" CACHE STRING "Sanitizer to enable: asan | ubsan | tsan (empty = off)")
+set_property(CACHE VIGINE_SANITIZER PROPERTY STRINGS "" asan ubsan tsan)
+if(NOT VIGINE_SANITIZER STREQUAL "")
+    include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/VigineSanitizer.cmake)
+endif()
+
 if(MSVC)
     add_compile_options(/FS /utf-8)
 endif()
@@ -661,6 +670,13 @@ add_library(${PROJECT_NAME}
 # Scoped via target_compile_options inside the helper so FreeType and
 # other vendored dependencies are not affected.
 vigine_apply_compile_options(${PROJECT_NAME})
+
+# Apply sanitizer flags when VIGINE_SANITIZER is set. Guarded by the same
+# condition used at include-time above so the helper is only called when the
+# module has been loaded.
+if(NOT VIGINE_SANITIZER STREQUAL "")
+    vigine_apply_sanitizer(${PROJECT_NAME} ${VIGINE_SANITIZER})
+endif()
 
 # Include directories
 target_include_directories(${PROJECT_NAME}

--- a/cmake/VigineSanitizer.cmake
+++ b/cmake/VigineSanitizer.cmake
@@ -1,0 +1,68 @@
+# VigineSanitizer.cmake
+#
+# Per-sanitizer compile + link flag helper. Provides vigine_apply_sanitizer()
+# which applies the appropriate -fsanitize=... flags PRIVATE to a given target.
+# Only GCC / Clang on Linux are supported; calling this on MSVC is a
+# configuration error and will abort CMake with a clear message.
+#
+# Supported modes (case-insensitive):
+#   asan   - Address Sanitizer: OOB reads/writes, UAF, double-free, leaks.
+#   ubsan  - Undefined Behavior Sanitizer: null-deref, signed overflow,
+#            type-punning, shift UB.
+#   tsan   - Thread Sanitizer: data races across threads.
+#
+# Usage:
+#   include(VigineSanitizer)
+#   vigine_apply_sanitizer(vigine asan)
+#
+# Or via the VIGINE_SANITIZER CMake option:
+#   cmake -DVIGINE_SANITIZER=asan ...
+
+function(vigine_apply_sanitizer target mode)
+    if(MSVC)
+        message(FATAL_ERROR
+            "vigine_apply_sanitizer: ASAN/UBSAN/TSAN require Clang on Linux. "
+            "MSVC sanitizers are not supported by this helper.")
+    endif()
+
+    string(TOLOWER "${mode}" _san_lower)
+
+    if(_san_lower STREQUAL "asan")
+        set(_san_compile_flags
+            -fsanitize=address
+            -fno-omit-frame-pointer
+            -g
+        )
+        set(_san_link_flags
+            -fsanitize=address
+        )
+
+    elseif(_san_lower STREQUAL "ubsan")
+        set(_san_compile_flags
+            -fsanitize=undefined
+            -fno-omit-frame-pointer
+            -g
+        )
+        set(_san_link_flags
+            -fsanitize=undefined
+        )
+
+    elseif(_san_lower STREQUAL "tsan")
+        set(_san_compile_flags
+            -fsanitize=thread
+            -fno-omit-frame-pointer
+            -g
+        )
+        set(_san_link_flags
+            -fsanitize=thread
+        )
+
+    else()
+        message(FATAL_ERROR
+            "vigine_apply_sanitizer: unknown mode '${mode}'. "
+            "Valid values: asan, ubsan, tsan.")
+    endif()
+
+    target_compile_options(${target} PRIVATE ${_san_compile_flags})
+    target_link_options(${target}    PRIVATE ${_san_link_flags})
+endfunction()

--- a/sanitizer/asan.supp
+++ b/sanitizer/asan.supp
@@ -1,0 +1,18 @@
+# ASAN suppression file for the vigine library.
+#
+# Every entry must include a documented reason. Unreviewed suppressions
+# fail architect review (plan_26, policy section).
+#
+# Format: suppressions are newline-separated, one rule per line:
+#   <type>:<function/file/module>
+#
+# Types: leak, interceptor_via_fun, interceptor_via_lib, ...
+#
+# No suppressions are active in the initial commit. Add entries as
+# confirmed-benign patterns are discovered during sanitizer runs, with
+# an inline comment explaining why the suppression is safe.
+#
+# Example (commented out — not active):
+#   # Third-party allocator in FreeType does not participate in
+#   # vigine's ownership graph; false-positive leak at program exit.
+#   # leak:FT_Init_FreeType

--- a/sanitizer/tsan.supp
+++ b/sanitizer/tsan.supp
@@ -1,0 +1,19 @@
+# TSAN suppression file for the vigine library.
+#
+# Every entry must include a documented reason. Unreviewed suppressions
+# fail architect review (plan_26, policy section).
+#
+# Format: suppressions are newline-separated, one rule per line:
+#   <type>:<function/file/module>
+#
+# Types: race, mutex, signal, thread, called_from_lib, ...
+#
+# No suppressions are active in the initial commit. Add entries as
+# confirmed-benign patterns are discovered during sanitizer runs, with
+# an inline comment explaining why the suppression is safe.
+#
+# Example (commented out — not active):
+#   # Internal FreeType glyph-cache mutex is single-threaded in vigine's
+#   # render pipeline; the apparent race is a false positive from TSAN
+#   # not seeing the external serialization via the render thread lock.
+#   # mutex:FT_Library_SetLcdFilter


### PR DESCRIPTION
## Summary

- Adds `cmake/VigineSanitizer.cmake` with `vigine_apply_sanitizer(<target> <mode>)` helper (modes: `asan`, `ubsan`, `tsan`).
- Adds `-DVIGINE_SANITIZER=asan|ubsan|tsan` CMake option to `CMakeLists.txt`; default build unchanged.
- Adds `.github/workflows/sanitizer-matrix.yml` with three `ubuntu-22.04` + Clang jobs covering address, undefined-behavior, and thread sanitizers.
- Adds `sanitizer/asan.supp` and `sanitizer/tsan.supp` suppression files (empty initially; every future entry requires an inline reason per policy).
- Jobs are `continue-on-error: true` until the known-flaky `sleep_for`-based tests are rewritten around condition-variables.

## Test plan

- [ ] Workflow file parses correctly (GitHub Actions YAML lint).
- [ ] `cmake/VigineSanitizer.cmake` accepted by CMake 3.25 configure run with `-DVIGINE_SANITIZER=asan`.
- [ ] Existing Windows / Linux non-sanitizer `build` jobs in `ci.yml` untouched and still green.
- [ ] Three new `sanitizer-asan`, `sanitizer-ubsan`, `sanitizer-tsan` jobs appear in the Actions tab after merge.

Closes #123