### PR TITLE
Route SubscriptionToken through IBusControlBlock (#195)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,6 +229,7 @@ set(HEADER
     ${INCLUDE_DIR}/vigine/messaging/messagekind.h
     ${INCLUDE_DIR}/vigine/messaging/routemode.h
     ${INCLUDE_DIR}/vigine/messaging/messagefilter.h
+    ${INCLUDE_DIR}/vigine/messaging/subscriptionslot.h
     ${INCLUDE_DIR}/vigine/messaging/imessagepayload.h
     ${INCLUDE_DIR}/vigine/messaging/imessage.h
     ${INCLUDE_DIR}/vigine/messaging/isubscriber.h

--- a/include/vigine/messaging/abstractmessagebus.h
+++ b/include/vigine/messaging/abstractmessagebus.h
@@ -7,19 +7,19 @@
 #include <deque>
 #include <memory>
 #include <mutex>
-#include <shared_mutex>
-#include <unordered_map>
 #include <vector>
 
 #include "vigine/graph/abstractgraph.h"  // INV-11 EXEMPTION: AbstractMessageBus inherits graph substrate for internal routing
 #include "vigine/messaging/busconfig.h"
 #include "vigine/messaging/busid.h"
 #include "vigine/messaging/connectionid.h"
+#include "vigine/messaging/ibuscontrolblock.h"
 #include "vigine/messaging/imessage.h"
 #include "vigine/messaging/imessagebus.h"
 #include "vigine/messaging/isubscriber.h"
 #include "vigine/messaging/isubscriptiontoken.h"
 #include "vigine/messaging/messagefilter.h"
+#include "vigine/messaging/subscriptionslot.h"
 #include "vigine/result.h"
 
 namespace vigine::threading
@@ -52,27 +52,27 @@ class DefaultBusControlBlock;
  * @ref BusConfig shape; they do not override behaviour.
  *
  * Ownership and lifetime:
- *   - The bus owns a @c std::shared_ptr<IBusControlBlock>. Every
- *     @ref ConnectionToken handed to a registered
- *     @ref AbstractMessageTarget holds a matching
- *     @c std::weak_ptr to the same control block. When the bus is
- *     destroyed first, the control block is marked dead and token
- *     destructors become safe no-ops. When a target is destroyed first,
- *     its tokens run @c unregisterTarget to keep the registry in sync.
- *   - Subscriptions are owned by the bus: @ref subscribe stores the
- *     caller-supplied raw pointer in the registry and returns a
- *     @c std::unique_ptr<ISubscriptionToken>. Dropping the token removes
- *     the registry entry.
+ *   - The bus owns a @c std::shared_ptr<IBusControlBlock>. The control
+ *     block carries BOTH the target (connection) registry and the
+ *     subscription registry. Every @ref ConnectionToken handed to a
+ *     registered @ref AbstractMessageTarget holds a
+ *     @c std::weak_ptr to the same block; every
+ *     @ref SubscriptionToken returned by @ref subscribe holds the same
+ *     kind of weak reference. When the bus is destroyed first, the
+ *     control block is marked dead and every outstanding token becomes
+ *     a safe no-op on destruction. When a subscriber or target is
+ *     destroyed first, its token drains its slot through the control
+ *     block so the bus's registries never see a dangling pointer.
  *   - The injected @ref vigine::threading::IThreadManager is referenced
  *     by pointer; the engine guarantees the manager outlives every bus
  *     it hands a reference to.
  *
  * Thread-safety: @ref post serialises against the queue mutex; the
- * dispatch worker drains the queue under the same mutex; the
- * subscription registry is read-heavy and so guarded by a
- * @c std::shared_mutex (writers take an exclusive lock; dispatch takes a
- * shared lock for the duration of its snapshot). The control block
- * carries its own @c std::shared_mutex for the target registry.
+ * dispatch worker drains the queue under the same mutex. Both
+ * registries live inside the control block, which owns its own
+ * @c std::shared_mutex per registry -- dispatch takes a shared lock for
+ * the duration of its snapshot; writers (register / unregister) take an
+ * exclusive lock for the entry update.
  *
  * Exception policy: subscriber exceptions are isolated at the dispatch
  * boundary and reported as @ref DispatchResult::Handled so the registry
@@ -118,63 +118,13 @@ class AbstractMessageBus
 
   private:
     // ------ Internal types ------
-
-    /// @brief Shared mutable state that survives slot value-copies.
-    ///
-    /// The dispatch path takes a VALUE snapshot of each `SubscriptionSlot`
-    /// before the bus releases its registry lock, so any object that must
-    /// remain the same instance across all copies lives behind a `shared_ptr`.
-    ///
-    /// `SlotState` implements both guarantees that `ISubscriptionToken`
-    /// advertises:
-    ///
-    ///   - FF-70 (per-subscriber serialisation): `deliverMutex` is held
-    ///     exclusively by `deliver()` for the full duration of `onMessage`,
-    ///     so no two dispatch threads can run `onMessage` concurrently for
-    ///     the same subscriber.
-    ///
-    ///   - FF-69 (dtor-blocks contract): `lifecycleMutex` is a
-    ///     `std::shared_mutex`.  `deliver()` acquires it in SHARED mode
-    ///     before calling `onMessage` and releases it after.
-    ///     `removeSubscription()` acquires it in EXCLUSIVE mode, which
-    ///     blocks until every concurrent `deliver()` holding a shared
-    ///     lock has returned.  A `cancelled` flag set under the exclusive
-    ///     lock prevents new `deliver()` calls (from snapshot copies that
-    ///     pre-date the erase) from firing `onMessage` after the token
-    ///     has been cancelled — they acquire the shared lock, see
-    ///     `cancelled == true`, and return `Pass` without calling
-    ///     `onMessage`.
-    struct SlotState
-    {
-        /// Serialises concurrent `onMessage` calls to the same subscriber.
-        std::mutex              deliverMutex;
-        /// Guards the slot's active lifetime; shared for dispatch, exclusive
-        /// for cancellation.  See class comment above.
-        std::shared_mutex       lifecycleMutex;
-        /// Set to `true` under the exclusive `lifecycleMutex` by
-        /// `removeSubscription()`.  `deliver()` checks this flag under the
-        /// shared lock and skips `onMessage` when true.
-        bool                    cancelled{false};
-    };
-
-    /// @brief One registry entry. Holds the raw subscriber pointer, the
-    ///        filter, a serial id stamped when the slot is created, and
-    ///        a shared per-slot `SlotState` that carries the delivery mutex
-    ///        and the lifecycle (dtor-blocks) shared_mutex.
-    ///
-    /// `slotState` is `shared_ptr`-owned on purpose: the dispatch path
-    /// takes a VALUE snapshot of each slot before the bus unlocks its
-    /// registry, and `std::mutex` / `std::shared_mutex` are not copyable.
-    /// Sharing through `shared_ptr` keeps every copy pointing at the same
-    /// live object, so both guarantees hold even through the snapshot path.
-    struct SubscriptionSlot
-    {
-        ISubscriber                  *subscriber{nullptr};
-        MessageFilter                 filter{};
-        std::uint64_t                 serial{0};
-        bool                          active{true};
-        std::shared_ptr<SlotState>    slotState;
-    };
+    //
+    // `SlotState` and `SubscriptionSlot` live in
+    // `vigine/messaging/subscriptionslot.h` — they are shared between
+    // the bus (which builds them inside `subscribe()` before handing them
+    // to the control block) and the control block (which owns the
+    // registry and hands snapshot copies back to dispatch). Their doc
+    // comments sit next to the definitions in that header.
 
     /// @brief Queue entry. Owns the envelope plus the scheduled-for
     ///        timestamp so that the worker can requeue delayed traffic
@@ -186,11 +136,26 @@ class AbstractMessageBus
     };
 
     /// @brief Concrete subscription token handed back to callers of
