### PR TITLE
Plumb IThreadManager into legacy Engine's Context (#193)

### DIFF
--- a/example/window/main.cpp
+++ b/example/window/main.cpp
@@ -27,9 +27,10 @@
 #include <vigine/payload/payloadtypeid.h>
 #include <vigine/signalemitter/defaultsignalemitter.h>
 #include <vigine/signalemitter/isignalemitter.h>
-#include <vigine/threading/factory.h>
 #include <vigine/threading/ithreadmanager.h>
 #include <vigine/threading/threadaffinity.h>
+
+#include <vigine/context.h>
 
 #include <cassert>
 #include <memory>
@@ -38,10 +39,16 @@
 using namespace vigine;
 
 std::unique_ptr<TaskFlow> createInitTaskFlow(signalemitter::ISignalEmitter *signalEmitter,
+                                             Context *context,
                                              std::shared_ptr<TextEditState> textEditState,
                                              std::shared_ptr<TextEditorSystem> textEditorSystem)
 {
     auto taskFlow             = std::make_unique<TaskFlow>();
+    // Task flow needs the concrete legacy Context so its signal()
+    // non-Any branch can reach the engine-owned IThreadManager (see
+    // TaskFlow::signal and the accompanying code comment). The
+    // downcast happens once in main(); here we simply install it.
+    taskFlow->setContext(context);
 
     auto *initWindow          = taskFlow->addTask(std::make_unique<InitWindowTask>());
     auto *initVulkan          = taskFlow->addTask(std::make_unique<InitVulkanTask>());
@@ -69,24 +76,20 @@ std::unique_ptr<TaskFlow> createInitTaskFlow(signalemitter::ISignalEmitter *sign
     static_cast<void>(taskFlow->route(loadTextures, setupTexturedPlanes));
     static_cast<void>(taskFlow->route(setupTexturedPlanes, setupTextEdit));
     static_cast<void>(taskFlow->route(setupTextEdit, runWindow));
-    // ThreadAffinity::Any keeps the subscriber wired directly to the bus
-    // (no TaskFlow-side re-post through IThreadManager). The emitter is
-    // built with sharedBusConfig() below to signal architectural intent,
-    // but the current AbstractMessageBus::post implementation drains the
-    // Shared queue on the posting thread, so the handler actually lands
-    // on the Win32 pump thread today. A real cross-thread hop will land
-    // once the bus worker pump is wired in a later lifecycle change;
-    // until then callers who want a guaranteed hop must use a non-Any
-    // ThreadAffinity on TaskFlow::signal, which wires the subscription
-    // through IThreadManager::schedule. Pool affinity is not used here
-    // because the legacy vigine::Engine does not route IThreadManager
-    // into TaskFlow's context.
+    // Pool affinity wraps the subscriber in a scheduled-delivery adapter
+    // that hands the clone to IThreadManager::schedule. The engine's
+    // Context owns a real IThreadManager (Engine::Engine plumbs it on
+    // construction), so TaskFlow::signal can reach it through
+    // setContext(&engine.legacyContext()) called from main. Input
+    // handlers therefore run on a pool worker thread, off the Win32
+    // message pump thread, and clicking the window does not stall
+    // rendering if the handler grows heavier later.
     static_cast<void>(taskFlow->signal(runWindow, processInputEventTask,
                                        kMouseButtonDownPayloadTypeId,
-                                       threading::ThreadAffinity::Any));
+                                       threading::ThreadAffinity::Pool));
     static_cast<void>(taskFlow->signal(runWindow, processInputEventTask,
                                        kKeyDownPayloadTypeId,
-                                       threading::ThreadAffinity::Any));
+                                       threading::ThreadAffinity::Pool));
 
     taskFlow->changeCurrentTaskTo(initWindow);
 
