### PR TITLE
Check payload-registry bootstrap Result; drop broad catch(...); fix DedicatedSlot comment (#168)

### DIFF
--- a/src/payload/abstractpayloadregistry.cpp
+++ b/src/payload/abstractpayloadregistry.cpp
@@ -5,6 +5,7 @@
 #include <mutex>
 #include <optional>
 #include <shared_mutex>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -54,10 +55,30 @@ void AbstractPayloadRegistry::bootstrapEngineRanges()
     // Runs on the constructing thread before the instance is handed
     // out, so no locking is needed. The helper still goes through
     // registerRangeLocked so every invariant check lives in one place.
-    static_cast<void>(registerRangeLocked(kControlBegin, kControlEnd, kEngineOwner));
-    static_cast<void>(registerRangeLocked(kSystemBegin, kSystemEnd, kEngineOwner));
-    static_cast<void>(registerRangeLocked(kSystemExtBegin, kSystemExtEnd, kEngineOwner));
-    static_cast<void>(registerRangeLocked(kReservedBegin, kReservedEnd, kEngineOwner));
+    //
+    // Results MUST be checked. The engine-range constants are adjacent,
+    // non-overlapping, and sit inside the engine half by construction,
+    // so these calls cannot fail under a valid configuration — but
+    // that is exactly why a silent failure would be disastrous. If a
+    // future change drifts the constants (e.g. `kSystemExtEnd >=
+    // kReservedBegin`) the registry would ship with engine ranges
+    // missing and every later `registerRange()` that lands inside
+    // those ranges would succeed where it should have failed. Escalate
+    // through `std::logic_error` so the registry construction halts
+    // deterministically with a locatable stack trace, rather than
+    // leaving the engine in a broken-invariant state.
+    const auto check = [](const Result &r, const char *label) {
+        if (!r.isSuccess())
+        {
+            throw std::logic_error(
+                std::string{"payload: engine bootstrap failed for "} +
+                label + " range: " + std::string{r.message()});
+        }
+    };
+    check(registerRangeLocked(kControlBegin,   kControlEnd,   kEngineOwner), "Control");
+    check(registerRangeLocked(kSystemBegin,    kSystemEnd,    kEngineOwner), "System");
+    check(registerRangeLocked(kSystemExtBegin, kSystemExtEnd, kEngineOwner), "SystemExt");
+    check(registerRangeLocked(kReservedBegin,  kReservedEnd,  kEngineOwner), "Reserved");
 }
 
 Result AbstractPayloadRegistry::registerRange(PayloadTypeId    min,
@@ -119,18 +140,16 @@ std::optional<std::string>
 
 bool AbstractPayloadRegistry::isRegistered(PayloadTypeId id) const noexcept
 {
-    try
-    {
-        std::shared_lock<std::shared_mutex> lock(_mutex);
-        return findContainingLocked(id.value) != nullptr;
-    }
-    catch (...)
-    {
-        // Honouring the noexcept surface on the pure-virtual: a failed
-        // shared-lock acquisition translates to a conservative "not
-        // registered" answer rather than a crash.
-        return false;
-    }
+    // `noexcept` by contract — if the shared-lock construction or any
+    // downstream call somehow throws (std::bad_alloc from an exotic
+    // allocator, a custom-mutex deadlock trap, etc.) the runtime
+    // translates the escape into `std::terminate` per the standard.
+    // That is loud and locatable. The previous `catch(...)` branch
+    // turned every unexpected exception into a silent `false`, which
+    // collapsed real bugs into wrong answers the caller could not
+    // distinguish from a genuine "unregistered" result.
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    return findContainingLocked(id.value) != nullptr;
 }
 
 Result AbstractPayloadRegistry::unregister(std::string_view owner)

--- a/src/threading/defaultthreadmanager.cpp
+++ b/src/threading/defaultthreadmanager.cpp
@@ -278,11 +278,14 @@ struct DefaultThreadManager::Impl
     WorkQueue                pool;
     std::vector<std::thread> poolWorkers;
 
-    // Dedicated slots: lazy per-caller FIFO threads. Keyed by an opaque
-    // uintptr_t derived from the caller's IRunnable pointer class. For
-    // this leaf every Dedicated schedule gets its own slot, which is the
-    // simplest semantics that keeps FIFO intact per caller (the caller
-    // identity wiring via IContext is a later leaf).
+    // Dedicated slots: one fresh OS thread + one queue per schedule
+    // call. The slots live in an append-only vector — there is no
+    // caller-identity lookup yet, so the vector index is the only
+    // handle. The caller-keyed FIFO-reuse (with a cap from
+    // `ThreadManagerConfig::maxDedicatedThreads`) is deferred to a
+    // later leaf; until it lands, per-caller FIFO is achieved by
+    // reusing a single `NamedThreadId` through
+    // `scheduleOnNamed(runnable, id)` instead of `Dedicated`.
     struct DedicatedSlot
     {
         std::unique_ptr<WorkQueue> queue;


### PR DESCRIPTION
## Summary

Three correctness + doc fixes on the payload registry and the thread manager: a silently-dropped Result in the engine-range bootstrap, a broad `catch(...)` that masked real failures on `isRegistered()`, and a stale DedicatedSlot comment that described a keying scheme the shipped impl never had.

## Changes

### `bootstrapEngineRanges()` escalates inner failures

`src/payload/abstractpayloadregistry.cpp`

The bootstrap path called `registerRangeLocked(...)` four times and dropped every returned `Result`. Those calls are over hard-coded constants that cannot fail under a valid configuration — which is exactly why a silent failure would be devastating: if a future change drifts the constants (e.g. `kSystemExtEnd >= kReservedBegin`) the registry would ship with engine ranges missing, and every subsequent `registerRange()` landing inside those ranges would succeed where it should have failed.

The bootstrap now calls through a local `check(Result, const char *)` helper that throws `std::logic_error` carrying the failing range's label and the inner `Result::message()`. Construction halts deterministically with a locatable stack trace, rather than producing a broken-invariant registry.

### `isRegistered()` drops the `catch(...)` that hid real bugs

`src/payload/abstractpayloadregistry.cpp`

The noexcept contract on the pure-virtual already forbids exceptions escaping. The previous `catch(...) -> return false` path silently turned every unexpected exception (`bad_alloc` from an exotic allocator, a custom-mutex trap, etc.) into a wrong `"not registered"` answer the caller could not distinguish from a genuine absence.

The shared-lock now runs unguarded. Any escape is translated by the runtime into `std::terminate` per the noexcept spec — loud and locatable, which is the right failure mode for real bugs. The happy-path behaviour (`true` / `false` on the lookup) is unchanged.

### `DedicatedSlot` comment no longer describes an imaginary keying scheme

`src/threading/defaultthreadmanager.cpp`

The comment claimed `DedicatedSlot` is "keyed by an opaque uintptr_t derived from the caller's IRunnable pointer". The implementation uses an append-only vector with the index as the only handle — no caller-identity hash and no uintptr_t key exist. The comment now describes the actual fresh-per-schedule behaviour and points at `scheduleOnNamed(runnable, id)` for callers that need per-caller FIFO before the caller-keyed reuse lands.

## Test plan

- [x] `cmake --build build --config Debug --target vigine payload-smoke messaging-smoke` → clean.
- [x] `build/bin/Debug/payload-smoke.exe` → 9 / 9 passing.
- [x] `build/bin/Debug/messaging-smoke.exe` → 8 / 8 passing.
- [ ] CI matrix on push.

Impact scope: the bootstrap change is a hardening step on a path that currently always succeeds; a future constant drift would now be detected at construction time instead of silently propagating. The `isRegistered` change keeps the happy-path behaviour identical but removes a failure-masking branch. The DedicatedSlot comment change is doc-only.

## Notes

Part of #168 (post-shipment follow-up backlog). Three more items drained; the stream continues on the same branch.