-    ///        @ref subscribe. Removes its registry slot on destruction.
+    ///        @ref subscribe.
+    ///
+    /// The token carries a @c std::weak_ptr to the bus's
+    /// @ref IBusControlBlock and the serial id that addresses its slot
+    /// inside the block's subscription registry. The raw bus pointer
+    /// the token used to hold has moved out entirely: the bus's
+    /// lifetime is no longer observed by the token, only the control
+    /// block's is. A cancel (explicit or through the destructor) locks
+    /// the weak_ptr; if the lock fails or @ref IBusControlBlock::isAlive
+    /// reports @c false, the cancel is a safe no-op. Otherwise the
+    /// token asks the block to unregister its slot, which drains every
+    /// in-flight dispatch on that slot before returning.
+    ///
+    /// This is the exact pattern @ref ConnectionToken uses for target
+    /// registrations; the symmetry is intentional.
     class SubscriptionToken final : public ISubscriptionToken
     {
       public:
-        SubscriptionToken(AbstractMessageBus *bus, std::uint64_t serial) noexcept;
+        SubscriptionToken(std::weak_ptr<IBusControlBlock> control,
+                          std::uint64_t                   serial) noexcept;
         ~SubscriptionToken() override;
 
         void               cancel() noexcept override;
@@ -202,9 +167,9 @@ class AbstractMessageBus
         SubscriptionToken &operator=(SubscriptionToken &&)      = delete;
 
       private:
-        AbstractMessageBus *_bus;
-        std::uint64_t       _serial;
-        std::atomic<bool>   _cancelled{false};
+        std::weak_ptr<IBusControlBlock> _control;
+        std::uint64_t                   _serial;
+        std::atomic<bool>               _cancelled{false};
     };
 
     friend class SubscriptionToken;
@@ -256,7 +221,10 @@ class AbstractMessageBus
     [[nodiscard]] static DispatchResult deliver(const SubscriptionSlot &slot,
                                                 const IMessage         &message) noexcept;
 
-    /// @brief Builds a snapshot of the registry under the shared lock.
+    /// @brief Builds a snapshot of the registry by delegating to the
+    ///        control block. Kept as a thin wrapper so the dispatch
+    ///        driver does not have to know the subscription registry
+    ///        lives one level down.
     [[nodiscard]] std::vector<SubscriptionSlot> snapshotRegistry() const;
 
     /// @brief Drains the queue. Returns when the queue is empty and
@@ -264,19 +232,18 @@ class AbstractMessageBus
     ///        single drain pass.
     void drainQueue(bool untilShutdown);
 
-    /// @brief Internal entry point used by the @ref SubscriptionToken
-    ///        destructor. Removes the matching slot if still present.
-    void removeSubscription(std::uint64_t serial) noexcept;
-
     // ------ State ------
 
     BusConfig                                      _config;
     vigine::threading::IThreadManager             *_threadManager;
+    // The control block owns BOTH registries: the connection (target)
+    // registry AND the subscription registry. The bus keeps this
+    // shared_ptr alive for the lifetime of the bus; every
+    // `ConnectionToken` and every `SubscriptionToken` holds a
+    // `weak_ptr` to the same block so that a bus destroyed before its
+    // tokens is observed as a dead block instead of a dangling bus
+    // pointer.
     std::shared_ptr<DefaultBusControlBlock>        _control;
-
-    mutable std::shared_mutex                      _registryMutex;
-    std::unordered_map<std::uint64_t, SubscriptionSlot> _subscriptions;
-    std::uint64_t                                  _nextSerial{1};
 
     mutable std::mutex                             _queueMutex;
     std::condition_variable                        _queueCv;

--- a/include/vigine/messaging/ibuscontrolblock.h
+++ b/include/vigine/messaging/ibuscontrolblock.h
@@ -1,23 +1,43 @@
 #pragma once
 
+#include <cstdint>
+#include <memory>
+#include <vector>
+
 #include "vigine/messaging/connectionid.h"
