### PR TITLE
Make example-window resource lookup robust across cwd (#189)

### DIFF
--- a/example/window/CMakeLists.txt
+++ b/example/window/CMakeLists.txt
@@ -268,6 +268,17 @@ add_custom_command(TARGET ${PROJECT_WINDOW_NAME} POST_BUILD
     $<TARGET_FILE_DIR:${PROJECT_WINDOW_NAME}>/assets
 )
 
+# Mirror the engine-root `resource/` tree next to the exe so that
+# LoadTexturesTask finds `resource/img/` when the binary is launched
+# with its own directory as cwd. The task also walks cwd-relative
+# fallbacks, so this copy plus the fallbacks cover every common
+# launch path (engine root, exe dir, build/bin, build/bin/Release).
+add_custom_command(TARGET ${PROJECT_WINDOW_NAME} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+    ${CMAKE_SOURCE_DIR}/resource
+    $<TARGET_FILE_DIR:${PROJECT_WINDOW_NAME}>/resource
+)
+
 target_link_libraries(${PROJECT_WINDOW_NAME}
     PRIVATE
     vigine

--- a/example/window/task/vulkan/loadtexturestask.cpp
+++ b/example/window/task/vulkan/loadtexturestask.cpp
@@ -32,8 +32,6 @@ void LoadTexturesTask::contextChanged()
 
 vigine::Result LoadTexturesTask::execute()
 {
-    std::cout << "Loading textures from resource/img..." << std::endl;
-
     if (!_graphicsService)
     {
         return vigine::Result(vigine::Result::Code::Error, "Graphics service is unavailable");
@@ -41,13 +39,35 @@ vigine::Result LoadTexturesTask::execute()
 
     auto *entityManager = context()->entityManager();
 
-    // Scan resource/img/ for all supported image files
-    const std::filesystem::path imgDir{"resource/img"};
-    if (!std::filesystem::is_directory(imgDir))
+    // Try several candidate cwd-relative paths so the example works whether
+    // it is launched from the engine root, the exe directory (the build
+    // system post-build-copies `resource/` next to the exe), `build/bin/`,
+    // or `build/bin/Release/`. The first candidate that resolves to an
+    // existing directory wins. Matches the candidate-list pattern already
+    // used by SetupTextTask and SetupTextEditTask for `assets/fonts/`.
+    static constexpr const char *kImgCandidates[] = {
+        "resource/img",          // engine root, or exe dir (post-build copy)
+        "../resource/img",       // build/bin
+        "../../resource/img",    // build/bin/Release
+        "../../../resource/img", // deeper config layouts
+    };
+    std::filesystem::path imgDir;
+    for (const auto *candidate : kImgCandidates)
+    {
+        std::error_code ec;
+        if (std::filesystem::is_directory(candidate, ec))
+        {
+            imgDir = candidate;
+            break;
+        }
+    }
+    if (imgDir.empty())
     {
         return vigine::Result(vigine::Result::Code::Error,
                               "Image directory not found: resource/img");
     }
+
+    std::cout << "Loading textures from " << imgDir.string() << "..." << std::endl;
 
     std::vector<std::string> imagePaths;
     for (const auto &entry : std::filesystem::directory_iterator(imgDir))


### PR DESCRIPTION
## Summary

Fixes #189. `example-window` now opens its window regardless of the launch directory.

Before the fix, `LoadTexturesTask::execute` resolved a single relative path `resource/img` against the current working directory. Launching the binary from `build/bin/` or `build/bin/Release/` (the usual IDE launch path) missed the textures, the task returned `Result::Code::Error`, the state machine took the `init → error → work → close` edge in a few milliseconds, and the window appeared to never open.

## Changes

- `example/window/task/vulkan/loadtexturestask.cpp` walks a candidate list of relative paths and picks the first one that resolves to an existing directory — the same pattern `SetupTextTask` and `SetupTextEditTask` already use for `assets/fonts/`. The log line now reports the resolved path.
- `example/window/CMakeLists.txt` post-build-copies the engine-root `resource/` tree next to the exe, mirroring the existing `assets/` copy rule. With the copy in place, the first candidate wins even when cwd equals the exe directory.

## Test plan

Smoke tested from three working directories on Windows, VS 2026 Release build:

- `D:/work/project/CodeMap/external/Vigine/` (engine root) — hits the first candidate `resource/img`, window opens.
- `D:/work/project/CodeMap/external/Vigine/build/bin/` — hits `../../resource/img`, window opens.
- `D:/work/project/CodeMap/external/Vigine/build/bin/Release/` — hits the first candidate via the post-build copy, window opens.

Every run reaches `RunWindowTask::execute`, logs `[RunWindowTask] Showing window 1`, and keeps the process alive processing window events. No silent transition to `CloseState`.
