### PR TITLE
Tighten naming-convention checker parser and scan scope (#168)

### DIFF
--- a/script/check_naming_convention.py
+++ b/script/check_naming_convention.py
@@ -1,14 +1,18 @@
 #!/usr/bin/env python3
 """check_naming_convention.py -- Static checker for the I/Abstract naming convention (INV-10).
 
-Scans include/vigine/**/*.h and verifies that:
+Scans include/vigine/**/*.h and src/**/*.h and verifies that:
 
   Rule 1 (I-prefix): A class whose name starts with "I" followed by an
     uppercase letter must NOT have any non-virtual method with an inline
     body and must NOT have any underscore-prefixed data member.
     (Special-member housekeeping -- virtual destructor = default/delete,
     copy/move = default/delete, protected default constructor = default --
-    and virtual methods with optional-hook bodies are not counted.)
+    and virtual methods with optional-hook bodies are not counted. Non-
+    member lines that happen to carry `(` -- `using Callback = std::function
+    <...>`, `typedef void (*fn)(int);`, `friend bool operator==(...)`,
+    `static_assert(sizeof(...) == 8);` -- are not member functions and
+    therefore do not trigger Rule 1 either.)
 
   Rule 2 (Abstract-prefix): A class whose name starts with "Abstract" must
     have AT LEAST ONE method that is not pure-virtual (= 0) and not a
@@ -19,7 +23,8 @@ Only top-level class/struct definitions are checked; forward declarations
 (no body) are skipped; nested classes inside a body are not re-checked.
 
 Waiver: when the class declaration line contains "// INV-10 EXEMPTION:"
-the entire class is skipped without error.
+the ENTIRE class body is skipped without error, including any nested
+class or struct declared inside it.
 
 Exit codes:
   0 -- all checked classes conform.
@@ -37,7 +42,12 @@ from pathlib import Path
 
 WAIVER_MARKER = "// INV-10 EXEMPTION:"
 
-DEFAULT_SCAN_DIRS: list[str] = ["include/vigine"]
+# Default scan roots cover both the public engine API (`include/vigine`) and
+# the internal implementation (`src/`). INV-10 applies to class declarations
+# anywhere in the engine tree, not only the public surface — a concrete
+# `IFoo` helper that forgets the prefix convention in `src/` must still
+# trip CI.
+DEFAULT_SCAN_DIRS: list[str] = ["include/vigine", "src"]
 
 EXTENSIONS: frozenset[str] = frozenset({".h", ".hpp"})
 
@@ -67,6 +77,20 @@ _DATA_MEMBER_RE = re.compile(
 # A line that declares or defines a method (has parentheses) and is NOT
 # pure-virtual and NOT deleted/defaulted.  Used for the Abstract Rule 2.
 _METHOD_DECL_RE = re.compile(r"\(")   # any line with '(' is a method candidate
+
+# Non-method lines that may legitimately contain `(` inside a class body
+# and therefore must NOT trip the "has non-virtual method" branch of
+# Rule 1. Each pattern matches the beginning of a stripped line.
+_NON_METHOD_LINE_RES: tuple[re.Pattern[str], ...] = (
+    re.compile(r"^\s*using\b"),          # `using Callback = std::function<...>;`
+    re.compile(r"^\s*typedef\b"),        # `typedef void (*fn)(int);`
+    re.compile(r"^\s*friend\b"),         # `friend bool operator==(const X&, ...);`
+    re.compile(r"^\s*static_assert\b"),  # `static_assert(sizeof(...) == 8);`
+)
+
+
+def _is_non_method_line(sc: str) -> bool:
+    return any(pat.match(sc) for pat in _NON_METHOD_LINE_RES)
 
 # Comments.
 _BLOCK_COMMENT_RE = re.compile(r"^\s*/?\*")
@@ -121,6 +145,58 @@ def _extract_class_body(lines: list[str], start: int) -> tuple[list[str], int] |
 
 
 # ---------------------------------------------------------------------------
+# Continuation joiner
+# ---------------------------------------------------------------------------
+
+def _join_continuations(body_lines: list[str]) -> list[str]:
+    """Collapse C++ declarations that span multiple source lines into
+    single-line equivalents before per-line analysis.
+
+    A line that does not end with a statement-terminating character
+    (`;`, `{`, `}`, `:`) is glued to the next non-blank non-comment line.
+    This lets the analyser see idiomatic multi-line signatures like
+
+        [[nodiscard]] virtual Result
+            emit(std::unique_ptr<Payload> p) = 0;
+
+    as one logical statement where both `virtual` and `= 0;` are visible
+    at once — rather than separately flagging the parameter line as a
+    non-virtual method with a body.
+
+    Comment lines and blank lines pass through verbatim so the outer
+    depth-counter (which counts `{` and `}`) still balances correctly.
+    """
+    out: list[str] = []
+    buf: str = ""
+
+    def _flush_buf() -> None:
+        nonlocal buf
+        if buf:
+            out.append(buf)
+            buf = ""
+
+    for raw in body_lines:
+        if not raw.strip() or _is_comment_line(raw):
+            _flush_buf()
+            out.append(raw)
+            continue
+
+        sc = _strip_comments(raw).rstrip()
+        if buf:
+            buf = buf.rstrip() + " " + raw.strip()
+        else:
+            buf = raw
+
+        # End of logical statement when the comment-stripped line ends
+        # with one of the terminating characters.
+        if sc and sc[-1] in ";{}:":
+            _flush_buf()
+
+    _flush_buf()
+    return out
+
+
+# ---------------------------------------------------------------------------
 # Class body analyser
 # ---------------------------------------------------------------------------
 
@@ -143,7 +219,7 @@ class _ClassInfo:
         self.has_non_pure_non_virtual_impl = False
         self.has_any_non_delete_method     = False
         self.has_data_member               = False
-        self._parse(body_lines)
+        self._parse(_join_continuations(body_lines))
 
     def _parse(self, body_lines: list[str]) -> None:
         depth = 0  # 1 = directly inside the class being analysed.
@@ -184,6 +260,13 @@ class _ClassInfo:
 
             # -- Method lines (have parentheses) --
             if _METHOD_DECL_RE.search(sc):
+                # Some lines carry `(` but do not declare a member function
+                # of the current class (type aliases, forward friend
+                # declarations, static-assert expressions). They must not
+                # trip the "has non-virtual method" check — Rule 1 is about
+                # member functions specifically.
+                if _is_non_method_line(sc):
+                    continue
                 # A non-pure, non-delete, non-default method.
                 self.has_any_non_delete_method = True
                 # Check whether it is non-virtual (I-prefix violation).
@@ -260,7 +343,19 @@ def scan_file(path: Path, quiet: bool) -> list[str]:
         raw    = lines[idx]
         lineno = idx + 1
 
+        # A waiver marker placed on a class-open line (the idiomatic
+        # placement — see `ISignalEmiter`, `IHasState`) skips the WHOLE
+        # class body, not just the marker line. Without this, nested
+        # types inside a waivered class (`class Inner { ... };`) would
+        # be re-checked at the outer scope and produce spurious
+        # violations on declarations the waiver was meant to cover.
         if WAIVER_MARKER in raw:
+            if _CLASS_OPEN_RE.match(raw):
+                result = _extract_class_body(lines, idx)
+                if result is not None:
+                    _body, end_idx = result
+                    idx = end_idx + 1
+                    continue
             idx += 1
             continue
 

--- a/test/script/test_check_naming_convention.py
+++ b/test/script/test_check_naming_convention.py
@@ -19,7 +19,9 @@ from pathlib import Path
 import pytest
 
 # Add script/ to path so the module can be imported directly.
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "scripts"))
+# The directory was renamed from `scripts/` to `script/` during the
+# post-shipment cleanup — keep this path in sync.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "script"))
 
 import check_naming_convention as cnc  # noqa: E402
 
@@ -252,3 +254,91 @@ def test_missing_path_graceful(tmp_path: Path, capsys: pytest.CaptureFixture) ->
     captured = capsys.readouterr()
     assert code == 1, "Expected exit 1 for missing scan path"
     assert "not found" in captured.err.lower() or "not found" in captured.out.lower()
+
+
+# ---------------------------------------------------------------------------
+# Test 9 -- Waiver covers nested class/struct declarations inside the body
+# ---------------------------------------------------------------------------
+
+def test_waiver_covers_nested_types(tmp_path: Path) -> None:
+    """A nested I-prefix class inside a waivered parent must also be
+    waivered. Previously the waiver only skipped the opening line, which
+    let nested declarations trigger spurious Rule 1 violations at the
+    outer scope."""
+    d = tmp_path / "include" / "vigine"
+    write_header(
+        d,
+        "waived_nested.h",
+        """\
+        #pragma once
+        namespace test {
+        class IHasState // INV-10 EXEMPTION: legacy ABI
+        {
+          public:
+            // This nested interface would trip Rule 1 if re-checked at
+            // the outer scope (non-virtual body inside an I-prefix
+            // class), but the waiver on the parent must cover it too.
+            class INestedBad {
+              public:
+                void helper() { /* non-virtual body */ }
+                int  _field{0};
+            };
+
+            virtual void work() = 0;
+          private:
+            int _field{0};
+        };
+        }
+        """,
+    )
+    code = run(["--path", str(d), "--quiet"])
+    assert code == 0, "Expected exit 0 when waiver covers nested types"
+
+
+# ---------------------------------------------------------------------------
+# Test 10 -- Rule 1 does not misfire on non-method lines that contain '('
+# ---------------------------------------------------------------------------
+
+def test_rule_1_ignores_non_method_lines(tmp_path: Path) -> None:
+    """Lines that carry `(` but are not member functions (type aliases,
+    friend declarations, static-assert, typedef function-pointers) must
+    not count as non-virtual methods for Rule 1 purposes."""
+    d = tmp_path / "include" / "vigine"
+    write_header(
+        d,
+        "ok_non_method_parens.h",
+        """\
+        #pragma once
+        #include <functional>
+        namespace test {
+        class IWithAliases {
+          public:
+            // Type alias that mentions `(` inside the function-type
+            // signature.
+            using Callback = std::function<void(int)>;
+
+            // Classical C-style typedef for a function pointer.
+            typedef void (*RawCallback)(int);
+
+            // Forward-friend declaration of a free function.
+            friend bool operator==(const IWithAliases &, const IWithAliases &);
+
+            // Compile-time check that is not a member function.
+            static_assert(sizeof(int) == 4, "int must be 32 bits");
+
+            virtual void doWork() = 0;
+
+          protected:
+            IWithAliases()                                 = default;
+            virtual ~IWithAliases()                        = default;
+            IWithAliases(const IWithAliases &)             = delete;
+            IWithAliases &operator=(const IWithAliases &) = delete;
+        };
+        }
+        """,
+    )
+    code = run(["--path", str(d), "--quiet"])
+    assert code == 0, (
+        "Expected exit 0 — using/typedef/friend/static_assert lines "
+        "that happen to contain `(` must not trigger Rule 1"
+    )


### PR DESCRIPTION
## Summary

Tightens the I/Abstract naming-convention static checker so it correctly handles multi-line method signatures, legitimate non-method lines that carry parentheses, whole-class waivers, and the internal `src/` tree. The default scan is now clean across all 226 headers (190 public + 36 internal); previously 9 false positives shipped against intended-to-be-clean interfaces.

## Changes

### Continuation joiner — multi-line signatures parsed as one statement

`script/check_naming_convention.py` → new `_join_continuations()` pre-pass.

Every engine interface uses the attribute-first multi-line signature style:

```cpp
[[nodiscard]] virtual Result
    emit(std::unique_ptr<Payload> p) = 0;
```

Per-line analysis saw the parameter line as "has `(`, no `virtual`" and flagged the enclosing `I`-prefix class as a non-virtual-method carrier. The new pre-pass glues lines that do not end in `;`, `{`, `}`, or `:` into their successors, so `virtual` and `= 0;` are visible on the same logical line during Rule 1 analysis. Real-world headers that were tripping this false positive (now clean): `ISignalEmitter`, `IThreadManager`, `IPipelineBuilder`, `IRequestBus`, `IChannel`, `IChannelFactory`, `IEventScheduler`, `ITimerSource`, `IPayloadRegistry`.

### Rule 1 no longer trips on non-method lines that carry `(`

New `_NON_METHOD_LINE_RES` tuple covers lines that are not member functions even though they contain `(`:

- `using Callback = std::function<void(int)>;`
- `typedef void (*RawCallback)(int);`
- `friend bool operator==(const X &, const X &);`
- `static_assert(sizeof(int) == 4, "int must be 32 bits");`

The method-detection branch now short-circuits on those before flagging.

### Waiver covers the whole class body

The `EXEMPTION:` marker on a class-open line now skips to the matching `}` via `_extract_class_body()`, so nested types declared inside a waivered parent are also waivered. Previously the outer-scope scan re-entered the body and flagged any nested class or struct as a top-level violation.

### Default scan includes `src/`

`DEFAULT_SCAN_DIRS` goes from `["include/vigine"]` to `["include/vigine", "src"]`. The naming convention applies to every class declaration in the engine, not only the public surface — an internal helper that drops state in `src/` still needs to trip the check. All 226 headers scan clean under the tightened default.

## Test plan

- [x] `python -m pytest test/script/test_check_naming_convention.py -v` → 10 / 10 passing (eight originals + two new regression cases).
- [x] `python script/check_naming_convention.py` (default scan = include/vigine + src) → `226 files scanned, 0 violations`.

### New test cases

1. `test_waiver_covers_nested_types` — a waivered parent with a nested type that would itself trigger Rule 1 stays waivered.
2. `test_rule_1_ignores_non_method_lines` — an I-prefix class with every legitimate non-method-line shape compiles cleanly under Rule 1 when its real member function is pure-virtual and its special members are `= default` / `= delete`.

### Other

- The `sys.path.insert(...)` line in the test file was pointing at `scripts/` — updated to `script/` to match the directory rename.

## Notes

Part of #168 (post-shipment follow-up backlog). This PR drains four more items from the catalogue; the stream continues on the same branch.