+#include "vigine/messaging/messagefilter.h"
+#include "vigine/messaging/subscriptionslot.h"
 
 namespace vigine::messaging
 {
 class AbstractMessageTarget;
+class ISubscriber;
 
 /**
  * @brief Pure-virtual shared-heap state owned jointly by a message bus
  *        and the connection tokens it hands out.
  *
  * @ref IBusControlBlock is the safety anchor that removes the
- * destruction-ordering hazard between an @ref IMessageBus and its
- * subscribers. The bus holds a @c std::shared_ptr to the control block
- * and every token holds a @c std::weak_ptr to the same block. When the
- * bus dies first, its destructor calls @ref markDead so that every still-
- * held token becomes a safe no-op on destruction; when a target dies
- * first, the token's destructor calls @ref unregisterTarget so that the
- * bus's registry never sees a dangling target pointer.
+ * destruction-ordering hazard between an @ref IMessageBus and the two
+ * kinds of handles it hands out: @ref ConnectionToken for registered
+ * @ref AbstractMessageTarget objects and
+ * @ref AbstractMessageBus::SubscriptionToken for subscribers. The bus
+ * holds a @c std::shared_ptr to the control block and every token holds
+ * a @c std::weak_ptr to the same block. When the bus dies first, its
+ * destructor calls @ref markDead so that every still-held token becomes
+ * a safe no-op on destruction; when a target or subscriber dies first,
+ * the token's destructor calls @ref unregisterTarget or
+ * @ref unregisterSubscription so the matching registry never sees a
+ * dangling pointer.
+ *
+ * The block carries BOTH registries: a target registry that resolves
+ * @ref ConnectionId values back to live @ref AbstractMessageTarget
+ * pointers for outbound dispatch, and a subscription registry that the
+ * bus snapshots on the dispatch hot path to reach subscribers. Keeping
+ * both inside the control block is how a token can erase its own entry
+ * without ever touching the bus pointer — which is what makes the
+ * bus-destroyed-first race safe for subscribers the same way it is for
+ * targets.
  *
  * Ownership and lifetime:
  *   - The control block outlives the bus exactly long enough for any
@@ -83,6 +103,67 @@ class IBusControlBlock
      * @ref ConnectionToken).
      */
     virtual void unregisterTarget(ConnectionId id) noexcept = 0;
+
+    /**
+     * @brief Registers a subscription slot and returns its serial id.
+     *
+     * Called by the message bus from inside
+     * @ref IMessageBus::subscribe. The control block assigns a
+     * monotonic, non-zero serial, stores a @ref SubscriptionSlot built
+     * from the arguments, and hands the serial back so the caller can
+     * pair it with a @c std::weak_ptr to this block inside the
+     * @ref ISubscriptionToken it returns to the user.
+     *
+     * The block stores @p subscriber as a raw, non-owning pointer; the
+     * caller (the bus) must guarantee that either the subscriber
+     * outlives its token or the token's destructor runs before the
+     * subscriber is freed -- the same invariant that
+     * @ref ISubscriptionToken's dtor-blocks contract provides.
+     *
+     * Returns @c 0 (the inert sentinel) when:
+     *   - the block is already dead (after @ref markDead),
+     *   - @p subscriber is @c nullptr, or
+     *   - @p slotState is empty.
+     *
+     * Tokens built with an inert serial become no-ops for every
+     * subsequent @ref ISubscriptionToken operation, so call sites do
+     * not need a separate @ref Result to signal failure.
+     */
+    [[nodiscard]] virtual std::uint64_t
+        registerSubscription(ISubscriber               *subscriber,
+                             MessageFilter              filter,
+                             std::shared_ptr<SlotState> slotState) = 0;
+
+    /**
+     * @brief Removes the subscription addressed by @p serial.
+     *
+     * Idempotent: unregistering an unknown serial, the inert serial
+     * (@c 0), or a serial on a dead bus is a no-op. On a live bus the
+     * entry is erased from the subscription registry AND the slot's
+     * @ref SlotState is driven through the exclusive @c lifecycleMutex
+     * so every still-in-flight dispatch drains before this call
+     * returns. Snapshot copies that have not yet entered the dispatch
+     * shared region observe the @c cancelled flag and skip
+     * @c onMessage.
+     *
+     * Called from @ref AbstractMessageBus::SubscriptionToken's cancel
+     * path after locking the @c weak_ptr on this block.
+     */
+    virtual void unregisterSubscription(std::uint64_t serial) noexcept = 0;
+
+    /**
+     * @brief Returns a value-copy of every active subscription slot.
+     *
+     * Called by the bus on the dispatch hot path. The copy is taken
+     * under an internal shared lock so a concurrent
+     * @ref registerSubscription or @ref unregisterSubscription does
+     * not trip the iteration. The snapshot's @c slotState pointers
+     * still refer to the live @ref SlotState objects, which is how the
+     * dispatch path reaches the per-slot @c deliverMutex and
+     * @c lifecycleMutex.
+     */
+    [[nodiscard]] virtual std::vector<SubscriptionSlot>
+        snapshotSubscriptions() const = 0;
 
     IBusControlBlock(const IBusControlBlock &)            = delete;
     IBusControlBlock &operator=(const IBusControlBlock &) = delete;

--- a/include/vigine/messaging/subscriptionslot.h
+++ b/include/vigine/messaging/subscriptionslot.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <atomic>
 #include <cstdint>
 #include <memory>
 #include <mutex>

--- a/include/vigine/messaging/subscriptionslot.h
+++ b/include/vigine/messaging/subscriptionslot.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+
+#include "vigine/messaging/messagefilter.h"
+
+namespace vigine::messaging
+{
+class ISubscriber;
+
+/**
+ * @brief Shared mutable per-slot state that survives value-copies of the
+ *        owning @ref SubscriptionSlot.
+ *
+ * The dispatch hot path takes a VALUE snapshot of each
+ * @ref SubscriptionSlot before the registry releases its lock, so any
+ * object that has to remain the same instance across every snapshot copy
+ * must live behind a @c std::shared_ptr. @ref SlotState is exactly that
+ * object: it carries the per-subscriber mutexes plus the cancellation
+ * flag that pair with the @ref ISubscriptionToken contract.
+ *
+ * Two guarantees ride on this struct:
+ *
+ *   - @b Per-subscriber @b serialisation. @c deliverMutex is held
+ *     exclusively by the dispatch path for the entire duration of the
+ *     subscriber's @c onMessage, so two dispatch threads racing the
+ *     registry can never interleave @c onMessage calls on the same
+ *     subscriber.
+ *
+ *   - @b Dtor-blocks @b contract. @c lifecycleMutex is a
+ *     @c std::shared_mutex. The dispatch path acquires it in SHARED
+ *     mode before calling @c onMessage and releases it after; the
+ *     unsubscribe path (@ref IBusControlBlock::unregisterSubscription)
+ *     acquires it in EXCLUSIVE mode, which blocks until every concurrent
+ *     shared-holder has returned. Once the exclusive lock is held,
+ *     @c cancelled is flipped to @c true so that snapshot copies still
+ *     waiting to enter the shared region observe the flag and skip
+ *     @c onMessage entirely. That is the use-after-free barrier for a
+ *     subscriber whose owner drops the token and then destroys the
+ *     subscriber right after the cancel returns.
+ *
+ * The struct is non-copyable and non-movable because the contained
+ * mutexes are neither. A lifetime share through @c std::shared_ptr is
+ * how snapshot copies all point at the same live object.
+ */
+struct SlotState
+{
+    /// Serialises concurrent @c onMessage calls to the same subscriber.
+    std::mutex        deliverMutex;
+    /// Guards the slot's active lifetime: shared for dispatch, exclusive
+    /// for cancellation. See class comment above.
+    std::shared_mutex lifecycleMutex;
+    /// Set to @c true under the exclusive @c lifecycleMutex by the
+    /// unsubscribe path. The dispatch path checks it under the shared
+    /// lock and skips @c onMessage when true.
+    bool              cancelled{false};
+
+    SlotState()                             = default;
+    ~SlotState()                            = default;
+    SlotState(const SlotState &)            = delete;
+    SlotState &operator=(const SlotState &) = delete;
+    SlotState(SlotState &&)                 = delete;
+    SlotState &operator=(SlotState &&)      = delete;
+};
+
+/**
+ * @brief One subscription registry entry.
+ *
+ * Holds the raw, non-owning subscriber pointer, the filter the caller
+ * supplied to @ref IMessageBus::subscribe, a bus-assigned serial id that
+ * addresses the slot inside the registry, and a shared @ref SlotState
+ * so every snapshot copy of the slot refers to the same mutexes and
+ * cancellation flag.
+ *
+ * @c slotState is @c shared_ptr-owned on purpose: the dispatch path
+ * takes a VALUE snapshot of each slot before the registry unlocks, and
+ * neither @c std::mutex nor @c std::shared_mutex is copyable. Sharing
+ * through @c shared_ptr keeps every copy pointing at the same live
+ * object, so the serialisation and dtor-blocks guarantees hold even
+ * through the snapshot path.
+ *
+ * The struct is a plain aggregate with value semantics: copying a slot
+ * copies the pointer, the filter, the serial, the active flag, and
+ * bumps the @c SlotState ref-count.
+ */
+struct SubscriptionSlot
+{
+    ISubscriber               *subscriber{nullptr};
+    MessageFilter              filter{};
+    std::uint64_t              serial{0};
+    bool                       active{true};
+    std::shared_ptr<SlotState> slotState;
+};
+
+} // namespace vigine::messaging

--- a/src/messaging/abstractmessagebus.cpp
+++ b/src/messaging/abstractmessagebus.cpp
@@ -27,16 +27,19 @@ namespace vigine::messaging
 // SubscriptionToken -- RAII handle returned from AbstractMessageBus::subscribe
 // ---------------------------------------------------------------------------
 
-AbstractMessageBus::SubscriptionToken::SubscriptionToken(AbstractMessageBus *bus,
-                                                         std::uint64_t       serial) noexcept
-    : _bus(bus)
+AbstractMessageBus::SubscriptionToken::SubscriptionToken(
+    std::weak_ptr<IBusControlBlock> control,
+    std::uint64_t                   serial) noexcept
+    : _control(std::move(control))
     , _serial(serial)
 {
 }
 
 AbstractMessageBus::SubscriptionToken::~SubscriptionToken()
 {
-    // Idempotent: the cancel path handles the dead-bus case cleanly.
+    // Idempotent: the cancel path handles both the dead-bus case
+    // (weak_ptr.lock() returns null, or isAlive() reports false) and
+    // the already-cancelled case (the atomic exchange short-circuits).
     cancel();
 }
 
@@ -46,25 +49,45 @@ void AbstractMessageBus::SubscriptionToken::cancel() noexcept
     {
         return;
     }
-    if (_bus != nullptr)
+    if (_serial == 0)
     {
-        _bus->removeSubscription(_serial);
+        // Inert token (built from a shutdown or rejected subscribe).
+        // No slot to reach; nothing to unregister.
+        return;
     }
+
+    // Lock the weak_ptr into a temporary shared_ptr for the duration of
+    // the call. That keeps the control block alive through the
+    // unregister even if the bus is racing through its own destructor
+    // on another thread: either we observe isAlive() == false and skip
+    // the call, or we observe it == true and the block is guaranteed
+    // to outlive our call because `block` here holds a shared
+    // reference.
+    if (auto block = _control.lock())
+    {
+        if (block->isAlive())
+        {
+            block->unregisterSubscription(_serial);
+        }
+    }
+    // weak_ptr.lock() == null or isAlive() == false: the bus is gone
+    // or going, the control block's destructor (or markDead + dtor on
+    // the map) reclaims the slot; nothing to do here.
 }
 
 bool AbstractMessageBus::SubscriptionToken::active() const noexcept
 {
     // Three-way conjunction, matching the header contract:
-    //   1. The token points at a real bus (inert tokens carry
-    //      _bus == nullptr and _serial == 0 and are never active).
+    //   1. The token points at a real slot (inert tokens carry
+    //      _serial == 0 and an empty _control; they are never active).
     //   2. The token has not been cancelled (RAII teardown or an
     //      explicit cancel() flipped the flag).
-    //   3. The bus itself has not been shut down. A bus that
-    //      finished its shutdown handshake marks every existing
-    //      subscription as inert; reporting active == true on a
-    //      shut-down bus would invite a caller to unsubscribe a
-    //      slot the bus no longer tracks.
-    if (_bus == nullptr || _serial == 0)
+    //   3. The control block is reachable AND alive. A bus that
+    //      finished its shutdown handshake has called markDead on the
+    //      block; reporting active == true in that state would invite
+    //      a caller to unsubscribe a slot the bus has stopped
+    //      dispatching to.
+    if (_serial == 0)
     {
         return false;
     }
@@ -72,7 +95,12 @@ bool AbstractMessageBus::SubscriptionToken::active() const noexcept
     {
         return false;
     }
-    return !_bus->_shutdown.load(std::memory_order_acquire);
+    auto block = _control.lock();
+    if (!block)
+    {
+        return false;
+    }
+    return block->isAlive();
 }
 
 // ---------------------------------------------------------------------------
