### PR TITLE
Align traverse Stop semantics with the contract + fix topological snapshot leak (#168)

### DIFF
--- a/src/graph/defaultgraph_traverse.cpp
+++ b/src/graph/defaultgraph_traverse.cpp
@@ -108,7 +108,7 @@ Result AbstractGraph::traverse(NodeId startNode, TraverseMode mode, IGraphVisito
                 const NodeStep step = visitNode(*this, current, visitor);
                 if (step == NodeStep::Stop)
                 {
-                    return Result(Result::Code::Error, "traversal stopped");
+                    return Result();
                 }
                 if (step == NodeStep::Prune)
                 {
@@ -123,7 +123,7 @@ Result AbstractGraph::traverse(NodeId startNode, TraverseMode mode, IGraphVisito
                     const bool cont  = visitEdge(*this, *it, visitor, &prune);
                     if (!cont)
                     {
-                        return Result(Result::Code::Error, "traversal stopped");
+                        return Result();
                     }
                     if (prune)
                     {
@@ -159,7 +159,7 @@ Result AbstractGraph::traverse(NodeId startNode, TraverseMode mode, IGraphVisito
                 const NodeStep step = visitNode(*this, current, visitor);
                 if (step == NodeStep::Stop)
                 {
-                    return Result(Result::Code::Error, "traversal stopped");
+                    return Result();
                 }
                 if (step == NodeStep::Prune)
                 {
@@ -172,7 +172,7 @@ Result AbstractGraph::traverse(NodeId startNode, TraverseMode mode, IGraphVisito
                     const bool cont  = visitEdge(*this, eid, visitor, &prune);
                     if (!cont)
                     {
-                        return Result(Result::Code::Error, "traversal stopped");
+                        return Result();
                     }
                     if (prune)
                     {
@@ -266,20 +266,31 @@ Result AbstractGraph::traverse(NodeId startNode, TraverseMode mode, IGraphVisito
                 const NodeStep step = visitNode(*this, nid, visitor);
                 if (step == NodeStep::Stop)
                 {
-                    return Result(Result::Code::Error, "traversal stopped");
+                    return Result();
                 }
                 if (step == NodeStep::Prune)
                 {
                     continue;
                 }
-                const std::vector<EdgeId> outs = snapshotOutEdges(nid);
-                for (EdgeId eid : outs)
+                // Read outgoing edges from the snapshot captured above,
+                // not from the live graph. Going back to the live graph
+                // here would (a) reintroduce the lock contention the
+                // snapshot was built to eliminate, and (b) let edges
+                // added concurrently after the snapshot slip into the
+                // walk — breaking the documented "traversal is isolated
+                // from concurrent mutation" contract.
+                const auto outIt = snap.outByKey.find(Snapshot::nodeKey(nid));
+                if (outIt == snap.outByKey.end())
+                {
+                    continue;
+                }
+                for (EdgeId eid : outIt->second)
                 {
                     bool       prune = false;
                     const bool cont  = visitEdge(*this, eid, visitor, &prune);
                     if (!cont)
                     {
-                        return Result(Result::Code::Error, "traversal stopped");
+                        return Result();
                     }
                     if (prune)
                     {
@@ -306,7 +317,7 @@ Result AbstractGraph::traverse(NodeId startNode, TraverseMode mode, IGraphVisito
                 const NodeStep step = visitNode(*this, current, visitor);
                 if (step == NodeStep::Stop)
                 {
-                    return Result(Result::Code::Error, "traversal stopped");
+                    return Result();
                 }
                 if (step == NodeStep::Prune)
                 {

--- a/test/graph/contract_async_timeout.cpp
+++ b/test/graph/contract_async_timeout.cpp
@@ -73,16 +73,16 @@ class DeadlineVisitor : public IGraphVisitor
 
 using AsyncTimeoutContract = SevenNodeParamFixture;
 
-TEST_P(AsyncTimeoutContract, StopReportsDeterministicErrorMessage)
+TEST_P(AsyncTimeoutContract, StopReportsSuccessResult)
 {
     DeadlineVisitor visitor(/*fireAfter=*/3);
     const Result    r = fixture.graph->traverse(
         fixture.nodes[SevenNodeFixture::A], TraverseMode::DepthFirst, visitor);
 
-    // The visitor fired before the traversal could finish on its own.
+    // The visitor fired before the traversal could finish on its own —
+    // Stop is a normal early-exit signal, the walk returns success.
     EXPECT_TRUE(visitor.fired());
-    EXPECT_TRUE(r.isError());
-    EXPECT_EQ(r.message(), "traversal stopped");
+    EXPECT_TRUE(r.isSuccess());
 }
 
 TEST_P(AsyncTimeoutContract, StopCompletesInBoundedWallTime)
@@ -98,7 +98,8 @@ TEST_P(AsyncTimeoutContract, StopCompletesInBoundedWallTime)
         fixture.nodes[SevenNodeFixture::A], TraverseMode::DepthFirst, visitor);
     const auto elapsed = std::chrono::steady_clock::now() - start;
 
-    EXPECT_TRUE(r.isError());
+    // Stop aborts the walk cleanly; the Result is success.
+    EXPECT_TRUE(r.isSuccess());
     EXPECT_LT(std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count(), 2000)
         << "Stop should abort the traversal promptly";
 }

--- a/test/graph/contract_hsm_bubble.cpp
+++ b/test/graph/contract_hsm_bubble.cpp
@@ -31,8 +31,8 @@
 //     through the graph unchanged; the query surface filters on them.
 //   * Custom mode follows the chain exactly as the visitor decides.
 //   * VisitResult::Stop returned from onNode short-circuits the walk;
-//     the driver reports the stop through Result::Error with the
-//     "traversal stopped" message.
+//     the driver returns a successful Result — Stop is a normal
+//     early-exit signal, not a fault.
 // =============================================================================
 
 namespace vigine::graph::contract
@@ -125,8 +125,8 @@ TEST_P(BubbleContract, HandlerNodeStopsTheBubble)
     // Handler sits at mid2; bubble stops there, root is not visited.
     BubbleVisitor visitor(*graph, /*handler=*/mid2);
     const Result  r = graph->traverse(leaf, TraverseMode::Custom, visitor);
-    EXPECT_TRUE(r.isError());
-    EXPECT_EQ(r.message(), "traversal stopped");
+    // Stop is a normal early-exit signal — the walk returns success.
+    EXPECT_TRUE(r.isSuccess());
 
     ASSERT_EQ(visitor.order().size(), 3u);
     EXPECT_EQ(visitor.order()[0], leaf);

--- a/test/graph/contract_traversal.cpp
+++ b/test/graph/contract_traversal.cpp
@@ -26,14 +26,13 @@
 // Custom against the seven-node fixture, plus the Skip / Stop / prune
 // behaviour of the visitor return codes.
 //
-// A note on Stop semantics. The concrete AbstractGraph implementation
-// reports visitor-Stop by returning Result::Code::Error with the message
-// "traversal stopped". The IGraph interface doc says Stop terminates the
-// traversal with an error Result, and the core Result type only carries
-// two codes (Success / Error). The suite therefore asserts the shipped
-// behaviour: Stop -> isError() with the expected message. An engineer
-// reading this file: Stop is an early-exit signal, not a failure; the
-// message disambiguates it from other error conditions.
+// A note on Stop semantics. VisitResult::Stop is an early-exit signal,
+// not a failure: "the visitor is done, the walk does not need to
+// continue". The IGraph interface contract treats it as normal
+// completion, and the concrete AbstractGraph implementation returns a
+// successful Result on visitor-Stop. Only cycles (topological) and
+// invalid start nodes surface an error Result. The suite asserts the
+// success-on-Stop shape below.
 // =============================================================================
 
 namespace vigine::graph::contract
@@ -234,13 +233,14 @@ TEST_P(TraversalContract, DepthFirstSkipPrunesSubtree)
     EXPECT_NE(hasB, v.end());
 }
 
-TEST_P(TraversalContract, DepthFirstStopReportsErrorResult)
+TEST_P(TraversalContract, DepthFirstStopReportsSuccessResult)
 {
     StopAtVisitor visitor(fixture.nodes[SevenNodeFixture::D]);
     const Result  r = fixture.graph->traverse(
         fixture.nodes[SevenNodeFixture::A], TraverseMode::DepthFirst, visitor);
-    EXPECT_TRUE(r.isError());
-    EXPECT_EQ(r.message(), "traversal stopped");
+    // Stop is a normal early-exit signal, not a fault — the walk
+    // returns success.
+    EXPECT_TRUE(r.isSuccess());
 
     // The stop-at node is observed exactly once.
     const auto &v = visitor.visitedNodes();
@@ -299,13 +299,13 @@ TEST_P(TraversalContract, BreadthFirstVisitsDepthOneBeforeDepthTwo)
                          fixture.nodes[SevenNodeFixture::G]));
 }
 
-TEST_P(TraversalContract, BreadthFirstStopReportsErrorResult)
+TEST_P(TraversalContract, BreadthFirstStopReportsSuccessResult)
 {
     StopAtVisitor visitor(fixture.nodes[SevenNodeFixture::C]);
     const Result  r = fixture.graph->traverse(
         fixture.nodes[SevenNodeFixture::A], TraverseMode::BreadthFirst, visitor);
-    EXPECT_TRUE(r.isError());
-    EXPECT_EQ(r.message(), "traversal stopped");
+    // Stop is a normal early-exit signal, not a fault.
+    EXPECT_TRUE(r.isSuccess());
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two related graph-traversal correctness fixes: reconcile the `IGraph::traverse` impl with its (recently-tightened) public contract on visitor-Stop semantics, and close a snapshot leak in the topological driver.

## Changes

### Visitor-Stop now returns a successful `Result`

`src/graph/defaultgraph_traverse.cpp`, `test/graph/contract_traversal.cpp`, `test/graph/contract_async_timeout.cpp`, `test/graph/contract_hsm_bubble.cpp`

`IGraph::traverse`'s doc was tightened in PR #175 to treat `VisitResult::Stop` as a normal control-flow signal ("visitor is done, do not walk further"), with error `Result` reserved for cycles and implementation-defined failures. The concrete `DefaultGraph` driver still returned `Result::Code::Error` with the message `"traversal stopped"` on every early-exit path — seven sites across DepthFirst, BreadthFirst, Topological, and Custom modes. This forced callers to split a tri-state outcome (success / early-exit / real fault) across a binary status code and made wrappers that layer retry or rollback on top misfire on normal "visitor is done" signals.

All seven sites now return the default `Result()` on Stop. Topological cycles (`"cycle detected during topological traversal"`) and invalid start nodes (`"invalid start node"`) continue to report as errors.

Contract tests that pinned the old error-shape are updated: `DepthFirstStopReportsErrorResult` → `DepthFirstStopReportsSuccessResult`, `BreadthFirstStopReportsErrorResult` → `BreadthFirstStopReportsSuccessResult`, `StopReportsDeterministicErrorMessage` → `StopReportsSuccessResult`, plus assertion flips + doc-comment rewrites in each file's header explaining the new shape.

### Topological driver no longer reads the live graph mid-walk

`src/graph/defaultgraph_traverse.cpp`

The topological branch captures `Snapshot snap = buildSnapshot();` up front — the whole point is to isolate the walk from concurrent mutation. The final per-node edge-visit loop, however, still called `snapshotOutEdges(current)`, which goes back to the live graph under the shared lock. Two problems:

1. Reintroduces the lock contention the snapshot was built to eliminate.
2. Edges added concurrently after the snapshot were visible to the walk, contradicting the "traversal is isolated from concurrent mutation" contract on the topological mode.

The fix looks up out-edges via `snap.outByKey.find(Snapshot::nodeKey(nid))` so the whole driver runs against the captured state. When a node has no out-edges in the snapshot (`outByKey.end()`), the loop continues.

## Test plan

- [x] `cmake --build build --config Debug --target graph-contract` → clean.
- [x] `build/bin/Debug/graph-contract.exe` → 78 / 78 passing.
- [ ] CI matrix on push.

## Notes

Part of #168 (post-shipment follow-up backlog). The Stop-is-success reconciliation closes a loose end from PR #175, where the doc was updated but the impl change and test updates were deferred. The topological snapshot-leak fix is the second correctness item in this batch.
