### PR TITLE
Add Doxygen @brief to base/ public headers (#209)

### DIFF
--- a/include/vigine/base/constant.h
+++ b/include/vigine/base/constant.h
@@ -1,6 +1,19 @@
 #pragma once
 
+/**
+ * @file constant.h
+ * @brief Engine-wide numeric constants used by the base layer.
+ */
+
 namespace vigine
 {
+/**
+ * @brief First numeric id reserved for user-defined types.
+ *
+ * Engine-owned type ids live in the closed range @c [0, UserType); ids at or
+ * above this value are free for downstream code to assign. The value is a
+ * compile-time constant so it can participate in template dispatch and
+ * @c switch labels without ODR concerns.
+ */
 constexpr int UserType = 256;
 }

--- a/include/vigine/base/function.h
+++ b/include/vigine/base/function.h
@@ -1,7 +1,25 @@
 #pragma once
 
+/**
+ * @file function.h
+ * @brief Small free helpers shared across the engine base layer.
+ */
+
 namespace vigine
 {
+/**
+ * @brief Static cast wrapper with named intent.
+ *
+ * Convenience helper that forwards its argument through a @c static_cast to
+ * the target type @c T. Using this helper instead of a raw cast preserves
+ * the call-site intent ("convert to T") and makes the conversion easy to
+ * grep for.
+ *
+ * @tparam T  Target type produced by the cast.
+ * @tparam T2 Source type deduced from the argument.
+ * @param  type Value to convert.
+ * @return The argument converted to @c T via @c static_cast.
+ */
 template <typename T, typename T2>
 T to(T2 type)
 {

--- a/include/vigine/base/info.h
+++ b/include/vigine/base/info.h
@@ -1,9 +1,21 @@
 #pragma once
 
+/**
+ * @file info.h
+ * @brief Compile-time build and platform introspection.
+ *
+ * All helpers in this header are @c constexpr so that downstream code can
+ * branch on build flavour (Debug/Release) and host platform (Windows/Linux/
+ * macOS) at compile time.
+ */
+
 namespace vigine
 {
 namespace info
 {
+/**
+ * @brief Build flavour the engine was compiled with.
+ */
 enum class BuildType
 {
     Unknown,
@@ -11,6 +23,14 @@ enum class BuildType
     Release
 };
 
+/**
+ * @brief Returns the @ref BuildType that matches the compile-time
+ *        @c BUILD_TYPE / @c DEBUG / @c RELEASE macros.
+ *
+ * Falls back to @c BuildType::Unknown when the macros are not recognised,
+ * keeping the helper total so call sites can rely on it in a @c constexpr
+ * context.
+ */
 [[nodiscard]] constexpr BuildType buildType()
 {
     if constexpr (BUILD_TYPE == DEBUG)
@@ -27,6 +47,9 @@ enum class BuildType
 
 namespace platform
 {
+/**
+ * @brief Host operating system family the translation unit is compiled for.
+ */
 enum class Type
 {
     Windows,
@@ -35,6 +58,10 @@ enum class Type
     Unknown
 };
 
+/**
+ * @brief Returns the platform @ref Type the current translation unit is
+ *        being compiled for, based on standard preprocessor macros.
+ */
 [[nodiscard]] constexpr Type currentPlatform()
 {
 #if defined(_WIN32) || defined(_WIN64)
@@ -48,10 +75,13 @@ enum class Type
 #endif
 }
 
+/** @brief @c true when the current platform is Windows. */
 [[nodiscard]] constexpr bool isWindows() { return currentPlatform() == Type::Windows; }
 
+/** @brief @c true when the current platform is Linux. */
 [[nodiscard]] constexpr bool isLinux() { return currentPlatform() == Type::Linux; }
 
+/** @brief @c true when the current platform is macOS. */
 [[nodiscard]] constexpr bool isMacOS() { return currentPlatform() == Type::MacOS; }
 
 } // namespace platform

--- a/include/vigine/base/macros.h
+++ b/include/vigine/base/macros.h
@@ -1,11 +1,38 @@
 #pragma once
 
+/**
+ * @file macros.h
+ * @brief Boilerplate-generating preprocessor macros used across the engine.
+ *
+ * Each macro expands into a fixed set of @c using aliases (and, for the
+ * smart-pointer variant, matching @c make_ helpers) so that individual
+ * headers stay short and the naming convention stays uniform. Macros are
+ * the only public symbols in this header.
+ */
+
+/**
+ * @brief Declares the canonical raw-pointer / reference alias set for
+ *        @p className.
+ *
+ * Expands to:
+ *   - @c classNamePtr  — non-const raw pointer.
+ *   - @c classNameCPtr — const raw pointer.
+ *   - @c classNameRef  — non-const reference.
+ *   - @c classNameCRef — const reference.
+ */
 #define BUILD_PTR(className)                                                                       \
     using className##Ptr  = className *;                                                           \
     using className##CPtr = const className *;                                                     \
     using className##Ref  = className &;                                                           \
     using className##CRef = const className &
 
+/**
+ * @brief Declares the canonical @c std::vector alias set for @p className.
+ *
+ * Covers vectors of values, raw pointers, @c std::unique_ptr, const raw
+ * pointers, references, and const references. Requires @c <vector> and
+ * @c <memory> to be included by the translation unit using the macro.
+ */
 #define BUILD_PTR_VECTOR_VECTOR(className)                                                         \
     using className##Vector     = std::vector<className>;                                          \
     using className##PtrVector  = std::vector<className *>;                                        \
@@ -14,6 +41,15 @@
     using className##RefVector  = std::vector<className &>;                                        \
     using className##CRefVector = std::vector<const className &>
 
+/**
+ * @brief Declares smart-pointer aliases plus matching factory helpers for
+ *        @p className.
+ *
+ * Expands to the @c classNameUPtr / @c classNameSPtr aliases and the
+ * @c make_classNameUPtr / @c make_classNameSPtr forwarding helpers that
+ * perfect-forward their arguments into @c std::make_unique and
+ * @c std::make_shared respectively.
+ */
 #define BUILD_SMART_PTR(className)                                                                 \
     using className##UPtr = std::unique_ptr<className>;                                            \
     using className##SPtr = std::shared_ptr<className>;                                            \
@@ -28,5 +64,12 @@
         return std::make_shared<className>(std::forward<Args>(args)...);                           \
     }
 
+/**
+ * @brief Declares the canonical owning-container alias for @p className.
+ *
+ * Expands to @c classNameUPtrContainer, a @c std::vector of
+ * @c std::unique_ptr<className>. Assumes @ref BUILD_SMART_PTR has already
+ * been expanded for the same class so that @c classNameUPtr exists.
+ */
 #define BUILD_SMART_PTR_CONTAINER(className)                                                       \
     using className##UPtrContainer = std::vector<className##UPtr>;

--- a/include/vigine/base/name.h
+++ b/include/vigine/base/name.h
@@ -1,10 +1,26 @@
 #pragma once
 
+/**
+ * @file name.h
+ * @brief Strongly-typed wrapper around @c std::string used for identifier-
+ *        like values (entity names, tags, keys).
+ */
+
 #include <string>
 #include <utility>
 
 namespace vigine
 {
+/**
+ * @brief Strongly-typed name value backed by @c std::string.
+ *
+ * @ref Name is a thin value wrapper whose sole purpose is to carry name-
+ * kind semantics through the type system: a function taking @c Name cannot
+ * be silently called with an arbitrary @c std::string. It supports the
+ * usual relational and equality comparisons against both @ref Name and
+ * @c std::string, and implicitly converts to @c const @c std::string& and
+ * @c const @c char* for read-only interop with legacy APIs.
+ */
 class Name
 {
   public:

--- a/include/vigine/base/password.h
+++ b/include/vigine/base/password.h
@@ -1,5 +1,11 @@
 #pragma once
 
+/**
+ * @file password.h
+ * @brief Strongly-typed wrapper around a password string with an optional
+ *        regex-based validation rule.
+ */
+
 #include "macros.h"
 
 #include <optional>
@@ -8,6 +14,19 @@
 
 namespace vigine
 {
+/**
+ * @brief Value type representing a user-supplied password.
+ *
+ * @ref Password carries a @c std::string payload with explicit-only
+ * construction so that arbitrary strings cannot be silently promoted to a
+ * password. An optional @c std::regex validation rule can be attached via
+ * @ref setValidationRule; @ref isValid then returns whether the current
+ * value matches the rule (or @c true when no rule has been set).
+ *
+ * Smart-pointer aliases (see @ref BUILD_SMART_PTR) are emitted alongside
+ * the class so call sites can use @c PasswordUPtr / @c PasswordSPtr
+ * without redeclaring them.
+ */
 class Password
 {
   public:


### PR DESCRIPTION
## Summary

Adds Doxygen documentation to every public header under `include/vigine/base/` that previously lacked a `@brief` tag. Each file now carries:

- A top-level `@file` / `@brief` block near the `#pragma once` line.
- A per-class / struct / enum / macro / free-function `@brief` line explaining the role of that declaration, with a short body paragraph where the intent is not obvious from the signature alone.

Edits are comment-only — no API, layout, namespace, or logic changes. Every declaration, signature, and whitespace style outside the new comment blocks is preserved byte-for-byte.

Refs #209. Part of #197.

## Files touched

- `include/vigine/base/constant.h` — documents the `UserType` id boundary.
- `include/vigine/base/function.h` — documents the `to<T>` static-cast helper.
- `include/vigine/base/info.h` — documents `BuildType`, `platform::Type` and the `constexpr` query helpers.
- `include/vigine/base/macros.h` — documents `BUILD_PTR`, `BUILD_PTR_VECTOR_VECTOR`, `BUILD_SMART_PTR` and `BUILD_SMART_PTR_CONTAINER`.
- `include/vigine/base/name.h` — documents the `Name` value wrapper.
- `include/vigine/base/password.h` — documents the `Password` value wrapper.

## Verification

- `grep -L "@brief" include/vigine/base/*.h` — output is empty (all headers covered).
- Build not exercised locally (cmake not in PATH on this worktree); comment-only changes inside Doxygen `/** */` blocks cannot affect compilation. CI on this PR confirms.