@@ -310,73 +338,33 @@ AbstractMessageBus::subscribe(const MessageFilter &filter, ISubscriber *subscrib
         || !validKind(filter.kind))
     {
         // Inert token: active() always false, destructor is a no-op
-        // because the serial points at no live slot.
-        return std::make_unique<SubscriptionToken>(nullptr, 0);
+        // because the serial points at no live slot and the weak_ptr
+        // is empty.
+        return std::make_unique<SubscriptionToken>(
+            std::weak_ptr<IBusControlBlock>{}, 0);
     }
 
-    std::uint64_t serial = 0;
-    {
-        std::unique_lock<std::shared_mutex> lock{_registryMutex};
-        serial = _nextSerial++;
-        SubscriptionSlot slot{};
-        slot.subscriber  = subscriber;
-        slot.filter      = filter;
-        slot.serial      = serial;
-        slot.active      = true;
-        // One SlotState per slot, shared across every snapshot copy so
-        // the lifecycle mutex and delivery mutex remain the same object
-        // regardless of how many snapshot copies of this slot exist.
-        slot.slotState = std::make_shared<SlotState>();
-        _subscriptions.emplace(serial, std::move(slot));
-    }
+    // One SlotState per slot, shared across every snapshot copy so
+    // the lifecycle mutex and delivery mutex remain the same object
+    // regardless of how many snapshot copies of this slot exist.
+    auto slotState = std::make_shared<SlotState>();
 
