### PR TITLE
Tighten graph factory signature and IGraph doc-comments (#168)

### DIFF
--- a/include/vigine/graph/factory.h
+++ b/include/vigine/graph/factory.h
@@ -9,11 +9,14 @@ namespace vigine::graph
 /**
  * @brief Constructs the default in-memory @ref IGraph implementation.
  *
- * Returns a new graph instance wrapped in a `std::shared_ptr` so that
- * multiple wrappers can share the same substrate when required. The
- * factory is deliberately non-templated: every implementation is
- * selected at build time by the engine library.
+ * Returns a new graph instance that the caller owns uniquely. Promoting
+ * to `std::shared_ptr<IGraph>` is a single move when shared lifetime is
+ * genuinely required (`std::shared_ptr<IGraph>(std::move(g))`); the
+ * reverse promotion is not possible, so the factory hands back the
+ * tighter ownership by default. The factory is deliberately
+ * non-templated: every implementation is selected at build time by the
+ * engine library.
  */
-[[nodiscard]] std::shared_ptr<IGraph> createGraph();
+[[nodiscard]] std::unique_ptr<IGraph> createGraph();
 
 } // namespace vigine::graph

--- a/include/vigine/graph/igraph.h
+++ b/include/vigine/graph/igraph.h
@@ -28,9 +28,12 @@ namespace vigine::graph
  *   - @ref addNode and @ref addEdge take unique ownership of the
  *     implementation objects.
  *   - @ref node and @ref edge return non-owning raw pointers. Returned
- *     pointers are valid until the next mutation of the graph from any
- *     thread; callers that need longer-lived references should copy the
- *     identifier and re-resolve.
+ *     pointers are valid until the next mutation of the graph; callers
+ *     that need longer-lived references should copy the identifier and
+ *     re-resolve. The base interface does not offer a thread-safety
+ *     guarantee: concurrent access (read + mutate, or mutate + mutate)
+ *     requires external synchronization unless a concrete implementation
+ *     documents stronger guarantees.
  *   - Identifiers are generational (@ref NodeId, @ref EdgeId). Stale
  *     identifiers never alias live slots after removal.
  */
@@ -92,9 +95,12 @@ class IGraph
      * @brief Walks the graph starting at @p startNode under @p mode and
      *        reports each visited vertex and edge to @p visitor.
      *
-     * Returns a successful @ref Result on normal completion, an error
-     * @ref Result when the visitor requested a stop or when
-     * @ref TraverseMode::Topological encounters a cycle.
+     * Returns a successful @ref Result on normal completion AND when the
+     * visitor requested an early exit via @ref VisitResult::Stop — the
+     * stop signal is a normal control-flow outcome, not an error. Returns
+     * an error @ref Result only when @ref TraverseMode::Topological
+     * encounters a cycle or when an implementation-defined failure (e.g.
+     * @p startNode is stale) prevents the walk.
      */
     virtual Result traverse(NodeId startNode, TraverseMode mode, IGraphVisitor &visitor) = 0;
 

--- a/src/graph/factory.cpp
+++ b/src/graph/factory.cpp
@@ -7,12 +7,15 @@
 namespace vigine::graph
 {
 // Factory returns the default adjacency-list implementation behind the
-// pure-virtual IGraph interface. shared_ptr so that several wrappers can
-// share the same substrate when that is the right architectural choice.
+// pure-virtual IGraph interface. unique_ptr: the default hand-off is sole
+// ownership; a wrapper that legitimately needs to share the substrate
+// can promote with `std::shared_ptr<IGraph>(std::move(g))`. The reverse
+// direction (shared -> unique) is impossible, which is why the factory
+// returns the tighter type by default.
 
-std::shared_ptr<IGraph> createGraph()
+std::unique_ptr<IGraph> createGraph()
 {
-    return std::make_shared<DefaultGraph>();
+    return std::make_unique<DefaultGraph>();
 }
 
 } // namespace vigine::graph

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -395,7 +395,8 @@ gtest_discover_tests(${PIPELINEBUILDER_SMOKE_TARGET}
     DISCOVERY_MODE PRE_TEST
 )
 
-# ====================== Engine Smoke Target ================# Smoke coverage for IEngine lifecycle: construct-without-run, run +
+# ====================== Engine Smoke Target ============================
+# Smoke coverage for IEngine lifecycle: construct-without-run, run +
 # shutdown-from-other-thread, shutdown-from-main-thread-callback, and
 # double-shutdown idempotency. Also exercises the freeze-after-run
 # boundary that blocks context mutation once the pump is live.