@@ -109,10 +112,27 @@ std::unique_ptr<TaskFlow> createCloseTaskFlow() { return std::make_unique<TaskFl
 
 int main()
 {
-    // Thread manager owns the pool that drains the shared bus below. It
-    // must outlive the emitter and is declared before the Engine so its
-    // destructor runs last in the reverse-of-declaration order.
-    auto threadManager    = vigine::threading::createThreadManager();
+    // The engine owns the thread manager and wires it through its
+    // Context on construction. The signal emitter and the TaskFlow's
+    // non-Any signal path both reach into that single manager, so the
+    // pool bank is shared across the whole example.
+    Engine engine;
+
+    // Engine::state() returns IStateMachine&; downcast back to the
+    // concrete StateMachine for the rich state-machine API. The cast
+    // is temporary scaffolding that will disappear once addState /
+    // addTransition move onto the interface in a later change.
+    StateMachine *stMachine = dynamic_cast<StateMachine *>(&engine.state());
+    assert(stMachine != nullptr &&
+           "Engine::state() must be a concrete StateMachine until the "
+           "rich API lifts onto IStateMachine");
+
+    // Engine::context() returns IContext&; the task flow still takes
+    // the concrete legacy Context*, so downcast once here.
+    Context *legacyCtx = dynamic_cast<Context *>(&engine.context());
+    assert(legacyCtx != nullptr &&
+           "Engine::context() must be backed by the legacy Context until "
+           "the task flow migrates to the IContext surface");
 
     // Payload registry is stack-local for the example. Register the two
     // user-range payload ids used by the window input pipeline; the
@@ -128,21 +148,12 @@ int main()
 
     // Shared-pool bus so dispatch to ProcessInputEventTask::onMessage
     // lands on a pool worker, off the Win32 message pump thread. The
-    // TaskFlow::signal wiring below uses ThreadAffinity::Any; the
-    // cross-thread hop is provided by the bus policy, not by
-    // ScheduledDelivery.
+    // bus and the TaskFlow::signal non-Any scheduler both share the
+    // single IThreadManager that the engine plumbs through its
+    // Context — see TaskFlow::signal and Engine::Engine.
     auto signalEmitter    = vigine::signalemitter::createSignalEmitter(
-        *threadManager, vigine::signalemitter::sharedBusConfig());
-
-    Engine engine;
-    // Engine::state() now returns IStateMachine&; downcast back to the
-    // concrete StateMachine for the rich state-machine API. The cast
-    // is temporary scaffolding that will disappear once addState /
-    // addTransition move onto the interface in a later leaf.
-    StateMachine *stMachine = dynamic_cast<StateMachine *>(&engine.state());
-    assert(stMachine != nullptr &&
-           "Engine::state() must be a concrete StateMachine until the "
-           "rich API lifts onto IStateMachine");
+        engine.context().threadManager(),
+        vigine::signalemitter::sharedBusConfig());
 
     auto textEditState    = std::make_shared<TextEditState>();
     auto textEditorSystem = std::make_shared<TextEditorSystem>(textEditState);
@@ -158,7 +169,7 @@ int main()
     auto closePtr         = stMachine->addState(std::move(closeState));
 
     initPtr->setTaskFlow(
-        createInitTaskFlow(signalEmitter.get(), textEditState, textEditorSystem));
+        createInitTaskFlow(signalEmitter.get(), legacyCtx, textEditState, textEditorSystem));
     workPtr->setTaskFlow(createWorkTaskFlow());
     errorPtr->setTaskFlow(createErrorTaskFlow());
     closePtr->setTaskFlow(createCloseTaskFlow());

