### PR TITLE
Create core/api/impl folder skeleton (#199)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -735,6 +735,7 @@ if(NOT VIGINE_SANITIZER STREQUAL "")
 endif()
 
 # Include directories
+# Three-layer include/src layout: core/ + api/ + impl/ (R-Structure v0.1.0)
 target_include_directories(${PROJECT_NAME}
     PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include

--- a/cmake/VigineCompileOptions.cmake
+++ b/cmake/VigineCompileOptions.cmake
@@ -1,3 +1,4 @@
+# Three-layer include/src layout: core/ + api/ + impl/ (R-Structure v0.1.0)
 # VigineCompileOptions.cmake
 #
 # Central compile-option helper. Provides vigine_apply_compile_options()

--- a/include/vigine/api/.gitkeep
+++ b/include/vigine/api/.gitkeep
@@ -1,0 +1,4 @@
+Placeholder so Git keeps this directory.
+Three-layer public API: api/ holds the public surface (interfaces +
+factory entry points) consumers depend on. Source files land in
+follow-up PRs.

--- a/include/vigine/core/.gitkeep
+++ b/include/vigine/core/.gitkeep
@@ -1,0 +1,3 @@
+Placeholder so Git keeps this directory.
+Three-layer public API: core/ holds foundational domain types that
+do not depend on higher layers. Source files land in follow-up PRs.

--- a/include/vigine/impl/.gitkeep
+++ b/include/vigine/impl/.gitkeep
@@ -1,0 +1,4 @@
+Placeholder so Git keeps this directory.
+Three-layer public API: impl/ holds inline / template implementation
+details exposed to consumers but not part of the stable interface.
+Source files land in follow-up PRs.

--- a/src/api/.gitkeep
+++ b/src/api/.gitkeep
@@ -1,0 +1,2 @@
+Placeholder so Git keeps this directory.
+Mirrors include/vigine/api/. Source files land in follow-up PRs.

--- a/src/core/.gitkeep
+++ b/src/core/.gitkeep
@@ -1,0 +1,2 @@
+Placeholder so Git keeps this directory.
+Mirrors include/vigine/core/. Source files land in follow-up PRs.

--- a/src/impl/.gitkeep
+++ b/src/impl/.gitkeep
@@ -1,0 +1,2 @@
+Placeholder so Git keeps this directory.
+Mirrors include/vigine/impl/. Source files land in follow-up PRs.


### PR DESCRIPTION
## Summary

Prepares the three-layer source tree for v0.1.0 work on the Vigine engine.
Adds six empty directories (with `.gitkeep` placeholders) mirroring the
planned public / private split:

- `include/vigine/core/`, `include/vigine/api/`, `include/vigine/impl/`
- `src/core/`, `src/api/`, `src/impl/`

Also adds a one-line header comment to both `CMakeLists.txt` (above
`target_include_directories`) and `cmake/VigineCompileOptions.cmake`
documenting the three-layer intent. No source files move in this PR;
the existing `target_include_directories(... include)` entry already
resolves `<vigine/core/...>`, `<vigine/api/...>`, `<vigine/impl/...>`
once source headers land in follow-up PRs.

Pure scaffolding — zero behavioural change.

Related: #199, #197.

## Acceptance checks

- [x] `cmake -S . -B build` green on Windows (MSVC 18).
- [x] `cmake --build build --config Debug` green.
- [x] `ctest --test-dir build --output-on-failure` — 191/191 tests pass.
- [x] `ls include/vigine/{core,api,impl}` and `ls src/{core,api,impl}`
  return six directories, each containing one `.gitkeep`.
- [x] `grep -c "Three-layer" CMakeLists.txt` == 1.
- [x] `grep -c "Three-layer" cmake/VigineCompileOptions.cmake` == 1.

Linux and macOS coverage will be picked up by the umbrella branch's CI
matrix once the PR is green on Windows.