### PR TITLE
Thread manager: fix shutdown race, parametrise drain reason, harden Named scheduling (#168)

### DIFF
--- a/include/vigine/threading/threadaffinity.h
+++ b/include/vigine/threading/threadaffinity.h
@@ -25,11 +25,20 @@ enum class ThreadAffinity : std::uint8_t
     Any = 0,
     /// Strictly the main thread. Drains via @ref IThreadManager::runMainThreadPump.
     Main = 1,
-    /// One-per-caller dedicated thread with FIFO queue. Lazy-allocated.
+    /// Fresh dedicated OS thread per schedule call. The current
+    /// implementation does not reuse dedicated slots across calls — a
+    /// caller-keyed FIFO reuse (with an upper bound from
+    /// @ref ThreadManagerConfig::maxDedicatedThreads) is on the backlog;
+    /// until it lands, callers that need predictable per-caller FIFO
+    /// should reuse a single @ref NamedThreadId through
+    /// @ref IThreadManager::scheduleOnNamed instead.
     Dedicated = 2,
     /// Worker pool. Parallel execution across the configured pool size.
     Pool = 3,
-    /// Explicit named thread identified by @ref NamedThreadId.
+    /// Explicit named thread identified by @ref NamedThreadId. Route
+    /// through @ref IThreadManager::scheduleOnNamed — the generic
+    /// @ref IThreadManager::schedule path cannot carry an id and
+    /// rejects this affinity with an error `Result`.
     Named = 4,
 };
 

--- a/src/graph/nodeid_hasher.h
+++ b/src/graph/nodeid_hasher.h
@@ -36,7 +36,10 @@ struct NodeIdHasher
         {
             return static_cast<std::size_t>(key);
         }
-        return static_cast<std::size_t>(key ^ (key >> 32));
+        else
+        {
+            return static_cast<std::size_t>(key ^ (key >> 32));
+        }
     }
 };
 } // namespace vigine::graph::internal

--- a/src/threading/defaultthreadmanager.cpp
+++ b/src/threading/defaultthreadmanager.cpp
@@ -252,16 +252,18 @@ void workerLoop(WorkQueue &queue)
 }
 
 // Drain a stopped queue, settling every handle with a cancellation
-// Result so waiters do not hang.
-void drainStoppedQueue(WorkQueue &queue)
+// `Result` so waiters do not hang. The reason string travels to every
+// settled handle — callers supply it so debug output reflects the
+// actual cause (shutdown vs. named-thread unregistration) instead of
+// always blaming shutdown.
+void drainStoppedQueue(WorkQueue &queue, const char *reason)
 {
     auto leftovers = queue.drainCancelled();
     for (auto &entry : leftovers)
     {
         if (entry.handle)
         {
-            entry.handle->settle(
-                Result{Result::Code::Error, "threading: manager shut down"});
+            entry.handle->settle(Result{Result::Code::Error, reason});
         }
     }
 }
@@ -304,7 +306,12 @@ struct DefaultThreadManager::Impl
     std::mutex                   mainMutex;
     std::deque<QueueEntry>       mainQueue;
 
-    bool shutdownCompleted{false};
+    // `shutdown()` is documented as safe to call from any thread. The
+    // flag that tracks whether shutdown has already run is read and
+    // written by those concurrent callers — a plain `bool` would be a
+    // data race visible to TSAN. An atomic gives a sequentially
+    // consistent ordering with no lock overhead on the hot path.
+    std::atomic<bool> shutdownCompleted{false};
 };
 
 // =========================================================================
@@ -398,13 +405,16 @@ std::unique_ptr<ITaskHandle> DefaultThreadManager::schedule(
 
         case ThreadAffinity::Named:
         {
-            // Named affinity without an id falls back to the pool; a
-            // caller that wants a named thread should use scheduleOnNamed.
-            if (!_impl->pool.push(std::move(entry)))
-            {
-                handle->settle(
-                    Result{Result::Code::Error, "threading: pool queue closed"});
-            }
+            // The generic `schedule(runnable, affinity)` entry point has
+            // no way to carry a `NamedThreadId`, so a Named request here
+            // is always a caller bug. Previously we quietly diverted to
+            // the pool, which made the bug invisible. Surface it as an
+            // explicit error so the caller sees the missing id and
+            // routes through `scheduleOnNamed(runnable, id)` instead.
+            handle->settle(Result{
+                Result::Code::Error,
+                "threading: Named affinity requires a NamedThreadId; "
+                "use scheduleOnNamed(runnable, id)"});
             break;
         }
     }
@@ -535,7 +545,7 @@ void DefaultThreadManager::unregisterNamedThread(NamedThreadId id)
         {
             slot->worker.join();
         }
-        drainStoppedQueue(*slot->queue);
+        drainStoppedQueue(*slot->queue, "threading: named thread unregistered");
     }
 }
 
@@ -548,7 +558,14 @@ void DefaultThreadManager::shutdown()
     {
         return;
     }
-    if (_impl->shutdownCompleted)
+    // Atomic exchange: the first caller to flip the flag runs the
+    // full teardown; any concurrent or subsequent caller sees `true`
+    // and returns immediately. This replaces the plain-bool double-
+    // check idiom that produced a data race under two concurrent
+    // `shutdown()` invocations.
+    bool expected = false;
+    if (!_impl->shutdownCompleted.compare_exchange_strong(
+            expected, true, std::memory_order_acq_rel))
     {
         return;
     }