--- a/example/window/main.cpp
+++ b/example/window/main.cpp
@@ -79,11 +79,11 @@ std::unique_ptr<TaskFlow> createInitTaskFlow(signalemitter::ISignalEmitter *sign
     // Pool affinity wraps the subscriber in a scheduled-delivery adapter
     // that hands the clone to IThreadManager::schedule. The engine's
     // Context owns a real IThreadManager (Engine::Engine plumbs it on
-    // construction), so TaskFlow::signal can reach it through
-    // setContext(&engine.legacyContext()) called from main. Input
-    // handlers therefore run on a pool worker thread, off the Win32
-    // message pump thread, and clicking the window does not stall
-    // rendering if the handler grows heavier later.
+    // construction), and main() hands that concrete Context* into
+    // createInitTaskFlow, which installs it via taskFlow->setContext(context)
+    // above. Input handlers therefore run on a pool worker thread, off
+    // the Win32 message pump thread, and clicking the window does not
+    // stall rendering if the handler grows heavier later.
     static_cast<void>(taskFlow->signal(runWindow, processInputEventTask,
                                        kMouseButtonDownPayloadTypeId,
                                        threading::ThreadAffinity::Pool));

--- a/include/vigine/context.h
+++ b/include/vigine/context.h
@@ -13,6 +13,11 @@
 namespace vigine
 {
 
+namespace threading
+{
+class IThreadManager;
+} // namespace threading
+
 enum class Property;
 class EntityManager;
 
@@ -70,7 +75,7 @@ class Context : public IContext
     [[nodiscard]] bool isFrozen() const noexcept override;
 
   private:
-    Context(EntityManager *entityManager);
+    Context(EntityManager *entityManager, threading::IThreadManager *threadManager);
     AbstractServiceUPtr createService(const ServiceId &id, const Name &name);
     AbstractSystemUPtr createSystem(const SystemId &id, const SystemName &name);
 
@@ -78,6 +83,12 @@ class Context : public IContext
     std::unordered_map<ServiceId, ServiceInstancesContainer> _services;
     std::unordered_map<SystemId, SystemInstancesContainer> _systems;
     EntityManager *_entityManager{nullptr};
+    // Non-owning pointer into the engine-owned IThreadManager. Set by
+    // Engine::Engine before any task-flow wiring runs; surfaced to
+    // callers through threadManager() so TaskFlow::signal's non-Any
+    // path and any other context-driven scheduling works on the
+    // legacy Engine front door.
+    threading::IThreadManager *_threadManager{nullptr};
     // Atomic because `isFrozen()` is documented as safe from any
     // thread and runs alongside lifecycle transitions. A plain bool
     // here would be a TSAN-observable data race even though the

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -11,7 +11,6 @@
 #include "vigine/messaging/imessagebus.h"
 #include "vigine/property.h"
 #include "vigine/result.h"
-#include "vigine/threading/ithreadmanager.h"
 #include "vigine/service/databaseservice.h"
 #include "vigine/service/graphicsservice.h"
 #include "vigine/service/iservice.h"

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -11,6 +11,7 @@
 #include "vigine/messaging/imessagebus.h"
 #include "vigine/property.h"
 #include "vigine/result.h"
+#include "vigine/threading/ithreadmanager.h"
 #include "vigine/service/databaseservice.h"
 #include "vigine/service/graphicsservice.h"
 #include "vigine/service/iservice.h"
@@ -59,7 +60,12 @@ vigine::AbstractSystem *vigine::Context::system(const SystemId id, const SystemN
     return retVal;
 }
 
-vigine::Context::Context(EntityManager *entityManager) { _entityManager = entityManager; }
+vigine::Context::Context(EntityManager            *entityManager,
+                         threading::IThreadManager *threadManager)
+{
+    _entityManager  = entityManager;
+    _threadManager  = threadManager;
+}
 
 // COPILOT_TODO: Додати фабричні гілки для всіх систем, що вже оголошені в API, зокрема Render;
 // зараз частина запитів через Context приречена на nullptr.
@@ -208,8 +214,13 @@ vigine::taskflow::ITaskFlow &vigine::Context::taskFlow()
 
 vigine::threading::IThreadManager &vigine::Context::threadManager()
 {
-    throw std::logic_error{
-        "legacy vigine::Context has no thread manager; use vigine::context::createContext"};
+    if (_threadManager == nullptr)
+    {
+        throw std::logic_error{
+            "legacy vigine::Context was built without a thread manager; "
+            "construct Engine via its default ctor so the thread manager is plumbed through"};
+    }
+    return *_threadManager;
 }
 
 std::shared_ptr<vigine::service::IService>

--- a/src/vigine.cpp
+++ b/src/vigine.cpp
@@ -3,6 +3,7 @@
 #include "vigine/context.h"
 #include "vigine/ecs/entitymanager.h"
 #include "vigine/statemachine.h"
+#include "vigine/threading/factory.h"
 #include "vigine/threading/ithreadmanager.h"
 
 namespace vigine
@@ -11,7 +12,8 @@ namespace vigine
 Engine::Engine()
 {
     _entityManager.reset(new EntityManager());
-    _context.reset(new Context(_entityManager.get()));
+    _threadManager = threading::createThreadManager();
+    _context.reset(new Context(_entityManager.get(), _threadManager.get()));
     _stateMachine.reset(new StateMachine(_context.get()));
 }
 

--- a/test/contract/scenario_01_engine_lifecycle.cpp
+++ b/test/contract/scenario_01_engine_lifecycle.cpp
@@ -17,6 +17,7 @@
 #include "vigine/statemachine/istatemachine.h"
 #include "vigine/taskflow/itaskflow.h"
 #include "vigine/threading/ithreadmanager.h"
+#include "vigine/vigine.h"
 
 #include <gtest/gtest.h>
 
@@ -73,6 +74,24 @@ TEST_F(EngineLifecycle, FreezeTogglesTopologyFlag)
     // Second freeze must be idempotent.
     ctx.freeze();
     EXPECT_TRUE(ctx.isFrozen());
+}
+
+// Legacy vigine::Engine front door: confirms the engine ctor plumbs a
+// real IThreadManager into its Context. Before the wiring change,
+// Context::threadManager threw std::logic_error, which silently broke
+// TaskFlow::signal's non-default-affinity path for every caller that
+// instantiated Engine directly.
+TEST(LegacyEngineLifecycle, ConstructionPlumbsThreadManagerIntoContext)
+{
+    vigine::Engine engine;
+
+    auto &ctx = engine.context();
+    ASSERT_NO_THROW({
+        auto &tm = ctx.threadManager();
+        EXPECT_GE(tm.poolSize(), 1u)
+            << "legacy engine must plumb a thread manager whose pool "
+            << "carries at least one worker";
+    });
 }
 
 } // namespace