-    return std::make_unique<SubscriptionToken>(this, serial);
-}
-
-void AbstractMessageBus::removeSubscription(std::uint64_t serial) noexcept
-{
+    // Delegate to the control block. It owns the subscription
+    // registry and assigns the serial under its own exclusive lock,
+    // so the bus does not need to maintain a parallel registry mutex.
+    // A zero serial back means the block refused the registration
+    // (subscriber null or block already dead); fall through to an
+    // inert token so the caller sees a token that is safe to drop.
+    const std::uint64_t serial =
+        _control->registerSubscription(subscriber, filter, std::move(slotState));
     if (serial == 0)
     {
-        return;
+        return std::make_unique<SubscriptionToken>(
+            std::weak_ptr<IBusControlBlock>{}, 0);
     }
 
-    // Capture the SlotState shared_ptr BEFORE erasing the registry slot
-    // so the lifecycle mutex survives the map removal.
-    std::shared_ptr<SlotState> state;
-    {
-        std::unique_lock<std::shared_mutex> lock{_registryMutex};
-        auto it = _subscriptions.find(serial);
-        if (it == _subscriptions.end())
-        {
-            return;
-        }
-        state = it->second.slotState;
-        _subscriptions.erase(it);
-    }
-
-    // --- Dtor-blocks contract (FF-69) ---
-    //
-    // After the registry erase above, no new snapshot will include this
-    // slot.  However, dispatch threads that already copied the slot into a
-    // snapshot (before our exclusive registry lock above) may still call
-    // `deliver()` and invoke `onMessage`.  We must not return until all
-    // such calls finish.
-    //
-    // Acquiring `lifecycleMutex` exclusively here blocks until every
-    // concurrent `deliver()` that holds a shared lock on `lifecycleMutex`
-    // has released it.  Once we hold the exclusive lock we set `cancelled`
-    // so that any snapshot copies still waiting to enter `deliver()` will
-    // check the flag, see it is true, and return without calling
-    // `onMessage`.  We then release the exclusive lock and return.
-    //
-    // `state` is null for inert tokens (serial == 0 path is caught above;
-    // this covers legacy bare-SubscriptionSlot test fixtures that skip
-    // `subscribe()`).
-    if (state)
-    {
-        std::unique_lock<std::shared_mutex> ex{state->lifecycleMutex};
-        state->cancelled = true;
-    }
+    return std::make_unique<SubscriptionToken>(
+        std::weak_ptr<IBusControlBlock>(_control), serial);
 }
 
 // ---------------------------------------------------------------------------
@@ -405,16 +393,25 @@ Result AbstractMessageBus::shutdown()
     // pick up the shutdown flag on their next loop iteration and exit.
     drainQueue(true);
 
