### PR TITLE
Hypergraph sketch: namespace, signatures, lifetime, and edge contract fixes (#168)

### DIFF
--- a/doc/hypergraph_v1_1_sketch.md
+++ b/doc/hypergraph_v1_1_sketch.md
@@ -46,17 +46,23 @@ Names, parameter types, and return conventions may change before the
 first real implementation leaf.
 
 ```cpp
-// include/vigine/hypergraph/IHyperGraph.h  (v1.1+, does not exist yet)
+// include/vigine/hypergraph/ihypergraph.h  (v1.1+, does not exist yet)
 
-namespace vigine {
+namespace vigine::hypergraph {
 
 class IHyperGraph {
 public:
     virtual ~IHyperGraph() = default;
 
-    // Register an IGraph instance as a node in the meta-graph.
-    // Returns an opaque HyperNodeId; caller retains ownership of graph.
-    virtual HyperNodeId registerWrapper(IGraph* graph, std::string_view label) = 0;
+    // Register an IGraph instance as a node in the meta-graph. Returns
+    // an opaque HyperNodeId; caller retains ownership of the graph.
+    //
+    // Lifetime: the caller guarantees the passed `IGraph` outlives its
+    // hypergraph registration. Call `unregisterWrapper(id)` before
+    // destroying the wrapped graph, otherwise meta-edges that reference
+    // the freed graph become dangling.
+    virtual HyperNodeId registerWrapper(vigine::graph::IGraph *graph,
+                                        std::string_view       label) = 0;
 
     // Add a directed meta-edge between two wrapper nodes.
     virtual HyperEdgeId link(HyperNodeId from, HyperNodeId to) = 0;
@@ -64,18 +70,21 @@ public:
     // Remove a previously registered wrapper and all its meta-edges.
     virtual void unregisterWrapper(HyperNodeId id) = 0;
 
-    // Export the entire meta-graph in Graphviz DOT format.
-    virtual std::string exportGraphViz() const = 0;
+    // Export the entire meta-graph in Graphviz DOT format. The signature
+    // matches `vigine::graph::IGraph::exportGraphViz` — caller-owned
+    // buffer, Result error path, no I/O on the interface.
+    virtual vigine::Result exportGraphViz(std::string &out) const = 0;
 
-    // Return all cycle paths in the meta-graph (depth-first).
-    // Each inner vector is one cycle expressed as a sequence of HyperNodeIds.
+    // Return all cycle paths in the meta-graph (depth-first). Each inner
+    // vector is one cycle expressed as a sequence of HyperNodeIds.
     virtual std::vector<std::vector<HyperNodeId>> findCycles() const = 0;
 
     // Iterate registered wrapper nodes.
-    virtual void forEachWrapper(std::function<void(HyperNodeId, IGraph*)> fn) const = 0;
+    virtual void forEachWrapper(
+        std::function<void(HyperNodeId, vigine::graph::IGraph *)> fn) const = 0;
 };
 
-} // namespace vigine
+} // namespace vigine::hypergraph
 ```
 
 The engine would expose `IHyperGraph` through `Context` or a dedicated
@@ -115,7 +124,7 @@ Key design invariants:
 |--------|------|
 | Ownership | `IHyperGraph` does **not** own the `IGraph` instances it references. Ownership stays with the wrapper. |
 | Node granularity | One `IGraph` = one `HyperNode`. Sub-graph groupings within a single `IGraph` are not exposed at the meta-level. |
-| Edge semantics | A `HyperEdge` records a directed dependency between wrappers (e.g., "W1 consumes output from W2"). Its meaning is caller-defined; `IHyperGraph` does not interpret it. |
+| Edge semantics | A `HyperEdge` records a directed dependency between wrappers (e.g., "W1 consumes output from W2"). Meta-tools such as `findCycles()` and the cascade-delete motivating use cases DO interpret it — all edges are treated as dependency edges for ordering and reachability. Callers that want to attach additional payload (a reason string, a tag) can do so through a caller-defined sidecar map keyed on `HyperEdgeId`; the interface itself stays narrow. Edge labels, weights, or non-dependency semantics are out of scope for v1.1; they would land in a later revision. |
 | Concurrency | Not specified in this sketch; left for Q-HG4. |
 
 The plain `IGraph` interface is **unchanged**. An `IGraph` has no
@@ -169,9 +178,11 @@ abstraction and avoids introducing a separate adjacency-list
 implementation.
 
 For deeper background on why this design was deferred and what
-alternatives were considered, see
-[theory/theory_hypergraph_future.md](../theory/theory_hypergraph_future.md)
-(forthcoming artefact; will be created during the v1.1 analysis phase).
+alternatives were considered, see the analysis artefact that will
+accompany the first v1.1 implementation leaf. (Previous revisions of
+this doc linked at a path in a separate repository; that cross-repo
+link has been removed — the background document will live alongside
+the implementation inside this engine tree when it lands.)
 
 ---
 


### PR DESCRIPTION
## Summary

Five doc-level alignment fixes in the forward-looking hypergraph API sketch so the v1.1 implementer does not inherit contradictions, broken references, or pattern drift from sibling APIs before a line of real code ships.

## Changes

### Namespace qualification

`doc/hypergraph_v1_1_sketch.md`

The sketch nested `IHyperGraph` under `namespace vigine` and referenced `IGraph` unqualified. The shipped `IGraph` lives in `namespace vigine::graph`. A reference-quality sketch that pins the wrong namespace costs the future implementer a round of renames. Sketch now sits in `namespace vigine::hypergraph` with every cross-reference fully qualified (`vigine::graph::IGraph`, `vigine::Result`).

### `exportGraphViz()` signature matches `vigine::graph::IGraph`

Was `virtual std::string exportGraphViz() const = 0;`. The shipped `IGraph` pattern is `Result exportGraphViz(std::string &out) const` — caller-owned buffer, unified `Result` error path, no I/O on the interface. Two DOT-export shapes on sibling APIs would confuse maintenance; the sketch now adopts the same pattern.

### `registerWrapper` lifetime rule documented

The function takes a raw `IGraph *` with ownership staying at the caller. The sketch said nothing about the passed graph's lifetime. Lifetime contracts on raw-pointer parameters must be explicit — the first non-trivial consumer would hit dangling pointers without it. Added a one-sentence rule: the wrapped graph must outlive its registration until `unregisterWrapper(id)` or destruction of the hypergraph.

### Edge-semantics contradiction resolved

The invariant table said `HyperEdge` meaning is entirely caller-defined and `IHyperGraph` does not interpret it. Yet cascade-delete and dependency-ordering — the motivating use cases at the top of the document — require interpretation. The invariant now says edges are dependency edges for the purpose of cycle detection and cascade propagation; additional edge payload lives in a caller-defined sidecar map keyed on `HyperEdgeId`. Edge labels, weights, and non-dependency semantics are out of scope for v1.1; they would land in a later revision.

### Cross-repo theory link removed

The doc linked `../theory/theory_hypergraph_future.md`, a path that does not exist in this repo. The analysis artefact previously lived in a separate orchestration repo. Broken cross-repo links in shipped docs are confusing and leak non-engine structure into engine-repo content. The reference now states that the background document will land alongside the first v1.1 implementation leaf inside this tree.

## Test plan

Doc-only change; no build or test impact. Mermaid diagram + heading anchors preserved.

## Notes

Part of #168 (post-shipment follow-up backlog). Five more items drained; the stream continues on the same branch.