@@ -413,6 +414,23 @@ target_include_directories(${ENGINE_SMOKE_TARGET}
 )
 
 target_link_libraries(${ENGINE_SMOKE_TARGET}
+    PRIVATE
+    gtest
+    gtest_main
+    vigine
+    ${GLM_LIBRARIES}
+)
+
+set_target_properties(${ENGINE_SMOKE_TARGET} PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
+gtest_discover_tests(${ENGINE_SMOKE_TARGET}
+    PROPERTIES LABELS "engine-smoke"
+    DISCOVERY_TIMEOUT 60
+    DISCOVERY_MODE PRE_TEST
+)
+
 # ====================== Full-Stack Contract Suite =======================
 # End-to-end contract coverage for the unified substrate: engine
 # lifecycle, threading primitives, messaging bus, every Level-2 facade
@@ -455,15 +473,16 @@ target_link_libraries(${FULL_CONTRACT_TARGET}
     ${GLM_LIBRARIES}
 )
 
-set_target_properties(${ENGINE_SMOKE_TARGET} PROPERTIES
+set_target_properties(${FULL_CONTRACT_TARGET} PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
 )
 
-gtest_discover_tests(${ENGINE_SMOKE_TARGET}
-    PROPERTIES LABELS "engine-smoke"
+gtest_discover_tests(${FULL_CONTRACT_TARGET}
+    PROPERTIES LABELS "full-contract"
     DISCOVERY_TIMEOUT 60
     DISCOVERY_MODE PRE_TEST
 )
+
 # ====================== Linux Platform Smoke Target =======================
 # Three scenarios: XCB window open/close, SIGTERM self-pipe delivery,
 # SIGUSR1/SIGUSR2 subscribe succeeds. Gated to Linux only; invisible to
@@ -503,14 +522,4 @@ if(UNIX AND NOT APPLE)
         DISCOVERY_MODE PRE_TEST
     )
 endif() # UNIX AND NOT APPLE
-=======
-set_target_properties(${FULL_CONTRACT_TARGET} PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-)
-
-gtest_discover_tests(${FULL_CONTRACT_TARGET}
-    PROPERTIES LABELS "full-contract"
-    DISCOVERY_TIMEOUT 60
-    DISCOVERY_MODE PRE_TEST
-)
 

--- a/test/graph/fixtures/graph_fixture_7n10e.h
+++ b/test/graph/fixtures/graph_fixture_7n10e.h
@@ -29,7 +29,7 @@ namespace vigine::graph::contract
  * concrete IGraph implementation plugs into the same suite by registering
  * another factory with INSTANTIATE_TEST_SUITE_P.
  */
-using GraphFactory = std::function<std::shared_ptr<IGraph>()>;
+using GraphFactory = std::function<std::unique_ptr<IGraph>()>;
 
 /**
  * @brief Reserved edge kind for ChildOf relations used by the HSM-style
@@ -196,7 +196,7 @@ inline EdgeId addTestEdge(IGraph                   &graph,
  */
 struct SevenNodeFixture
 {
-    std::shared_ptr<IGraph> graph;
+    std::unique_ptr<IGraph> graph;
     std::array<NodeId, 7>   nodes{};
     std::array<EdgeId, 10>  edges{};
 
@@ -264,7 +264,7 @@ struct SevenNodeFixture
 class ContractFixture : public ::testing::TestWithParam<GraphFactory>
 {
   protected:
-    std::shared_ptr<IGraph> makeGraph() const { return GetParam()(); }
+    std::unique_ptr<IGraph> makeGraph() const { return GetParam()(); }
 };
 
 /**

--- a/test/graph/smoke_test.cpp
+++ b/test/graph/smoke_test.cpp
@@ -39,7 +39,7 @@ class RecordingVisitor final : public IGraphVisitor
 
 TEST(DefaultGraphSmoke, CreateAndAddNodes)
 {
-    std::shared_ptr<IGraph> graph = createGraph();
+    std::unique_ptr<IGraph> graph = createGraph();
     ASSERT_NE(graph, nullptr);
 
     const NodeId n1 = graph->addNode(internal::makeNode(kind::Generic));
@@ -55,7 +55,7 @@ TEST(DefaultGraphSmoke, CreateAndAddNodes)
 
 TEST(DefaultGraphSmoke, AddEdgeAndTraverseDfs)
 {
-    std::shared_ptr<IGraph> graph = createGraph();
+    std::unique_ptr<IGraph> graph = createGraph();
     const NodeId            a     = graph->addNode(internal::makeNode(kind::Generic));
     const NodeId            b     = graph->addNode(internal::makeNode(kind::Generic));
     const EdgeId            e     = graph->addEdge(internal::makeEdge(a, b, edge_kind::Generic));
@@ -72,7 +72,7 @@ TEST(DefaultGraphSmoke, AddEdgeAndTraverseDfs)
 
 TEST(DefaultGraphSmoke, RemoveNodeCascadesEdges)
 {
-    std::shared_ptr<IGraph> graph = createGraph();
+    std::unique_ptr<IGraph> graph = createGraph();
     const NodeId            a     = graph->addNode(internal::makeNode(kind::Generic));
     const NodeId            b     = graph->addNode(internal::makeNode(kind::Generic));
     const EdgeId            e     = graph->addEdge(internal::makeEdge(a, b, edge_kind::Generic));
@@ -87,7 +87,7 @@ TEST(DefaultGraphSmoke, RemoveNodeCascadesEdges)
 
 TEST(DefaultGraphSmoke, ExportGraphVizRoundTrip)
 {
-    std::shared_ptr<IGraph> graph = createGraph();
+    std::unique_ptr<IGraph> graph = createGraph();
     const NodeId            a     = graph->addNode(internal::makeNode(kind::Generic));
     const NodeId            b     = graph->addNode(internal::makeNode(kind::Generic));
     static_cast<void>(graph->addEdge(internal::makeEdge(a, b, edge_kind::Generic)));
@@ -101,7 +101,7 @@ TEST(DefaultGraphSmoke, ExportGraphVizRoundTrip)
 
 TEST(DefaultGraphSmoke, TopologicalOrderAndCycleDetection)
 {
-    std::shared_ptr<IGraph> graph = createGraph();
+    std::unique_ptr<IGraph> graph = createGraph();
     const NodeId            a     = graph->addNode(internal::makeNode(kind::Generic));
     const NodeId            b     = graph->addNode(internal::makeNode(kind::Generic));
     const NodeId            c     = graph->addNode(internal::makeNode(kind::Generic));


### PR DESCRIPTION
## Summary

Graph-substrate contract tightening + two `IGraph` doc-comment fixes, plus a pre-existing CMake parse bug that was blocking local configures.

## Changes

### `createGraph()` factory → `unique_ptr`

`include/vigine/graph/factory.h` + `src/graph/factory.cpp`

The factory used to return `std::shared_ptr<IGraph>`. Callers that own the graph outright paid an unnecessary control-block + atomic refcount; callers that want shared ownership can do `std::shared_ptr<IGraph>(std::move(g))` at the call site. The reverse direction is impossible, so the factory now returns the tighter type and consumers opt into the looser one when they need it. C++ Core Guidelines F.20-F.21.

### `IGraph` doc-comment tightenings

`include/vigine/graph/igraph.h`

- `node()` / `edge()`: the phrase "valid until the next mutation … from any thread" implied a thread-safety guarantee the base interface does not ship. The doc now says pointers are valid until the next mutation and concurrent access requires external synchronization unless a concrete implementation documents more.
- `traverse()`: `VisitResult::Stop` was previously listed alongside topological cycles as a cause of error `Result`. Stop is a normal control-flow signal, not a fault. The doc now treats Stop as successful early completion; error is reserved for cycles + implementation-defined failures.

### Tests track the factory-type change

`test/graph/fixtures/graph_fixture_7n10e.h` + `test/graph/smoke_test.cpp`

Three explicit type mentions in the fixture (the `GraphFactory` alias, the `SevenNodeFixture::graph` member, `ContractFixture::makeGraph()`) and five local vars in the smoke tests move from `shared_ptr<IGraph>` to `unique_ptr<IGraph>`. Every parametrised contract test uses `auto graph = makeGraph()`, so those files are unchanged.

### CMake parse fix (pre-existing)

`test/CMakeLists.txt`

Two leftovers from an earlier auto-merge that blocked local CMake configure:

1. The `target_link_libraries(${ENGINE_SMOKE_TARGET}` block was missing its closing `)`; it had run into the "Full-Stack Contract Suite" section header. Added the `PRIVATE gtest gtest_main vigine ${GLM_LIBRARIES}` list plus matching `set_target_properties` + `gtest_discover_tests` for engine-smoke in the right place.
2. The `set_target_properties` / `gtest_discover_tests` wiring for the `full-contract` target was stranded behind a stray `=======` conflict marker after the Linux platform smoke block, while a duplicate set of those calls (mis-pointing at `ENGINE_SMOKE_TARGET`) had replaced them mid-file. Moved the correct block to follow the `full-contract` `target_link_libraries` and deleted the stray marker.

## Test plan

- [x] `cmake --build build --config Debug --target vigine` → clean.
- [x] `cmake --build build --config Debug --target graph-contract` → clean.
- [x] `build/bin/Debug/graph-contract.exe` → 78 / 78 passing.
- [ ] CI matrix on push.

## Notes

Part of #168 (post-shipment follow-up backlog). This PR addresses three items; the remaining ones drain on subsequent commits to this branch.

The legacy `unittest` target still fails to build against `main` because it depends on headers removed by the earlier refactor (`vigine/component/componentmanager.h`, `TaskFlow::addTransition`) — tracked separately and out of scope here.
