### PR TITLE
Fix NodeIdHasher 32-bit UB and sharpen graph/threading contract docs (#168)

### DIFF
--- a/include/vigine/graph/igraph.h
+++ b/include/vigine/graph/igraph.h
@@ -75,6 +75,9 @@ class IGraph
      *
      * Implementations validate that the endpoints addressed by @p edge
      * exist; when they do not, the returned identifier is invalid.
+     * Passing a null pointer is a programming error and is undefined —
+     * same contract as @ref addNode; callers must hand over a
+     * fully-constructed concrete @ref IEdge.
      */
     [[nodiscard]] virtual EdgeId addEdge(std::unique_ptr<IEdge> edge) = 0;
 

--- a/include/vigine/threading/factory.h
+++ b/include/vigine/threading/factory.h
@@ -22,8 +22,10 @@ namespace vigine::threading
  *
  * A @c unique_ptr is used — not a @c shared_ptr — because the manager
  * is a singular owner inside the engine construction chain. Callers
- * that need shared ownership can downcast the returned pointer into a
- * @c shared_ptr at the call site.
+ * that need shared ownership can transfer the returned pointer into a
+ * @c shared_ptr at the call site
+ * (`std::shared_ptr<IThreadManager>(std::move(uniquePtr))`). That is an
+ * ownership transfer, not a downcast.
  */
 [[nodiscard]] std::unique_ptr<IThreadManager>
     createThreadManager(const ThreadManagerConfig &config = {});

--- a/src/graph/defaultgraph_query.cpp
+++ b/src/graph/defaultgraph_query.cpp
@@ -1,5 +1,7 @@
 #include "vigine/graph/abstractgraph.h"
 
+#include "graph/nodeid_hasher.h"
+
 #include <algorithm>
 #include <cstdint>
 #include <deque>
@@ -13,19 +15,10 @@ namespace vigine::graph
 {
 namespace
 {
-// Hash adapter so NodeId can be an unordered-container key.
-struct NodeIdHasher
-{
-    std::size_t operator()(NodeId id) const noexcept
-    {
-        return (static_cast<std::size_t>(id.index) << 32) ^ static_cast<std::size_t>(id.generation);
-    }
-};
-
-using NodeIdSet = std::unordered_set<NodeId, NodeIdHasher>;
+using NodeIdSet = std::unordered_set<NodeId, internal::NodeIdHasher>;
 
 template <class Value>
-using NodeIdMap = std::unordered_map<NodeId, Value, NodeIdHasher>;
+using NodeIdMap = std::unordered_map<NodeId, Value, internal::NodeIdHasher>;
 
 } // namespace
 

--- a/src/graph/defaultgraph_traverse.cpp
+++ b/src/graph/defaultgraph_traverse.cpp
@@ -1,5 +1,7 @@
 #include "vigine/graph/abstractgraph.h"
 
+#include "graph/nodeid_hasher.h"
+
 #include <algorithm>
 #include <cstdint>
 #include <deque>
@@ -11,16 +13,7 @@ namespace vigine::graph
 {
 namespace
 {
-// Hash adapter so NodeId can be stored in unordered containers.
-struct NodeIdHasher
-{
-    std::size_t operator()(NodeId id) const noexcept
-    {
-        return (static_cast<std::size_t>(id.index) << 32) ^ static_cast<std::size_t>(id.generation);
-    }
-};
-
-using NodeIdSet = std::unordered_set<NodeId, NodeIdHasher>;
+using NodeIdSet = std::unordered_set<NodeId, internal::NodeIdHasher>;
 
 // Re-looks-up a node / edge through the public read path, which handles
 // its own locking and generational check.
@@ -206,7 +199,7 @@ Result AbstractGraph::traverse(NodeId startNode, TraverseMode mode, IGraphVisito
             (void)startNode;
 
             const Snapshot snap = buildSnapshot();
-            std::unordered_map<NodeId, std::size_t, NodeIdHasher> indegree;
+            std::unordered_map<NodeId, std::size_t, internal::NodeIdHasher> indegree;
             for (const NodeId &nid : snap.nodes)
             {
                 const auto it = snap.inByKey.find(Snapshot::nodeKey(nid));

--- a/src/graph/nodeid_hasher.h
+++ b/src/graph/nodeid_hasher.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "vigine/graph/nodeid.h"
+
+namespace vigine::graph::internal
+{
+// ---------------------------------------------------------------------------
+// Hash adapter so NodeId can be a key in unordered containers.
+//
+// The hasher folds the (index, generation) pair into a single size_t:
+//
+//   1. Build the full 64-bit key from index (high 32 bits) | generation
+//      (low 32 bits). Both halves are widened to uint64_t before the
+//      shift, which dodges the [expr.shift] UB that hits a literal
+//      "<< 32" on a 32-bit operand (the shift amount would equal the
+//      promoted width).
+//
+//   2. On 64-bit platforms the key fits directly in size_t.
+//      On 32-bit platforms we fold the high half into the low half
+//      (XOR) before narrowing so both halves contribute to the bucket.
+//
+// Used in both traverse and query drivers — centralised here so the
+// implementation does not drift between sites.
+// ---------------------------------------------------------------------------
+struct NodeIdHasher
+{
+    std::size_t operator()(NodeId id) const noexcept
+    {
+        const std::uint64_t key =
+            (static_cast<std::uint64_t>(id.index) << 32)
+          | static_cast<std::uint64_t>(id.generation);
+        if constexpr (sizeof(std::size_t) >= sizeof(std::uint64_t))
+        {
+            return static_cast<std::size_t>(key);
+        }
+        return static_cast<std::size_t>(key ^ (key >> 32));
+    }
+};
+} // namespace vigine::graph::internal


### PR DESCRIPTION
## Summary

Three contract-level fixes on the graph substrate + threading factory: an explicit 32-bit UB in `NodeIdHasher`, a doc gap on `IGraph::addEdge()`'s null-argument contract, and a miscalled term in the threading factory doc-comment.

## Changes

### `NodeIdHasher` — 32-bit UB fix + dedup

`src/graph/nodeid_hasher.h` (new), `src/graph/defaultgraph_traverse.cpp`, `src/graph/defaultgraph_query.cpp`

The two duplicate hashers were doing `(static_cast<std::size_t>(id.index) << 32) ^ ...`. On platforms where `size_t` is 32 bits (Windows x86, some embedded toolchains) the shift amount equals the promoted operand width, which is undefined behaviour per [expr.shift].

The fix:

1. Build the full 64-bit key from (`index`, `generation`) up front using `std::uint64_t` widening, so the shift amount never equals the operand width.
2. On 64-bit platforms (`sizeof(size_t) >= sizeof(uint64_t)`) return the key directly.
3. On 32-bit platforms fold the high half into the low half via XOR before narrowing, so both halves contribute to the bucket.

Moved the hasher into a shared internal header (`src/graph/nodeid_hasher.h`, namespace `vigine::graph::internal`) so the traverse and query drivers include one definition instead of carrying duplicates that could drift.

### `IGraph::addEdge()` — document null-pointer contract

`include/vigine/graph/igraph.h`

`addNode()` documented that passing a null `unique_ptr<INode>` is undefined. `addEdge()` said nothing, which left the contract ambiguous for the sibling method. Now `addEdge()` states the same UB contract, so the two owning-pointer sinks on the interface agree.

### `createThreadManager()` doc — "transfer", not "downcast"

`include/vigine/threading/factory.h`

The doc-comment said callers can "downcast the returned pointer into a shared_ptr". That is an ownership transfer (`std::shared_ptr<IThreadManager>(std::move(uniquePtr))`), not a downcast. Reworded with the correct vocabulary plus a concrete code snippet so future readers see the idiomatic promotion pattern.

## Test plan

- [x] `cmake --build build --config Debug --target vigine` → clean.
- [x] `cmake --build build --config Debug --target graph-contract` → clean.
- [x] `build/bin/Debug/graph-contract.exe` → 78 / 78 passing.
- [ ] CI matrix on push.

## Notes

Part of #168 (post-shipment follow-up backlog). This PR addresses three more items; the stream continues on the same branch.