-    // Clear the subscription registry so that subsequent subscribe
-    // calls return inert tokens and existing SubscriptionToken
-    // destructors find nothing to remove.
-    {
-        std::unique_lock<std::shared_mutex> lock{_registryMutex};
-        _subscriptions.clear();
-    }
-
-    // Mark the control block dead so any outstanding ConnectionToken
-    // destructors become safe no-ops.
+    // Mark the control block dead. This does three things:
+    //   1. Every outstanding ConnectionToken destructor becomes a safe
+    //      no-op (unchanged behaviour).
+    //   2. Every outstanding SubscriptionToken destructor becomes a
+    //      safe no-op too — tokens lock the weak_ptr, observe
+    //      isAlive() == false, and skip the unregister call.
+    //   3. Any subsequent `subscribe()` on this bus is short-circuited
+    //      earlier by the `_shutdown` flag check, but a truly
+    //      concurrent subscribe that already passed that check gets a
+    //      second refusal inside registerSubscription() via its own
+    //      alive re-check under the registry lock.
+    //
+    // The subscription registry itself is NOT cleared here — it is
+    // owned by the control block, and the block's destructor reclaims
+    // the whole map en masse once the bus drops its shared_ptr. Clearing
+    // under shutdown would be racing the dispatch snapshots that are
+    // still walking the current snapshot copies; we would gain nothing
+    // from it because nothing can reach into the registry after markDead
+    // (post() is shut, subscribe() is refused, tokens no-op).
     if (_control)
     {
         _control->markDead();
@@ -427,20 +424,19 @@ Result AbstractMessageBus::shutdown()
 // AbstractMessageBus -- dispatch helpers
 // ---------------------------------------------------------------------------
 
-std::vector<AbstractMessageBus::SubscriptionSlot>
+std::vector<SubscriptionSlot>
 AbstractMessageBus::snapshotRegistry() const
 {
-    std::vector<SubscriptionSlot> snapshot;
-    std::shared_lock<std::shared_mutex> lock{_registryMutex};
-    snapshot.reserve(_subscriptions.size());
-    for (const auto &entry : _subscriptions)
+    // Thin wrapper: the control block owns the subscription registry
+    // and does the locked copy. Keeping this method on the bus lets
+    // the dispatch driver call a bus-local name (via the class scope
+    // the dispatchFirstMatch / FanOut / Chain / Bubble / Broadcast
+    // helpers already use) without knowing the registry moved.
+    if (!_control)
     {
-        if (entry.second.active)
-        {
-            snapshot.push_back(entry.second);
-        }
+        return {};
     }
-    return snapshot;
+    return _control->snapshotSubscriptions();
 }
 
 void AbstractMessageBus::drainQueue(bool untilShutdown)
@@ -536,12 +532,12 @@ DispatchResult AbstractMessageBus::deliver(const SubscriptionSlot &slot,
     //   (one per subscriber slot in concurrent FanOut), so unrelated
     //   subscribers are not serialised against each other.
     //
-    //   `removeSubscription()` tries to acquire `lifecycleMutex` in
+    //   `IBusControlBlock::unregisterSubscription()` tries to acquire `lifecycleMutex` in
     //   EXCLUSIVE mode, which blocks until every shared holder has released.
     //   This is the dtor-blocks guarantee: `cancel()` / the token destructor
     //   cannot return while any `onMessage` call is still executing.
     //
-    //   After acquiring the exclusive lock, `removeSubscription()` sets
+    //   After acquiring the exclusive lock, `unregisterSubscription()` sets
     //   `cancelled = true` and releases.  Any subsequent `deliver()` call
     //   that acquires the shared lock after that point will see the flag and
     //   return Pass without calling `onMessage`, preventing use-after-free
@@ -559,7 +555,7 @@ DispatchResult AbstractMessageBus::deliver(const SubscriptionSlot &slot,
     //   same subscriber.  It is held for the full duration of `onMessage`
     //   while the shared `lifecycleMutex` lock is also held, so the nesting
     //   order is always: lifecycleMutex(shared) -> deliverMutex(exclusive).
-    //   `removeSubscription()` only ever acquires lifecycleMutex(exclusive)
+    //   `unregisterSubscription()` only ever acquires lifecycleMutex(exclusive)
     //   and never touches deliverMutex, so there is no lock-order inversion.
 
     std::shared_lock<std::shared_mutex> lifeLock;

--- a/src/messaging/ibuscontrolblock_default.cpp
+++ b/src/messaging/ibuscontrolblock_default.cpp
@@ -1,6 +1,9 @@
 #include "messaging/ibuscontrolblock_default.h"
 
 #include <mutex>
+#include <utility>
+
+#include "vigine/messaging/isubscriber.h"
 
 namespace vigine::messaging
 {
@@ -116,6 +119,120 @@ void DefaultBusControlBlock::unregisterTarget(ConnectionId id) noexcept
     _nextGenerationByIndex[id.index] = nextGen;
     _registry.erase(it);
     _freeIndices.push_back(id.index);
+}
+
+std::uint64_t DefaultBusControlBlock::registerSubscription(
+    ISubscriber               *subscriber,
+    MessageFilter              filter,
+    std::shared_ptr<SlotState> slotState)
+{
+    if (subscriber == nullptr)
+    {
+        return 0;
+    }
+    if (!slotState)
+    {
+        return 0;
+    }
+    if (!_alive.load(std::memory_order_acquire))
+    {
+        return 0;
+    }
+
+    std::unique_lock<std::shared_mutex> lock{_subscriptionRegistryMutex};
+
+    // Re-check under the lock: a concurrent markDead may have raced
+    // ahead between the fast-path read and the lock. Without the re-
+    // check a bus caught mid-shutdown could still hand out a serial
+    // that the bus's subscribe() wraps in a token, with no one left
+    // to drain it.
+    if (!_alive.load(std::memory_order_acquire))
+    {
+        return 0;
+    }
+
+    std::uint64_t serial = _nextSerial++;
+    // Wrap-around guard: serial 0 is the inert sentinel that the
+    // token path uses to short-circuit active() / cancel(). Skip it
+    // on overflow so the registry never emits it for a live slot.
+    if (serial == 0)
+    {
+        serial      = _nextSerial++;
+    }
+
+    SubscriptionSlot slot{};
+    slot.subscriber = subscriber;
+    slot.filter     = std::move(filter);
+    slot.serial     = serial;
+    slot.active     = true;
+    slot.slotState  = std::move(slotState);
+
+    _subscriptions.emplace(serial, std::move(slot));
+    return serial;
+}
+
+void DefaultBusControlBlock::unregisterSubscription(std::uint64_t serial) noexcept
+{
+    if (serial == 0)
+    {
+        return;
+    }
+    if (!_alive.load(std::memory_order_acquire))
+    {
+        // Fast-path after markDead: the control block's destructor
+        // reclaims the whole subscription map en masse. Running the
+        // per-slot drain here against a dead block is pointless —
+        // the bus is gone, no dispatcher can still be looking at
+        // these slots.
+        return;
+    }
+
+    // Capture the SlotState shared_ptr BEFORE erasing the registry
+    // entry so the lifecycle mutex survives the map removal. A
+    // snapshot copy still in flight through the dispatch path owns
+    // its own shared_ptr to the same SlotState; after this capture
+    // AND the erase, the lifecycle mutex below serialises against
+    // every such in-flight deliver() before we return — which is the
+    // dtor-blocks guarantee that the token contract advertises.
+    std::shared_ptr<SlotState> state;
+    {
+        std::unique_lock<std::shared_mutex> lock{_subscriptionRegistryMutex};
+        auto it = _subscriptions.find(serial);
+        if (it == _subscriptions.end())
+        {
+            return;
+        }
+        state = it->second.slotState;
+        _subscriptions.erase(it);
+    }
+
+    if (state)
+    {
+        // Acquire lifecycleMutex EXCLUSIVELY. Every concurrent
+        // deliver() holds it SHARED for the duration of onMessage, so
+        // the exclusive acquisition blocks until all of them have
+        // returned. Once we hold the lock we flip `cancelled` so that
+        // any snapshot copy still waiting to enter the shared region
+        // will observe the flag and skip onMessage without running
+        // the subscriber.
+        std::unique_lock<std::shared_mutex> ex{state->lifecycleMutex};
+        state->cancelled = true;
+    }
+}
+
+std::vector<SubscriptionSlot> DefaultBusControlBlock::snapshotSubscriptions() const
+{
+    std::vector<SubscriptionSlot>       snapshot;
+    std::shared_lock<std::shared_mutex> lock{_subscriptionRegistryMutex};
+    snapshot.reserve(_subscriptions.size());
+    for (const auto &entry : _subscriptions)
+    {
+        if (entry.second.active)
+        {
+            snapshot.push_back(entry.second);
+        }
+    }
+    return snapshot;
 }
 
 DefaultBusControlBlock::LookupGuard

--- a/src/messaging/ibuscontrolblock_default.h
+++ b/src/messaging/ibuscontrolblock_default.h
@@ -2,15 +2,20 @@
 
 #include <atomic>
 #include <cstdint>
+#include <memory>
 #include <shared_mutex>
 #include <unordered_map>
+#include <vector>
 
 #include "vigine/messaging/connectionid.h"
 #include "vigine/messaging/ibuscontrolblock.h"
+#include "vigine/messaging/messagefilter.h"
+#include "vigine/messaging/subscriptionslot.h"
 
 namespace vigine::messaging
 {
 class AbstractMessageTarget;
+class ISubscriber;
 
 /**
  * @brief Reference implementation of @ref IBusControlBlock used by the
@@ -41,6 +46,14 @@ class DefaultBusControlBlock final : public IBusControlBlock
     [[nodiscard]] ConnectionId
         allocateSlot(AbstractMessageTarget *target) override;
     void unregisterTarget(ConnectionId id) noexcept override;
+
+    [[nodiscard]] std::uint64_t
+        registerSubscription(ISubscriber               *subscriber,
+                             MessageFilter              filter,
+                             std::shared_ptr<SlotState> slotState) override;
+    void unregisterSubscription(std::uint64_t serial) noexcept override;
+    [[nodiscard]] std::vector<SubscriptionSlot>
+        snapshotSubscriptions() const override;
 
     /**
      * @brief RAII pair holding the registry's shared lock alongside
@@ -102,6 +115,18 @@ class DefaultBusControlBlock final : public IBusControlBlock
     std::vector<std::uint32_t>                       _freeIndices;
     std::unordered_map<std::uint32_t, std::uint32_t> _nextGenerationByIndex;
     std::atomic<bool>                             _alive{true};
+
+    // Subscription registry. Kept on the control block (not on the
+    // bus) so that `SubscriptionToken` can drop its slot by locking a
+    // `weak_ptr<IBusControlBlock>` exactly the way `ConnectionToken`
+    // drops target slots. A bus destroyed before its tokens observes
+    // the weak_ptr.lock() returning null (or isAlive() returning
+    // false when the block is still reachable through another shared
+    // owner) and the token becomes a no-op — no more reaching into a
+    // freed bus pointer.
+    mutable std::shared_mutex                           _subscriptionRegistryMutex;
+    std::unordered_map<std::uint64_t, SubscriptionSlot> _subscriptions;
+    std::uint64_t                                       _nextSerial{1};
 };
 
 } // namespace vigine::messaging

--- a/test/contract/scenario_03_messaging_bus.cpp
+++ b/test/contract/scenario_03_messaging_bus.cpp
@@ -92,5 +92,99 @@ TEST_F(MessagingRoundTrip, ShutdownRejectsSubsequentPost)
         << "post after shutdown must report an error Result";
 }
 
+// Pins the contract that a SubscriptionToken can safely outlive the bus
+// that produced it. The token holds a std::weak_ptr to the bus control
+// block (not a raw pointer to the bus itself), so when the bus is
+// destroyed first the token's cancel() path observes the locked weak_ptr
+// returning null and becomes a no-op instead of chasing a dangling bus
+// pointer into freed memory.
+//
+// The previous shape of the token stored the bus by raw pointer and
+// called bus->removeSubscription(serial) unconditionally from its
+// destructor; if the bus had already been freed (which is easy to
+// arrange when an emitter in the application layer is declared after
+// the engine that owns the bus), the call landed on freed memory and
+// locked on a stale registry mutex -- the close-window hang that
+// motivated this rework.
+TEST_F(MessagingRoundTrip, TokenOutlivesBusWithoutHangOrCrash)
+{
+    std::unique_ptr<vigine::messaging::ISubscriptionToken> token;
+
+    {
+        auto stack = makePrivateStack(/*inlineOnly=*/true);
+        ASSERT_TRUE(stack.valid());
+
+        CountingSubscriber subscriber{
+            vigine::messaging::DispatchResult::Handled};
+
+        vigine::messaging::MessageFilter filter{};
+        filter.kind   = vigine::messaging::MessageKind::Signal;
+        filter.typeId = vigine::payload::PayloadTypeId{0x10102u};
+
+        token = stack.bus().subscribe(filter, &subscriber);
+        ASSERT_NE(token, nullptr);
+        EXPECT_TRUE(token->active());
+
+        // Inner scope exit destroys `stack` (bus first, then thread
+        // manager) AND the `subscriber` local. `token` is held by the
+        // outer scope and survives. The bus's shared_ptr to the
+        // control block drops with the bus; since tokens hold only a
+        // weak_ptr, the control block destructs alongside the bus and
+        // the weak_ptr lock after this point returns null.
+    }
+
+    // The bus and its control block are gone. active() must report
+    // false (the weak_ptr lock returns null), and dropping the token
+    // must not chase a freed pointer.
+    EXPECT_FALSE(token->active())
+        << "token must report inactive once the bus is destroyed";
+
+    // The destructor running here is the original bug site: previously
+    // it called bus->removeSubscription() on a dangling pointer. Under
+    // the new design, cancel() locks the weak_ptr, sees it is empty,
+    // and returns without touching anything. Reaching the next line
+    // without a crash or a hang is the pass condition.
+    token.reset();
+    SUCCEED() << "SubscriptionToken destructor survived bus destruction";
+}
+
+// Pins the contract that a token whose bus has been shut down (but not
+// yet destroyed) also cancels cleanly. shutdown() calls markDead on the
+// control block, and active() observes that through the
+// IBusControlBlock::isAlive() check; the cancel path also short-
+// circuits on the same check, so no unregister call reaches the
+// already-drained registry.
+TEST_F(MessagingRoundTrip, TokenCancelAfterShutdownIsNoOp)
+{
+    auto stack = makePrivateStack(/*inlineOnly=*/true);
+    ASSERT_TRUE(stack.valid());
+    auto &bus = stack.bus();
+
+    CountingSubscriber subscriber{vigine::messaging::DispatchResult::Handled};
+
+    vigine::messaging::MessageFilter filter{};
+    filter.kind   = vigine::messaging::MessageKind::Signal;
+    filter.typeId = vigine::payload::PayloadTypeId{0x10103u};
+
+    auto token = bus.subscribe(filter, &subscriber);
+    ASSERT_NE(token, nullptr);
+    EXPECT_TRUE(token->active());
+
+    const vigine::Result shut = bus.shutdown();
+    EXPECT_TRUE(shut.isSuccess());
+
+    // After shutdown, active() must report false because the control
+    // block's alive flag is down.
+    EXPECT_FALSE(token->active())
+        << "token must report inactive after the bus is shut down";
+
+    // Dropping the token here runs cancel(); the cancel must take the
+    // dead-path (no unregister call) without touching the bus internal
+    // state. Reaching the line after the reset is the pass condition.
+    token.reset();
+    SUCCEED()
+        << "SubscriptionToken destructor survived bus shutdown before bus death";
+}
+
 } // namespace
 } // namespace vigine::contract

