### PR TITLE
Tighten payload + graph public contracts and drop two over-specified tests (#168)

### DIFF
--- a/include/vigine/graph/igraph.h
+++ b/include/vigine/graph/igraph.h
@@ -82,7 +82,15 @@ class IGraph
     [[nodiscard]] virtual EdgeId addEdge(std::unique_ptr<IEdge> edge) = 0;
 
     /**
-     * @brief Removes the edge addressed by @p id. Idempotent.
+     * @brief Removes the edge addressed by @p id.
+     *
+     * Symmetric with @ref removeNode: removing a stale identifier
+     * reports a @ref Result::Code::Error status without side effects.
+     * On success returns a default-constructed (Success) @ref Result.
+     * Calling with the id of an edge that was already removed is a
+     * "stale identifier" case and therefore Errors, not a silent
+     * no-op — this makes the two remove surfaces behave identically
+     * and lets wrappers treat the outcome uniformly.
      */
     virtual Result removeEdge(EdgeId id) = 0;
 

--- a/include/vigine/payload/ipayloadregistry.h
+++ b/include/vigine/payload/ipayloadregistry.h
@@ -18,9 +18,10 @@ namespace vigine::payload
  * Reserved — see @ref payloadrange.h); application code registers
  * additional ranges at runtime before first use. Every registration is
  * validated against the current table: overlap with an already-registered
- * range is rejected with @ref Result::Code::DuplicatePayloadId; a request
- * outside the valid 32-bit window or straddling the Reserved/User gap is
- * rejected with @ref Result::Code::OutOfRange.
+ * range is rejected with @ref Result::Code::DuplicatePayloadId; an
+ * ill-formed range (`min > max`) or one that straddles the engine-bundled
+ * half (`[0, 0xFFFF]`) and the user half (`[0x10000, ...]`) is rejected
+ * with @ref Result::Code::OutOfRange.
  *
  * Thread-safety: implementations must be safe to call from any thread.
  * Mutating entry points take an exclusive lock on an internal
@@ -44,9 +45,11 @@ class IPayloadRegistry
      * Returns a success @ref Result when the range was installed cleanly.
      * Returns @ref Result::Code::DuplicatePayloadId when any identifier
      * in the requested range is already covered by another registration.
-     * Returns @ref Result::Code::OutOfRange when @p min > @p max, when
-     * the range crosses the Reserved/User gap, or when the range
-     * straddles the engine-bundled half and the user-registered half.
+     * Returns @ref Result::Code::OutOfRange when @p min > @p max or when
+     * the range straddles the engine-bundled half (`[0, 0xFFFF]`) and
+     * the user-registered half (`[0x10000, ...]`). The two halves meet
+     * at the 16-bit boundary — there is no unallocated "gap" between
+     * them.
      *
      * @p owner is copied; an empty @p owner is a programming error and
      * the call is rejected with @ref Result::Code::OutOfRange.

--- a/include/vigine/payload/payloadrange.h
+++ b/include/vigine/payload/payloadrange.h
@@ -30,10 +30,10 @@ namespace vigine::payload
  *     half is performed at runtime through
  *     @ref IPayloadRegistry::registerRange.
  *
- * The `0x8000..0xFFFF` range and the `0x10000` boundary are deliberately
- * disjoint: identifiers in `[0x10000 ..)` are legal user territory; the
- * small gap between the Reserved end and the User begin exists only
- * because the constants split naturally at the 16-bit boundary.
+ * `kReservedEnd = 0xFFFF` and `kUserBegin = 0x10000` are adjacent:
+ * the engine-bundled half covers `[0x0000 .. 0xFFFF]` and the user
+ * half starts immediately after at `0x10000`. There is no gap between
+ * them — the split is at the 16-bit boundary.
  */
 
 inline constexpr std::uint32_t kControlBegin   = 0x0000u;

--- a/include/vigine/payload/payloadtypeid.h
+++ b/include/vigine/payload/payloadtypeid.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
+#include <functional>
 
 namespace vigine::payload
 {
@@ -19,7 +21,11 @@ namespace vigine::payload
  * first use.
  *
  * The type is a plain aggregate: trivially copyable, comparable, and
- * usable as a key in ordered and hash-based associative containers.
+ * usable as a key in ordered and hash-based associative containers. A
+ * specialisation of @c std::hash is provided at the bottom of this
+ * header so that @c std::unordered_map and @c std::unordered_set accept
+ * @ref PayloadTypeId keys without requiring each caller to write their
+ * own hasher.
  */
 struct PayloadTypeId
 {
@@ -45,3 +51,17 @@ struct PayloadTypeId
 };
 
 } // namespace vigine::payload
+
+// std::hash specialisation — the doc-comment on PayloadTypeId advertises
+// hash-container usability; shipping the specialisation here keeps that
+// promise. Keyed off the wrapped uint32_t and delegated to the std::hash
+// for uint32_t so the quality matches the standard library's default.
+template <>
+struct std::hash<vigine::payload::PayloadTypeId>
+{
+    [[nodiscard]] std::size_t
+    operator()(vigine::payload::PayloadTypeId id) const noexcept
+    {
+        return std::hash<std::uint32_t>{}(id.value);
+    }
+};

--- a/test/graph/contract_traversal.cpp
+++ b/test/graph/contract_traversal.cpp
@@ -345,8 +345,12 @@ TEST_P(TraversalContract, TopologicalReportsErrorOnCycle)
     RecordingVisitor visitor;
     const Result     r = fixture.graph->traverse(
         fixture.nodes[SevenNodeFixture::A], TraverseMode::Topological, visitor);
