### PR TITLE
Fix message-channel contract divergences and sync-primitive factory doc (#168)

### DIFF
--- a/include/vigine/threading/abstractthreadmanager.h
+++ b/include/vigine/threading/abstractthreadmanager.h
@@ -65,11 +65,16 @@ class AbstractThreadManager : public IThreadManager
     // ------ IThreadManager: sync primitive factories (shared impl) ------
 
     /**
-     * @brief Default @ref IMutex factory returning a @c std::mutex
+     * @brief Default @ref IMutex factory returning a @c std::timed_mutex
      *        wrapper.
      *
-     * Derived classes override only when they need a different concrete
-     * mutex (for example a sanitiser-instrumented one).
+     * @c std::timed_mutex is chosen over plain @c std::mutex so that
+     * @ref IMutex::lockFor honours finite timeouts through
+     * @c std::timed_mutex::try_lock_for without the wrapper faking a
+     * busy-wait. Infinite timeouts forward to
+     * @c std::timed_mutex::lock. Derived classes override only when
+     * they need a different concrete mutex (for example a sanitiser-
+     * instrumented one).
      */
     [[nodiscard]] std::unique_ptr<IMutex> createMutex() override;
 

--- a/include/vigine/threading/imessagechannel.h
+++ b/include/vigine/threading/imessagechannel.h
@@ -92,12 +92,20 @@ class IMessageChannel
      * @brief Sends a message, blocking up to @p timeout when the channel
      *        is full.
      *
-     * Transfers ownership of @p message into the channel on success.
+     * `Message` is move-only, so callers invoke
+     * `channel.send(std::move(msg))`. Ownership transfers into the
+     * parameter before the function body runs; the original variable is
+     * in a valid-but-unspecified moved-from state immediately after the
+     * call returns, regardless of outcome.
+     *
      * Returns a successful @ref Result when the message was queued.
      * Returns an error @ref Result when @p timeout elapses before space
-     * becomes available, or when the channel is closed. On failure the
-     * caller retains ownership through @p message (the implementation
-     * leaves the buffer intact on the caller side).
+     * becomes available, or when the channel is closed. The moved-from
+     * `Message` on the caller side is NOT restored on failure — callers
+     * that need retry semantics must reconstruct the message before
+     * calling again. For the "inspect failure and retry with the same
+     * payload" pattern, prefer @ref trySend, which takes a reference
+     * and leaves ownership with the caller when it returns false.
      */
     [[nodiscard]] virtual Result send(Message message, std::chrono::milliseconds timeout = std::chrono::milliseconds::max()) = 0;
 

--- a/src/threading/defaultmessagechannel.cpp
+++ b/src/threading/defaultmessagechannel.cpp
@@ -79,12 +79,17 @@ Result DefaultMessageChannel::receive(Message &out, std::chrono::milliseconds ti
     }
     else if (!_notEmpty.wait_for(lock, timeout, predicate))
     {
+        // Contract: on failure @p out is left default-constructed so
+        // callers looping with a shared Message variable do not see
+        // stale data from a previous receive.
+        out = Message{};
         return Result{Result::Code::Error, "threading: channel receive timeout"};
     }
 
     if (_queue.empty())
     {
-        // Closed and empty — final-drain path.
+        // Closed and empty — final-drain path. Reset @p out per contract.
+        out = Message{};
         return Result{Result::Code::Error, "threading: channel closed"};
     }
 


### PR DESCRIPTION
## Summary

Three doc + impl fixes across the messaging + sync-primitive surfaces: `IMessageChannel::send` ownership wording, `DefaultMessageChannel::receive` stale-data leak, and the `AbstractThreadManager::createMutex` factory doc.

## Changes

### `IMessageChannel::send` doc no longer promises move-semantics it can't deliver

`include/vigine/threading/imessagechannel.h`

`Message` is move-only, so callers invoke `channel.send(std::move(msg))`. Ownership transfers into the parameter before the function body runs; the old wording "on failure the caller retains ownership through `@p message` / the buffer is left intact on the caller side" is unachievable. API users who acted on it found a moved-from `Message` after a failed send.

The doc now states the truth: the caller's moved-from `Message` is in a valid-but-unspecified state after the call regardless of outcome, and callers that want inspect-and-retry semantics should prefer `trySend`, which takes a reference and leaves ownership with the caller when it returns false.

### `DefaultMessageChannel::receive` honours its public reset-on-failure contract

`src/threading/defaultmessagechannel.cpp`

`IMessageChannel::receive`'s interface contract says "on timeout or close-with-no-queued-messages, `@p out` is left default-constructed". The implementation returned an error without resetting `out`, which leaked stale data across calls in the common `while (receive(msg)) ...` loop pattern. Both error-return paths now do `out = Message{};` before returning the error `Result`.

### `AbstractThreadManager::createMutex` doc matches the impl

`include/vigine/threading/abstractthreadmanager.h`

The doc said the default factory returns a `std::mutex` wrapper; the shipped implementation wraps `std::timed_mutex`. The wrapper picked `timed_mutex` so `IMutex::lockFor` can honour finite timeouts via `try_lock_for` without faking a busy-wait. The doc is now accurate, with a sentence explaining the choice so anyone overriding the factory understands the baseline contract they inherit.

## Test plan

- [x] `cmake --build build --config Debug --target vigine messaging-smoke` → clean.
- [x] `build/bin/Debug/messaging-smoke.exe` → 8 / 8 passing.
- [ ] CI matrix on push.

The new `receive()` reset path executes on the exact branches the existing suite does not currently exercise for stale-data specifically; the tightening is preventative, blocking a class of bugs the current tests would not have caught.

## Notes

Part of #168 (post-shipment follow-up backlog). Three more items drained; the stream continues on the same branch.