--- a/test/contract/scenario_03_messaging_bus.cpp
+++ b/test/contract/scenario_03_messaging_bus.cpp
@@ -125,12 +125,13 @@ TEST_F(MessagingRoundTrip, TokenOutlivesBusWithoutHangOrCrash)
         ASSERT_NE(token, nullptr);
         EXPECT_TRUE(token->active());
 
-        // Inner scope exit destroys `stack` (bus first, then thread
-        // manager) AND the `subscriber` local. `token` is held by the
-        // outer scope and survives. The bus's shared_ptr to the
-        // control block drops with the bus; since tokens hold only a
-        // weak_ptr, the control block destructs alongside the bus and
-        // the weak_ptr lock after this point returns null.
+        // Inner scope exit first destroys the `subscriber` local, then
+        // destroys `stack` (and with it the bus, then the thread
+        // manager). `token` is held by the outer scope and survives.
+        // The bus's shared_ptr to the control block drops with the
+        // bus; since tokens hold only a weak_ptr, the control block
+        // destructs alongside the bus and the weak_ptr lock after this
+        // point returns null.
     }
 
     // The bus and its control block are gone. active() must report


### PR DESCRIPTION
## Problem

`AbstractMessageBus::SubscriptionToken` held a raw `AbstractMessageBus *`
and called `bus->removeSubscription(serial)` unconditionally from its
destructor. If the bus was destroyed before the token -- which is
easy to arrange when an `ISignalEmitter` (or any other subscriber
holder) is declared after the engine that owns the bus -- cancel
chased a dangling bus pointer into freed memory and then spun on a
stale registry mutex. That is the close-window hang seen in the
example-window when the window task's subscriber outlived the bus.