### PR DESCRIPTION
## Summary

Closes #193. `vigine::Engine::Engine` now constructs an `IThreadManager` and hands it to the legacy `Context`, so `Context::threadManager` returns a usable reference instead of throwing. `TaskFlow::signal(..., ThreadAffinity::Pool)` (and any other non-default affinity) now works out of the box on the legacy engine front door; the example's mouse and key handlers run on a pool worker thread, off the Win32 message pump.

## What changes

- `include/vigine/context.h` + `src/context.cpp` — constructor gains an `IThreadManager*` parameter, stored in a new private member; `threadManager()` returns the stored reference, throwing only if the pointer is null (safety net for a future caller that skips the new argument).
- `src/vigine.cpp` — `Engine::Engine` calls `threading::createThreadManager()` and passes the pointer to the `Context` constructor before the state machine is built. Member declaration order in `include/vigine/vigine.h` is `_threadManager` → `_systemBus` → `_userBuses` → `_stateMachine` → `_context` → `_entityManager`; destruction proceeds in reverse, so `_context` (which holds a non-owning pointer into the thread manager) is destroyed before `_threadManager` goes away.
- `example/window/main.cpp` — drops the stack-local `createThreadManager` call; the emitter's bus reuses `engine.context().threadManager()` so the whole example shares a single pool. `engine.context()` is downcast once to `Context*` and handed to `TaskFlow::setContext` so the signal path can reach the manager. Both `taskFlow->signal` calls now ask for `ThreadAffinity::Pool`.
- `test/contract/scenario_01_engine_lifecycle.cpp` — adds a `LegacyEngineLifecycle` test that constructs `vigine::Engine` directly and asserts `engine.context().threadManager()` returns a usable reference (non-throw, pool size ≥ 1). Guards the legacy front door against a future regression.

## Acceptance

- `vigine`, `example-window`, and `full-contract` build clean with the Insiders VS 2026 toolchain.
- `full-contract` covers the new case; the suite stays green.
- `example-window.exe` opens the window, Vulkan initialises, textures load, the Win32 pump runs.
- `Context::threadManager` no longer throws when called through the legacy engine path.

## Review notes

Copilot PR review round 1 posted four findings; all addressed inline on this branch (duplicate include removed, stale comment rewritten, legacy-engine test added, this description corrected). All review threads marked resolved. Merge decision is deferred to the reviewer per the no-admin-merge-before-review rule.