+    // The public contract on topological traversal only specifies that
+    // a cycle produces an error Result. The exact message text is an
+    // implementation detail of DefaultGraph — a future concrete
+    // IGraph that reports "topological invariant broken" (or similar)
+    // is still spec-compliant.
     EXPECT_TRUE(r.isError());
-    EXPECT_NE(r.message().find("cycle"), std::string::npos);
 }
 
 // -----------------------------------------------------------------------------

--- a/test/graph/fixtures/graph_fixture_7n10e.h
+++ b/test/graph/fixtures/graph_fixture_7n10e.h
@@ -173,7 +173,15 @@ inline EdgeId addTestEdge(IGraph                   &graph,
     auto        rawEdge = std::make_unique<TestEdge>(from, to, kind, std::move(data));
     TestEdge   *raw     = rawEdge.get();
     const EdgeId id     = graph.addEdge(std::move(rawEdge));
-    raw->stampId(id);
+    // When `addEdge` rejects the endpoints (invalid ids, impl-specific
+    // cycle check, etc.) the moved-in unique_ptr has already been
+    // destroyed by the implementation, which means `raw` now dangles.
+    // Only stamp the id when the graph accepted the edge; negative-path
+    // tests need this guard to avoid use-after-free.
+    if (id.valid())
+    {
+        raw->stampId(id);
+    }
     return id;
 }
 

--- a/test/payload/smoke_test.cpp
+++ b/test/payload/smoke_test.cpp
@@ -35,8 +35,9 @@ TEST(DefaultPayloadRegistrySmoke, EngineRangesPreRegisteredAtBootstrap)
     EXPECT_TRUE(registry->isRegistered(PayloadTypeId{kReservedBegin}));
     EXPECT_TRUE(registry->isRegistered(PayloadTypeId{kReservedEnd}));
 
-    // Identifiers above the Reserved end but below kUserBegin fall in
-    // the gap and must stay unregistered.
+    // `kUserBegin` (0x10000) is the first identifier in the user half
+    // of the split. Until the application registers a range that
+    // covers it, it reports as not-registered.
     EXPECT_FALSE(registry->isRegistered(PayloadTypeId{kUserBegin}));
 
     const auto owner = registry->resolve(PayloadTypeId{kControlBegin});


### PR DESCRIPTION
## Summary

Five small contract-tightening fixes across the payload API, the graph public interface, and the graph contract-suite fixtures.

## Changes

### `std::hash<PayloadTypeId>` specialisation ships with the header

`include/vigine/payload/payloadtypeid.h`

The `PayloadTypeId` doc-comment has always advertised hash-container usability, but no specialisation of `std::hash` was provided — every caller had to write their own or the code refused to compile. The specialisation at the bottom of the header keyes off the wrapped `uint32_t` and delegates to `std::hash<uint32_t>` so the quality matches the standard library default.

### Payload-registry doc drops unrepresentable edge cases

`include/vigine/payload/ipayloadregistry.h`, `include/vigine/payload/payloadrange.h`, `test/payload/smoke_test.cpp`

Two wording issues:

- "Outside the valid 32-bit window" is impossible — `PayloadTypeId::value` is `uint32_t` by definition, so every representable value IS in the 32-bit window.
- "Straddling the Reserved/User gap" is impossible — `kReservedEnd = 0xFFFF` and `kUserBegin = 0x10000` are adjacent. The split is at the 16-bit boundary; there is no unallocated gap between them.

The headers now describe the split plainly: engine half `[0, 0xFFFF]`, user half `[0x10000, ...)`, meeting at the boundary. The real `OutOfRange` trigger (a range that straddles the two halves, e.g. `min = 0x8000` with `max = 0x20000`) stays documented. The smoke-test comment next to `isRegistered(PayloadTypeId{kUserBegin})` is reworded to describe the actual semantic ("first id in the user half, not yet registered") instead of the non-existent gap.

### Test fixture guards its raw-pointer back-stamp

`test/graph/fixtures/graph_fixture_7n10e.h`

`addTestEdge` captured a raw `TestEdge *` before moving the `unique_ptr` into `graph.addEdge` and unconditionally called `raw->stampId(id)` afterwards. When `addEdge` rejects the endpoints (invalid ids, impl-specific cycle checks) the moved-in unique_ptr is destroyed and `raw` dangles — the stamp is a use-after-free. May pass on the happy path but any negative-path test the suite grows on top would crash. The fixture now stamps only when the returned `EdgeId` is `valid()`.

### `IGraph::removeEdge` doc aligned with `removeNode`

`include/vigine/graph/igraph.h`

`removeNode` explicitly documents "stale id returns `Result::Code::Error`". `removeEdge` only said "Idempotent", which left the stale-id outcome unspecified. The contract test has asserted the Error shape since the suite landed, so the doc was the lagging side. The two remove surfaces now behave identically per the public contract; wrappers can treat node-remove and edge-remove outcomes uniformly.

### Traversal contract test drops the exact "cycle" substring check

`test/graph/contract_traversal.cpp`

The cycle-detection test asserted `r.message().find("cycle") != npos`. The public contract specifies only that a topological walk over a cycle yields an error `Result`; the "cycle detected" wording is a DefaultGraph implementation detail. Assertion relaxed to `EXPECT_TRUE(r.isError())` with a comment noting that the message is impl-specific. A future concrete IGraph that uses different phrasing must still pass the suite.

## Test plan

- [x] `cmake --build build --config Debug --target vigine graph-contract payload-smoke` → clean.
- [x] `build/bin/Debug/graph-contract.exe` → 78 / 78 passing.
- [x] `build/bin/Debug/payload-smoke.exe` → 9 / 9 passing.
- [ ] CI matrix on push.

## Notes

Part of #168 (post-shipment follow-up backlog). Five more items drained; the stream continues on the same branch.