`ConnectionToken` already solved the same destruction-order race for
target registrations by holding a `std::weak_ptr<IBusControlBlock>`;
subscriptions were the one surface still using a raw bus pointer.

## Change

Move the subscription registry onto `IBusControlBlock` alongside the
existing target registry, and give `SubscriptionToken` a
`std::weak_ptr<IBusControlBlock>`. `cancel()` now locks the weak_ptr,
checks `isAlive()`, and delegates `unregisterSubscription` to the
block. A bus destroyed first lets the block's shared count drop to
zero; the token's weak_ptr lock then returns null and the cancel
becomes a safe no-op. The shape mirrors
`ConnectionToken::~ConnectionToken` exactly.

`SlotState` and `SubscriptionSlot` move out of `AbstractMessageBus`
into `include/vigine/messaging/subscriptionslot.h` so both the bus
(register / snapshot) and the control block (storage / drain) can
see the types. The per-slot dtor-blocks drain
(`lifecycleMutex` exclusive lock + `cancelled` flag) migrates into
`DefaultBusControlBlock::unregisterSubscription` with the same
contract it had on the bus side.

`shutdown()` stops clearing the subscription map by hand -- `markDead`
on the control block is enough. The registry itself is reclaimed
when the block destructs after the bus drops its shared_ptr.

## Testing

Contract tests added to `test/contract/scenario_03_messaging_bus.cpp`:
- `TokenOutlivesBusWithoutHangOrCrash` -- inner-scope bus
  destruction while an outer-scope token is still alive; token cancel
  must not hang or chase freed memory.
- `TokenCancelAfterShutdownIsNoOp` -- shutdown flips the block alive
  flag and the token observes that on cancel without touching the
  drained registry.

Full `full-contract` suite runs green locally (VS Insiders cl.exe +
Ninja, Debug).

## Notes

- No behaviour change for the happy path (token destroyed before bus):
  the unregister still drains the per-slot lifecycle lock exactly
  the way `AbstractMessageBus::removeSubscription` did before.
- `AbstractMessageBus::snapshotRegistry()` is now a thin delegate to
  `_control->snapshotSubscriptions()`; routing TUs are unchanged.
- No API change in `ISubscriptionToken` / `IMessageBus`.

Closes #195.