@@ -566,7 +583,7 @@ void DefaultThreadManager::shutdown()
         }
     }
     _impl->poolWorkers.clear();
-    drainStoppedQueue(_impl->pool);
+    drainStoppedQueue(_impl->pool, "threading: manager shut down");
 
     // Stop + join every dedicated slot.
     std::vector<std::unique_ptr<Impl::DedicatedSlot>> dedicated;
@@ -585,7 +602,7 @@ void DefaultThreadManager::shutdown()
         {
             slot->worker.join();
         }
-        drainStoppedQueue(*slot->queue);
+        drainStoppedQueue(*slot->queue, "threading: manager shut down");
         releaseDedicatedSlot();
     }
 
@@ -607,7 +624,7 @@ void DefaultThreadManager::shutdown()
         {
             slot->worker.join();
         }
-        drainStoppedQueue(*slot->queue);
+        drainStoppedQueue(*slot->queue, "threading: manager shut down");
     }
 
     // Drain the main-thread queue so its handles settle instead of hang.
@@ -625,7 +642,11 @@ void DefaultThreadManager::shutdown()
         }
     }
 
-    _impl->shutdownCompleted = true;
+    // No trailing store of `shutdownCompleted = true` here: the
+    // compare_exchange_strong at the top of the function already set
+    // the flag. Repeating the write would be correct but redundant
+    // and misleading — callers racing at the top check the flag via
+    // the CAS, not via a plain load after the teardown completes.
 }
 
 } // namespace vigine::threading


### PR DESCRIPTION
## Summary

Four fixes in the concurrency substrate: a shutdown race on the completion flag, a misleading drain message on named-thread unregistration, a silent fallback when `Named` affinity is used without an id, and a doc/impl divergence on `ThreadAffinity::Dedicated`. Plus a minor MSVC warning clean-up in the graph hasher.

## Changes

### `shutdown()` no longer races on its own completion flag

`src/threading/defaultthreadmanager.cpp`

`shutdown()` is documented as safe to call from any thread. The completion guard `_impl->shutdownCompleted` was a plain `bool`, read + written without synchronization by racing callers — a data race that TSAN would observe on the threading manager's own shutdown path. The member is now `std::atomic<bool>`, and the early-return double-check is replaced by a single `compare_exchange_strong` so only the first caller runs the teardown and every concurrent / subsequent caller returns immediately. The redundant trailing store after the teardown is dropped.

### `drainStoppedQueue()` parametrised with a reason string

`src/threading/defaultthreadmanager.cpp`

The helper ran from two paths — `shutdown()` and `unregisterNamedThread()` — but always settled pending handles with `"threading: manager shut down"`. That was a lie from the unregister path: a task queued on a named thread that the caller later unregisters was reported as a shutdown casualty, pointing anyone debugging a hung task at the wrong cause.

The helper now takes the reason as a `const char *`. Shutdown call sites pass `"threading: manager shut down"`; the unregister path passes `"threading: named thread unregistered"`.

### `schedule(..., Named)` without an id is no longer silent

`src/threading/defaultthreadmanager.cpp`

The generic `schedule(runnable, affinity)` API has no way to carry a `NamedThreadId`, so a `Named` affinity on that entry point is always a caller bug. Previously the path quietly diverted to the pool, which made the bug invisible. The failure is now loud: the handle settles with an error `Result` naming the missing id and pointing at the correct entry point (`scheduleOnNamed(runnable, id)`).

### `ThreadAffinity::Dedicated` / `Named` doc rollback

`include/vigine/threading/threadaffinity.h`

`Dedicated` was documented as "one-per-caller dedicated thread with FIFO queue". The shipped implementation allocates a fresh OS thread per schedule call; the caller-keyed FIFO-reuse (bounded by `ThreadManagerConfig::maxDedicatedThreads`) is on the backlog. The doc now states that plainly and points callers that need predictable per-caller FIFO at `scheduleOnNamed`. `Named`'s doc also notes that the generic `schedule()` path rejects it.

### Bonus: silence MSVC `C4702 unreachable code` in `nodeid_hasher.h`

`src/graph/nodeid_hasher.h`

The 32-bit fallback after the `if constexpr` is unreachable on 64-bit platforms (where `std::size_t` is at least 64 bits). Wrapping the branch in a matching `else` silences the warning without behaviour change.

## Test plan

- [x] `cmake --build build --config Debug --target vigine` → clean.
- [x] `cmake --build build --config Debug --target graph-contract` → clean.
- [x] `build/bin/Debug/graph-contract.exe` → 78 / 78 passing.
- [x] Every facade smoke suite (actorhost / channelfactory / messaging / payload / pipelinebuilder / reactivestream / topicbus) runs green locally.
- [ ] CI matrix on push.

### Known flaky, pre-existing

Two `eventscheduler-smoke` cases fail identically on unmodified `main`: `OneShotTimerFiresOnce` and `OsSignalTriggersDelivery`. They time out at `count() == 0` vs expected `1` — classic `sleep_for`-based timer races on Windows. Already tracked in the sanitizer-matrix `continue-on-error` configuration; outside this PR's scope.

## Notes

Part of #168 (post-shipment follow-up backlog). Four more items drained from the threading cluster; the stream continues on the same branch.
