### PR TITLE
Add Doxygen @brief to postgres, service, and factory headers (#210)

### DIFF
--- a/include/vigine/channelfactory/factory.h
+++ b/include/vigine/channelfactory/factory.h
@@ -1,5 +1,15 @@
 #pragma once
 
+/**
+ * @file factory.h
+ * @brief Convenience re-export header for @c createChannelFactory.
+ *
+ * Lets callers include a single predictable header to obtain an
+ * owning @c std::unique_ptr<IChannelFactory> without naming the
+ * concrete @c DefaultChannelFactory type. The function itself is
+ * defined in @c src/channelfactory/factory.cpp.
+ */
+
 #include "vigine/channelfactory/defaultchannelfactory.h"
 
 // factory.h is a convenience header that re-exports createChannelFactory so

--- a/include/vigine/ecs/postgresql/column.h
+++ b/include/vigine/ecs/postgresql/column.h
@@ -1,5 +1,13 @@
 #pragma once
 
+/**
+ * @file column.h
+ * @brief Declares the @c Column value type describing a single
+ *        PostgreSQL table column (name, data type, and per-column
+ *        flags such as primary, unique, foreign key, generated,
+ *        default-null).
+ */
+
 #include "vigine/base/macros.h"
 #include "vigine/base/name.h"
 #include "vigine/ecs/postgresql/columntype.h"
@@ -10,6 +18,18 @@ namespace vigine
 {
 namespace postgresql
 {
+/**
+ * @brief Value object describing one column of a PostgreSQL table.
+ *
+ * Stores the column name, its @ref DataType, and the per-column
+ * flags the engine needs to emit DDL and to validate read / write
+ * paths: @c primary, @c unique, @c foreignKey, @c generated
+ * (identity), and @c nullByDefault. Columns are plain values: copy,
+ * move, and the default relational operators behave as expected.
+ * The string conversion operators and @ref str return the column
+ * name so a @c Column can stand in for a column identifier in query
+ * string builders.
+ */
 class Column
 {
   public:

--- a/include/vigine/ecs/postgresql/columntype.h
+++ b/include/vigine/ecs/postgresql/columntype.h
@@ -1,5 +1,17 @@
 #pragma once
 
+/**
+ * @file columntype.h
+ * @brief X-macro list and @c DataType enum declaring the PostgreSQL
+ *        column types the engine recognises.
+ *
+ * The @c VIGINE_POSTGRESQL_DATA_COLUMN_TYPE_LIST X-macro enumerates
+ * each supported column kind together with its C++ type; it is
+ * expanded below to generate the @c DataType enum and is reused
+ * elsewhere (see @c data.h) to drive the @c std::variant data
+ * payload and the @c DataTypeMap trait table.
+ */
+
 #include <cstdint>
 
 #define VIGINE_POSTGRESQL_DATA_COLUMN_TYPE_LIST                                                    \
@@ -13,11 +25,27 @@ namespace vigine
 {
 namespace postgresql
 {
+/**
+ * @brief Empty placeholder appended to the column-type @c std::variant
+ *        so the variant always has at least one default-constructible
+ *        alternative (needed when the X-macro list is otherwise empty
+ *        or when a value is not yet bound to a type).
+ */
 struct Void
 {
     constexpr bool operator==(const Void &) const noexcept { return true; }
 };
 
+/**
+ * @brief Closed enum of PostgreSQL column types supported by the
+ *        engine.
+ *
+ * @c NotRcognized is the sentinel returned when the engine cannot
+ * map a database-side type to one of the recognised kinds; the
+ * remaining enumerators are generated from
+ * @c VIGINE_POSTGRESQL_DATA_COLUMN_TYPE_LIST and mirror the C++
+ * types that the @c Data payload stores.
+ */
 enum class DataType
 {
     NotRcognized,

--- a/include/vigine/ecs/postgresql/connectiondata.h
+++ b/include/vigine/ecs/postgresql/connectiondata.h
@@ -1,5 +1,12 @@
 #pragma once
 
+/**
+ * @file connectiondata.h
+ * @brief Declares the @c ConnectionData value object that bundles the
+ *        PostgreSQL connection parameters (host, port, database name,
+ *        user name, password) handed to the @c PostgreSQLSystem.
+ */
+
 #include "vigine/base/macros.h"
 #include "vigine/base/name.h"
 #include "vigine/base/password.h"
@@ -13,6 +20,17 @@ namespace postgresql
 using Host = std::string;
 using Port = std::string;
 
+/**
+ * @brief Holds the parameters required to open a PostgreSQL
+ *        connection: host, port, database name, user name, and
+ *        password.
+ *
+ * Plain data container: fields are set via setters and read through
+ * matching accessors. The @c Password type (declared under
+ * @c vigine/base) wraps the secret so it is not printed accidentally.
+ * Owned by the @c DatabaseConfiguration that carries it into the
+ * @c PostgreSQLSystem at connect time.
+ */
 class ConnectionData
 {
   public:

--- a/include/vigine/ecs/postgresql/data.h
+++ b/include/vigine/ecs/postgresql/data.h
@@ -1,5 +1,12 @@
 #pragma once
 
+/**
+ * @file data.h
+ * @brief Declares @c Data (a type-tagged PostgreSQL cell value) along
+ *        with the @c DataTypeMap trait that maps a @ref DataType enum
+ *        to its concrete C++ representation.
+ */
+
 #include "vigine/base/info.h"
 #include "vigine/ecs/postgresql/columntype.h"
 
@@ -13,6 +20,16 @@ namespace vigine
 namespace postgresql
 {
 
+/**
+ * @brief Trait mapping a @ref DataType enumerator to the C++ type
+ *        that represents values of that kind.
+ *
+ * The primary template resolves to @c std::nullptr_t, acting as the
+ * "unmapped" sentinel. Specialisations for every entry of
+ * @c VIGINE_POSTGRESQL_DATA_COLUMN_TYPE_LIST are generated just
+ * below via an X-macro, so adding a new column type in one place
+ * automatically extends the trait.
+ */
 template <DataType>
 struct DataTypeMap
 {
@@ -29,6 +46,14 @@ struct DataTypeMap
 VIGINE_POSTGRESQL_DATA_COLUMN_TYPE_LIST
 #undef VIGINE_POSTGRESQL_DATA_X
 
+/**
+ * @brief Compile-time predicate: @c true when @p T appears in the
+ *        alternatives of the given @c std::variant, @c false
+ *        otherwise.
+ *
+ * Used by @ref Data::as to short-circuit to @c std::nullopt when a
+ * caller asks for a type that the @c Data variant cannot hold.
+ */
 template <typename T, typename Variant>
 struct isInVariant;
 
@@ -37,6 +62,19 @@ struct isInVariant<T, std::variant<Ts...>> : std::disjunction<std::is_same<T, Ts
 {
 };
 
+/**
+ * @brief Type-tagged cell value: stores one PostgreSQL datum together
+ *        with its @ref DataType, and exposes a typed accessor
+ *        @ref as<dataType> that returns @c std::optional of the
+ *        mapped C++ type.
+ *
+ * The payload is a @c std::variant covering every type listed by
+ * @c VIGINE_POSTGRESQL_DATA_COLUMN_TYPE_LIST plus the empty @c Void
+ * alternative. The tag (@ref type) records which @ref DataType the
+ * caller attached to the value. @ref as performs compile-time
+ * validation through @ref DataTypeMap and @ref isInVariant and
+ * returns @c std::nullopt for unmapped / unsupported kinds.
+ */
 class Data
 {
   public:
@@ -74,6 +112,14 @@ class Data
     DataType _type;
 };
 
+/**
+ * @brief Convenience subclass of @ref Data that forces the tag to
+ *        @c DataType::Text.
+ *
+ * Useful at call sites that build a @ref Data from a
+ * @c std::string-valued @c Data::Value and want to avoid repeating
+ * the @c DataType::Text tag.
+ */
 class TextData : public Data
 {
   public:

--- a/include/vigine/ecs/postgresql/databaseconfiguration.h
+++ b/include/vigine/ecs/postgresql/databaseconfiguration.h
@@ -1,5 +1,12 @@
 #pragma once
 
+/**
+ * @file databaseconfiguration.h
+ * @brief Declares the @c DatabaseConfiguration aggregate that couples
+ *        a list of expected @c Table definitions with the
+ *        @c ConnectionData needed to reach the PostgreSQL server.
+ */
+
 #include "vigine/base/macros.h"
 #include "vigine/ecs/postgresql/column.h"
 #include "vigine/ecs/postgresql/connectiondata.h"
@@ -11,6 +18,18 @@ namespace vigine
 {
 namespace postgresql
 {
+/**
+ * @brief Aggregate describing the database a @c PostgreSQLSystem
+ *        connects to.
+ *
+ * Carries two pieces: the owned @c ConnectionData (how to reach the
+ * server) and the list of @c Table definitions the engine expects to
+ * find (used by scheme-check and DDL-create paths). Ownership of the
+ * connection data is held through a @c std::unique_ptr; the table
+ * list is owned by value. The service that uses this configuration
+ * (see @c DatabaseService) is responsible for populating it before
+ * calling connect.
+ */
 class DatabaseConfiguration
 {
   public:

--- a/include/vigine/ecs/postgresql/postgresqlresult.h
+++ b/include/vigine/ecs/postgresql/postgresqlresult.h
@@ -1,5 +1,13 @@
 #pragma once
 
+/**
+ * @file postgresqlresult.h
+ * @brief Declares @c PostgreSQLResult, the engine-side view of a
+ *        @c pqxx::result: converts a driver-produced result set into
+ *        a sequence of @c Row values keyed by @c DataType-aware
+ *        column metadata.
+ */
+
 #include "vigine/ecs/postgresql/row.h"
 #include "vigine/result.h"
 
@@ -18,6 +26,19 @@ using ColumnName = Name;
 
 class PostgreSQLTypeConverter;
 
+/**
+ * @brief Query result wrapper: transforms a @c pqxx::result into a
+ *        vector of engine-side @c Row objects together with column
+ *        metadata (name, index, @c DataType).
+ *
+ * Constructed by @c PostgreSQLSystem after a successful query. Uses
+ * the supplied @c PostgreSQLTypeConverter to translate driver-side
+ * type oids into engine @c DataType values at build time so that
+ * subsequent row / column accesses are cheap. Inherits from
+ * @c vigine::Result so it flows through the engine's uniform result
+ * plumbing: a failed query returns a @c Result with an error payload
+ * and an empty row set.
+ */
 class PostgreSQLResult : public vigine::Result
 {
   public:

--- a/include/vigine/ecs/postgresql/postgresqlsystem.h
+++ b/include/vigine/ecs/postgresql/postgresqlsystem.h
@@ -1,5 +1,14 @@
 #pragma once
 
+/**
+ * @file postgresqlsystem.h
+ * @brief Declares @c PostgreSQLSystem, the ECS system that wraps the
+ *        @c libpqxx client: owns the database configuration and the
+ *        per-entity @c PostgreSQLComponent map, and exposes the
+ *        connect / schema-check / DDL / query entry points the
+ *        database service delegates to.
+ */
+
 #include "vigine/base/macros.h"
 #include "vigine/ecs/abstractsystem.h"
 #include "vigine/ecs/postgresql/postgresqlresult.h"
@@ -15,6 +24,19 @@ namespace postgresql
 class PostgreSQLComponent;
 class DatabaseConfiguration;
 
+/**
+ * @brief ECS system that talks to a PostgreSQL server through
+ *        @c libpqxx and exposes connect / schema / query operations.
+ *
+ * Hooks into the ECS lifecycle via @ref hasComponents,
+ * @ref createComponents, and @ref destroyComponents to track one
+ * @c PostgreSQLComponent per bound entity. The public engine API
+ * surfaces the database configuration aggregate
+ * (@ref dbConfiguration), connection bootstrap (@ref connect), schema
+ * validation (@ref checkTablesScheme), and table / query execution
+ * helpers. The @c DatabaseService is the usual client and keeps this
+ * system off the user-facing surface.
+ */
 class PostgreSQLSystem : public AbstractSystem
 {
   public:

--- a/include/vigine/ecs/postgresql/postgresqltypeconverter.h
+++ b/include/vigine/ecs/postgresql/postgresqltypeconverter.h
@@ -1,5 +1,12 @@
 #pragma once
 
+/**
+ * @file postgresqltypeconverter.h
+ * @brief Declares @c PostgreSQLTypeConverter, the lookup object that
+ *        maps PostgreSQL internal type oids (and their textual names)
+ *        to engine-side @c DataType values.
+ */
+
 #include "vigine/base/macros.h"
 #include "vigine/ecs/postgresql/columntype.h"
 
@@ -15,6 +22,18 @@ namespace postgresql
 using BDInternalType = int;
 using BDExternalType = std::string;
 
+/**
+ * @brief Bidirectional lookup between PostgreSQL type oids (and their
+ *        external textual names) and the engine's @ref DataType.
+ *
+ * Seeded at connect time by @c PostgreSQLSystem (it queries
+ * @c pg_type once and records the server-local oids because oids are
+ * not stable across installations). @ref toColumnType resolves an
+ * internal oid to a @c DataType, returning @c std::nullopt when the
+ * oid has no matching engine type. @ref pgExternalToVigineDataType
+ * performs the same mapping from the textual side and also records
+ * the resolved pair so subsequent oid lookups succeed.
+ */
 class PostgreSQLTypeConverter
 {
   public:

--- a/include/vigine/ecs/postgresql/query/querybuilder.h
+++ b/include/vigine/ecs/postgresql/query/querybuilder.h
@@ -1,5 +1,13 @@
 #pragma once
 
+/**
+ * @file querybuilder.h
+ * @brief Declares the @c QueryBuilder DSL for assembling PostgreSQL
+ *        statements (SELECT, WHERE / AND, JOIN / ON, GROUP BY,
+ *        ORDER BY, HAVING, LIMIT / OFFSET, INSERT INTO, SET) from a
+ *        chain of fluent calls that takes @c Data values directly.
+ */
+
 #include "vigine/base/macros.h"
 #include "vigine/ecs/postgresql/data.h"
 
@@ -22,6 +30,10 @@ namespace query
 {
 class QueryBuilder;
 
+/**
+ * @brief Comparison operator a caller passes to @ref QueryBuilder::SET
+ *        when expressing "column @c op value" fragments.
+ */
 enum class Operation
 {
     equal,
@@ -32,6 +44,19 @@ enum class Operation
     greater_equal
 };
 
+/**
+ * @brief Fluent builder that assembles a PostgreSQL statement out of
+ *        chained clause-shaped calls (@ref SELECT, @ref FROM,
+ *        @ref WHERE, @ref AND, @ref JOIN, @ref ORDER_BY,
+ *        @ref INSERT_INTO, and so on) and renders the final text
+ *        through @ref str.
+ *
+ * Clause methods append to an internal deque of fragments; @ref str
+ * joins the fragments. Value-bearing clauses accept a @ref Data and
+ * route it through @ref escape so callers do not build SQL strings
+ * by hand. @ref isQueryValid exposes a lightweight structural check
+ * intended for call-site sanity asserts, not full SQL validation.
+ */
 class QueryBuilder
 {
   public:

--- a/include/vigine/ecs/postgresql/row.h
+++ b/include/vigine/ecs/postgresql/row.h
@@ -1,5 +1,13 @@
 #pragma once
 
+/**
+ * @file row.h
+ * @brief Declares @c Row, the engine-side representation of a single
+ *        result or insert row: an ordered sequence of
+ *        (column-name, @c Data) pairs with index- and name-based
+ *        access.
+ */
+
 #include "vigine/base/macros.h"
 #include "vigine/ecs/postgresql/column.h"
 #include "vigine/ecs/postgresql/data.h"
@@ -14,6 +22,18 @@ namespace postgresql
 using ColumnName = vigine::Name;
 using ColumnData = std::pair<ColumnName, Data>;
 
+/**
+ * @brief One database row as an ordered list of
+ *        (@ref ColumnName, @ref Data) pairs, addressable by integer
+ *        index, by @c Column, or by column name.
+ *
+ * Rows are constructed by @c PostgreSQLResult when translating a
+ * @c pqxx::result into engine types, and by callers that assemble
+ * rows for insert paths via @ref set. Access helpers (@ref get,
+ * @ref operator[]) return the matching @c Data; name-based lookup is
+ * linear in the row width. The row has no notion of a schema; each
+ * entry carries its own column name so the row is self-describing.
+ */
 class Row
 {
   public:

--- a/include/vigine/ecs/postgresql/table.h
+++ b/include/vigine/ecs/postgresql/table.h
@@ -1,5 +1,12 @@
 #pragma once
 
+/**
+ * @file table.h
+ * @brief Declares @c Table, the value object describing a PostgreSQL
+ *        table (name, storage type, schema, and ordered column list)
+ *        used when the engine builds DDL or validates a live schema.
+ */
+
 #include "vigine/base/name.h"
 #include "vigine/ecs/postgresql/column.h"
 
@@ -10,9 +17,28 @@ namespace vigine
 {
 namespace postgresql
 {
+/**
+ * @brief Value object describing one PostgreSQL table: name, storage
+ *        type, schema (namespace), and ordered list of @c Column
+ *        definitions.
+ *
+ * Constructed by callers that declare a database layout; consumed by
+ * @c DatabaseConfiguration and then by @c PostgreSQLSystem when it
+ * emits DDL or validates the live schema matches expectation. The
+ * string conversion operators and @ref str return the table name so
+ * a @c Table can stand in for a table identifier in query string
+ * builders.
+ */
 class Table
 {
   public:
+    /**
+     * @brief PostgreSQL table storage type.
+     *
+     * Mirrors the PostgreSQL concepts the engine has to emit when
+     * creating a table; @ref Regular is the plain persistent table
+     * used by default.
+     */
     enum class Type
     {
         Regular,      // by default
@@ -25,6 +51,13 @@ class Table
         View          // virtual
     };
 
+    /**
+     * @brief PostgreSQL schema (namespace) that owns the table.
+     *
+     * Only the built-in @c public schema is supported today;
+     * @ref Custom is reserved for future user-defined schemas and
+     * currently routes through the same code path as @ref Public.
+     */
     enum class Schema
     {
         Public, // by default

--- a/include/vigine/ecs/postgresql/tablerows.h
+++ b/include/vigine/ecs/postgresql/tablerows.h
@@ -1,5 +1,11 @@
 #pragma once
 
+/**
+ * @file tablerows.h
+ * @brief Declares @c TableRows, the value object that pairs a
+ *        @c Table description with its concrete @c Row set.
+ */
+
 #include "vigine/base/macros.h"
 #include "vigine/ecs/postgresql/row.h"
 #include "vigine/ecs/postgresql/table.h"
@@ -11,6 +17,15 @@ namespace vigine
 {
 namespace postgresql
 {
+/**
+ * @brief Bundle of a @c Table schema and its ordered @c Row set.
+ *
+ * Used when a caller needs to carry both the table description and
+ * its current rows as a single unit — for example when building an
+ * insert payload or when snapshotting a select result together with
+ * its schema. The rows are owned by value and can be iterated,
+ * indexed, or replaced wholesale via @ref setRows / @ref addRow.
+ */
 class TableRows
 {
   public:

--- a/include/vigine/requestbus/factory.h
+++ b/include/vigine/requestbus/factory.h
@@ -1,5 +1,15 @@
 #pragma once
 
+/**
+ * @file factory.h
+ * @brief Convenience re-export header for @c createRequestBus.
+ *
+ * Lets callers include a single predictable header to obtain an
+ * owning @c std::unique_ptr<IRequestBus> without naming the concrete
+ * @c DefaultRequestBus type. The function itself is defined in
+ * @c src/requestbus/defaultrequestbus.cpp.
+ */
+
 #include "vigine/requestbus/defaultrequestbus.h"
 
 // factory.h is a convenience header that re-exports createRequestBus so

--- a/include/vigine/service/databaseservice.h
+++ b/include/vigine/service/databaseservice.h
@@ -1,5 +1,16 @@
 #pragma once
 
+/**
+ * @file databaseservice.h
+ * @brief Concrete service that exposes database operations (connect,
+ *        scheme check / create, row read / write / clear) through the
+ *        service container.
+ *
+ * Database operations are compiled in only when the project is built
+ * with @c VIGINE_POSTGRESQL enabled; otherwise the service still exists
+ * but its database-facing API is omitted.
+ */
+
 #include "vigine/abstractservice.h"
 #include "vigine/base/macros.h"
 #include "vigine/ecs/entity.h"
@@ -23,6 +34,18 @@ class Column;
 } // namespace postgresql
 #endif
 
+/**
+ * @brief Database service: wraps a @c PostgreSQLSystem and exposes
+ *        database connect / schema / row CRUD operations to callers
+ *        through the service container.
+ *
+ * Holds no database state of its own; delegates every operation to
+ * the owned @c postgresql::PostgreSQLSystem. The database-facing API
+ * is only compiled when @c VIGINE_POSTGRESQL is enabled at build time.
+ * When the build flag is off the service still registers with the
+ * container but exposes only the lifecycle surface inherited from
+ * @c AbstractService.
+ */
 class DatabaseService : public AbstractService
 {
   public:

--- a/include/vigine/service/graphicsservice.h
+++ b/include/vigine/service/graphicsservice.h
@@ -1,5 +1,12 @@
 #pragma once
 
+/**
+ * @file graphicsservice.h
+ * @brief Concrete service that wires graphics-side rendering
+ *        (render system, render and texture components) into the
+ *        engine service container.
+ */
+
 #include "vigine/abstractservice.h"
 #include "vigine/base/macros.h"
 
@@ -11,6 +18,16 @@ class RenderComponent;
 class RenderSystem;
 class TextureComponent;
 
+/**
+ * @brief Graphics service: owns a @c RenderSystem and exposes render
+ *        initialisation plus access to render and texture components.
+ *
+ * Instantiated by the engine and registered against a bound entity.
+ * @ref initializeRender boots the underlying render backend against a
+ * native window handle and a surface size; the accessors
+ * @ref renderComponent and @ref textureComponent expose the per-entity
+ * render data for other services / systems to consume.
+ */
 class GraphicsService : public AbstractService
 {
   public:

--- a/include/vigine/service/platformservice.h
+++ b/include/vigine/service/platformservice.h
@@ -1,5 +1,12 @@
 #pragma once
 
+/**
+ * @file platformservice.h
+ * @brief Concrete service that exposes window-platform operations
+ *        (window creation, visibility, native handle access, event
+ *        handler binding) through the service container.
+ */
+
 #include "vigine/abstractservice.h"
 #include "vigine/base/macros.h"
 #include "vigine/ecs/platform/iwindoweventhandler.h"
@@ -15,6 +22,16 @@ class WindowSystem;
 class IWindowEventHandlerComponent;
 class WindowComponent;
 
+/**
+ * @brief Platform service: owns a @c WindowSystem and mediates
+ *        window lifecycle and event-handler binding for clients.
+ *
+ * Created by the engine and registered against a bound entity; it
+ * exposes a window-centric API (create, show, query native handle,
+ * bind an @c IWindowEventHandlerComponent) built on top of the
+ * ECS-side @c WindowSystem. The service is not directly constructed
+ * by user code; callers reach it through the service container.
+ */
 class PlatformService : public AbstractService
 {
   public:

--- a/include/vigine/topicbus/factory.h
+++ b/include/vigine/topicbus/factory.h
@@ -1,5 +1,17 @@
 #pragma once
 
+/**
+ * @file factory.h
+ * @brief Convenience re-export header for @c createTopicBus.
+ *
+ * Lets callers include a single predictable header to obtain an
+ * owning @c std::unique_ptr<ITopicBus> without naming the concrete
+ * @c DefaultTopicBus type. The function definition itself lives in
+ * @c src/topicbus/defaulttopicbus.cpp alongside the concrete class;
+ * @c src/topicbus/factory.cpp only holds a pointer-comment noting
+ * that location.
+ */
+
 #include "vigine/topicbus/defaulttopicbus.h"
 
 // factory.h is a convenience header that re-exports createTopicBus so


### PR DESCRIPTION
## Summary

Adds Doxygen `@brief` coverage to the remaining medium-priority public headers under `include/vigine/`:

- **PostgreSQL subsystem** (`include/vigine/ecs/postgresql/`): `column.h`, `columntype.h`, `connectiondata.h`, `data.h`, `databaseconfiguration.h`, `postgresqlresult.h`, `postgresqlsystem.h`, `postgresqltypeconverter.h`, `row.h`, `table.h`, `tablerows.h`, plus `query/querybuilder.h`.
- **Service concretes** (`include/vigine/service/`): `platformservice.h`, `graphicsservice.h`, `databaseservice.h`.
- **Factory shims**: `include/vigine/channelfactory/factory.h`, `include/vigine/requestbus/factory.h`, `include/vigine/topicbus/factory.h`.

Every touched header now has a top-level `/** @file ... @brief ... */` block and a per-class / per-struct / per-enum `@brief` on every public declaration.

## Nature of the change

- **Comment-only.** No code move, no rename, no signature change, no include change, no `#define` change. `git diff` is purely additive: 18 files, +375 lines, 0 lines removed.
- **Build impact:** none expected. Verified locally with `cmake --build build --config Debug` (MSVC 14.50, vcpkg toolchain, `ENABLE_POSTGRESQL=ON`) — `vigine.lib`, `example-postgresql.exe`, and `example-window.exe` all build clean, zero compiler warnings, zero errors.
- **Doxygen impact:** headers that previously had no `@brief` will now render into the generated docs with a short description.

## Scope / follow-ups

- The postgres subsystem is scheduled to move into `experimental/` in a follow-up; these comments travel with the files and remain valid after the move.
- Factory shims retained their existing free-text header comment; the Doxygen block is prepended so both views (doc-generator + plain read) stay correct.

## Files touched

```
include/vigine/channelfactory/factory.h
include/vigine/ecs/postgresql/column.h
include/vigine/ecs/postgresql/columntype.h
include/vigine/ecs/postgresql/connectiondata.h
include/vigine/ecs/postgresql/data.h
include/vigine/ecs/postgresql/databaseconfiguration.h
include/vigine/ecs/postgresql/postgresqlresult.h
include/vigine/ecs/postgresql/postgresqlsystem.h
include/vigine/ecs/postgresql/postgresqltypeconverter.h
include/vigine/ecs/postgresql/query/querybuilder.h
include/vigine/ecs/postgresql/row.h
include/vigine/ecs/postgresql/table.h
include/vigine/ecs/postgresql/tablerows.h
include/vigine/requestbus/factory.h
include/vigine/service/databaseservice.h
include/vigine/service/graphicsservice.h
include/vigine/service/platformservice.h
include/vigine/topicbus/factory.h
```

## Refs

- Closes #210
- Part of umbrella #197
