### PR TITLE
Add Doxygen @brief to legacy and ECS public headers (#211)

### DIFF
--- a/include/vigine/abstractservice.h
+++ b/include/vigine/abstractservice.h
@@ -1,5 +1,10 @@
 #pragma once
 
+/**
+ * @file abstractservice.h
+ * @brief Legacy base class for named services bound to Context and Entity.
+ */
+
 #include "contextholder.h"
 #include "entitybindinghost.h"
 
@@ -15,6 +20,14 @@ using ServiceId = std::string;
 
 class Entity;
 
+/**
+ * @brief Base for services that share a Context and may bind to an Entity.
+ *
+ * Concrete services identify their kind via id() (e.g. "Http") and
+ * carry an instance-level Name supplied at construction. They combine
+ * ContextHolder (for global context access) with EntityBindingHost
+ * (for optional per-Entity binding).
+ */
 class AbstractService : public ContextHolder, public EntityBindingHost
 {
   public:

--- a/include/vigine/abstractstate.h
+++ b/include/vigine/abstractstate.h
@@ -1,5 +1,10 @@
 #pragma once
 
+/**
+ * @file abstractstate.h
+ * @brief Legacy base class for a state hosted by StateMachine.
+ */
+
 #include "result.h"
 #include "taskflow.h"
 
@@ -10,6 +15,13 @@ namespace vigine
 
 class Context;
 
+/**
+ * @brief Base for state objects driven by StateMachine.
+ *
+ * A state owns a TaskFlow which is executed between enter() and exit().
+ * The Result returned by exit() is forwarded to StateMachine to pick
+ * the next transition. Concrete states implement enter() and exit().
+ */
 class AbstractState // ENCAP EXEMPTION: legacy; protected _taskFlow/_isActive/_context pending cleanup
 {
   public:

--- a/include/vigine/abstracttask.h
+++ b/include/vigine/abstracttask.h
@@ -1,5 +1,10 @@
 #pragma once
 
+/**
+ * @file abstracttask.h
+ * @brief Legacy base class for a single unit of work run inside a TaskFlow.
+ */
+
 #include "contextholder.h"
 #include "result.h"
 
@@ -8,6 +13,13 @@ namespace vigine
 
 class Context;
 
+/**
+ * @brief Base for task objects executed by TaskFlow / StateMachine.
+ *
+ * A task receives its Context via ContextHolder, runs once when its
+ * owning flow schedules it, and returns a Result whose Code drives the
+ * next transition. Concrete tasks implement execute().
+ */
 class AbstractTask : public ContextHolder
 {
   public:

--- a/include/vigine/abstracttaskflow.h
+++ b/include/vigine/abstracttaskflow.h
@@ -1,5 +1,10 @@
 #pragma once
 
+/**
+ * @file abstracttaskflow.h
+ * @brief Legacy task-flow container that sequences AbstractTask instances.
+ */
+
 #include "abstracttask.h"
 #include "result.h"
 
@@ -10,6 +15,14 @@
 namespace vigine
 {
 
+/**
+ * @brief Owns tasks and transitions and drives sequential task execution.
+ *
+ * Tasks are added by addTask(), linked by addTransition(), and run one
+ * at a time via runCurrentTask(). Each task's Result::Code selects the
+ * next task from the transition map. A TaskFlow is typically owned by
+ * an AbstractState.
+ */
 class TaskFlow
 {
     using TaskUPtr            = std::unique_ptr<AbstractTask>;

--- a/include/vigine/contextholder.h
+++ b/include/vigine/contextholder.h
@@ -1,10 +1,22 @@
 #pragma once
 
+/**
+ * @file contextholder.h
+ * @brief Mixin that stores a non-owning Context pointer for dependent classes.
+ */
+
 namespace vigine
 {
 
 class Context;
 
+/**
+ * @brief Carries a non-owning Context pointer for its derived classes.
+ *
+ * Derived classes obtain the Context via context() and may react to
+ * binding changes by overriding contextChanged(). The pointer is set
+ * externally via setContext(); this class never takes ownership.
+ */
 class ContextHolder
 {
   public:

--- a/include/vigine/ecs/abstractcomponent.h
+++ b/include/vigine/ecs/abstractcomponent.h
@@ -1,8 +1,20 @@
 #pragma once
 
+/**
+ * @file abstractcomponent.h
+ * @brief Legacy root base class for ECS components.
+ */
+
 namespace vigine
 {
 
+/**
+ * @brief Empty polymorphic base shared by every legacy ECS component.
+ *
+ * Provides a common pointer type so ComponentManager can store
+ * heterogeneous components through a single base. Carries no state
+ * and no virtual methods other than the destructor.
+ */
 class AbstractComponent
 {
   public:

--- a/include/vigine/ecs/abstractentity.h
+++ b/include/vigine/ecs/abstractentity.h
@@ -1,5 +1,10 @@
 #pragma once
 
+/**
+ * @file abstractentity.h
+ * @brief Legacy root base class for ECS entities.
+ */
+
 #include "abstractcomponent.h"
 
 #include <string>
@@ -7,6 +12,13 @@
 
 namespace vigine
 {
+/**
+ * @brief Empty polymorphic base for legacy ECS entity classes.
+ *
+ * Acts as the common type for entity containers and references.
+ * Carries no state; the concrete Entity class in entity.h fills in
+ * lifecycle details.
+ */
 class AbstractEntity
 {
   public:

--- a/include/vigine/ecs/abstractsystem.h
+++ b/include/vigine/ecs/abstractsystem.h
@@ -1,5 +1,10 @@
 #pragma once
 
+/**
+ * @file abstractsystem.h
+ * @brief Legacy base class for ECS systems that create / destroy components.
+ */
+
 #include "vigine/entitybindinghost.h"
 
 #include <memory>
@@ -12,6 +17,14 @@ using SystemName = std::string;
 
 class Entity;
 
+/**
+ * @brief Base for systems that attach components to a bound Entity.
+ *
+ * Derives from EntityBindingHost, so exactly one Entity is bound at a
+ * time. Concrete systems expose a stable kind via id(), carry an
+ * instance Name, and implement create / destroy / has-components
+ * against the bound Entity.
+ */
 class AbstractSystem : public EntityBindingHost
 {
   public:

--- a/include/vigine/ecs/componentmanager.h
+++ b/include/vigine/ecs/componentmanager.h
@@ -1,5 +1,10 @@
 #pragma once
 
+/**
+ * @file componentmanager.h
+ * @brief Legacy type-indexed store for ECS components.
+ */
+
 #include <any>
 #include <memory>
 #include <typeindex>
@@ -14,6 +19,14 @@ using ComponentSPtr = std::shared_ptr<T>;
 template <typename T>
 using ComponentContainer = std::vector<ComponentSPtr<T>>;
 
+/**
+ * @brief Stores heterogeneous component containers keyed by std::type_index.
+ *
+ * createComponent<T>(...) allocates a shared T and appends it to the
+ * per-type container. cbegin<T>() / cend<T>() iterate the container for
+ * type T, returning an empty range if none exist. removeComponents<T>()
+ * drops every component of type T; clear() drops all components.
+ */
 class ComponentManager
 {
   public:

--- a/include/vigine/ecs/entity.h
+++ b/include/vigine/ecs/entity.h
@@ -1,8 +1,20 @@
 #pragma once
 
+/**
+ * @file entity.h
+ * @brief Legacy concrete ECS entity identity.
+ */
+
 namespace vigine
 {
 
+/**
+ * @brief Opaque identity for a single game-object in the legacy ECS.
+ *
+ * Components and systems reference an Entity by pointer; lifetime is
+ * owned by EntityManager. The class itself carries no state in the
+ * public header -- it is a handle that engines extend internally.
+ */
 class Entity
 {
   public:

--- a/include/vigine/ecs/entitymanager.h
+++ b/include/vigine/ecs/entitymanager.h
@@ -1,5 +1,10 @@
 #pragma once
 
+/**
+ * @file entitymanager.h
+ * @brief Legacy concrete EntityManager that owns Entity lifetimes.
+ */
+
 #include "vigine/ecs/ientitymanager.h"
 
 #include <map>
@@ -14,6 +19,14 @@ class Entity;
 
 using EntityUPtr = std::unique_ptr<Entity>;
 
+/**
+ * @brief Owns the live set of Entity objects and their string aliases.
+ *
+ * createEntity() allocates a new Entity and keeps it alive until
+ * removeEntity() releases it. Optional string aliases registered via
+ * addAlias() allow lookup by getEntityByAlias(). Instances are created
+ * by Engine.
+ */
 class EntityManager : public IEntityManager
 {
   public:

--- a/include/vigine/ecs/platform/iwindoweventhandler.h
+++ b/include/vigine/ecs/platform/iwindoweventhandler.h
@@ -1,9 +1,17 @@
 #pragma once
 
+/**
+ * @file iwindoweventhandler.h
+ * @brief Platform window-event handler interface and its input event types.
+ */
+
 namespace vigine
 {
 namespace platform
 {
+/**
+ * @brief Mouse buttons reported by window events.
+ */
 enum class MouseButton
 {
     Left,
@@ -13,6 +21,9 @@ enum class MouseButton
     X2,
 };
 
+/**
+ * @brief Bit-flag set describing active keyboard modifiers during an event.
+ */
 enum KeyModifier : unsigned int
 {
     KeyModifierNone    = 0,
@@ -24,6 +35,9 @@ enum KeyModifier : unsigned int
     KeyModifierNum     = 1u << 5,
 };
 
+/**
+ * @brief Snapshot of a single key press / release.
+ */
 struct KeyEvent
 {
     unsigned int keyCode{0};
@@ -33,6 +47,9 @@ struct KeyEvent
     bool isRepeat{false};
 };
 
+/**
+ * @brief Snapshot of a single text-input event (one Unicode code point).
+ */
 struct TextEvent
 {
     unsigned int codePoint{0};
@@ -40,6 +57,14 @@ struct TextEvent
     unsigned int repeatCount{0};
 };
 
+/**
+ * @brief Pure-interface callback for all window-surface input events.
+ *
+ * WindowSystem dispatches platform events to any registered handler
+ * component. Implementers receive window lifecycle notifications,
+ * mouse events (move / wheel / button / enter / leave), and keyboard
+ * events (key down / up, character, dead-key).
+ */
 class IWindowEventHandlerComponent
 {
   public:

--- a/include/vigine/ecs/platform/windowsystem.h
+++ b/include/vigine/ecs/platform/windowsystem.h
@@ -1,5 +1,10 @@
 #pragma once
 
+/**
+ * @file windowsystem.h
+ * @brief ECS system that creates and manages platform window components.
+ */
+
 #include "iwindoweventhandler.h"
 
 #include "vigine/base/macros.h"
@@ -17,6 +22,14 @@ namespace platform
 class WindowComponent;
 class WindowEventDispatcher;
 
+/**
+ * @brief Owns WindowComponent instances and routes events to handlers.
+ *
+ * Derived from AbstractSystem. Creates windows on demand, binds them
+ * to an Entity, shows them, and attaches IWindowEventHandlerComponent
+ * callbacks via an internal WindowEventDispatcher. Exposes read-only
+ * lookups for the windows and handlers owned by a given Entity.
+ */
 class WindowSystem : public AbstractSystem
 {
   public:

--- a/include/vigine/ecs/render/graphicshandles.h
+++ b/include/vigine/ecs/render/graphicshandles.h
@@ -1,5 +1,10 @@
 #pragma once
 
+/**
+ * @file graphicshandles.h
+ * @brief Backend-neutral handle types and descriptors for the graphics API.
+ */
+
 #include <cstdint>
 #include <glm/mat4x4.hpp>
 #include <glm/vec3.hpp>
@@ -12,24 +17,36 @@ namespace graphics
 {
 
 // Opaque handle types wrapping uint64_t
+/**
+ * @brief Opaque handle identifying a graphics pipeline resource.
+ */
 struct PipelineHandle
 {
     uint64_t value{0};
     bool isValid() const { return value != 0; }
 };
 
+/**
+ * @brief Opaque handle identifying a GPU buffer resource.
+ */
 struct BufferHandle
 {
     uint64_t value{0};
     bool isValid() const { return value != 0; }
 };
 
+/**
+ * @brief Opaque handle identifying a GPU texture resource.
+ */
 struct TextureHandle
 {
     uint64_t value{0};
     bool isValid() const { return value != 0; }
 };
 
+/**
+ * @brief Opaque handle identifying a compiled shader module.
+ */
 struct ShaderModuleHandle
 {
     uint64_t value{0};
@@ -37,6 +54,9 @@ struct ShaderModuleHandle
 };
 
 // Vertex layout description
+/**
+ * @brief Scalar / vector format of a single vertex attribute.
+ */
 enum class VertexFormat
 {
     Float32,
@@ -46,6 +66,9 @@ enum class VertexFormat
     UInt32
 };
 
+/**
+ * @brief Single attribute slot inside a vertex binding (location, format, offset).
+ */
 struct VertexAttribute
 {
     uint32_t location;
@@ -53,6 +76,9 @@ struct VertexAttribute
     uint32_t offset;
 };
 
+/**
+ * @brief Vertex binding description: stride, step rate, and attribute list.
+ */
 struct VertexBindingDesc
 {
     uint32_t binding;
@@ -62,18 +88,27 @@ struct VertexBindingDesc
 };
 
 // Pipeline description
+/**
+ * @brief Blend mode selected by a pipeline (opaque or alpha-blended).
+ */
 enum class BlendMode
 {
     Opaque,
     AlphaBlend
 };
 
+/**
+ * @brief Primitive topology for rasterisation.
+ */
 enum class Topology
 {
     TriangleList,
     LineList
 };
 
+/**
+ * @brief Full pipeline description used to create a PipelineHandle.
+ */
 struct PipelineDesc
 {
     ShaderModuleHandle vertexShader;
@@ -87,6 +122,9 @@ struct PipelineDesc
 };
 
 // Buffer description
+/**
+ * @brief Intended GPU usage of a buffer (vertex / index / uniform / storage).
+ */
 enum class BufferUsage
 {
     Vertex,
@@ -95,6 +133,9 @@ enum class BufferUsage
     Storage
 };
 
+/**
+ * @brief Memory domain of a buffer (GPU-only, upload, readback).
+ */
 enum class MemoryUsage
 {
     GpuOnly,
@@ -102,6 +143,9 @@ enum class MemoryUsage
     GpuToCpu
 };
 
+/**
+ * @brief Buffer description used to create a BufferHandle.
+ */
 struct BufferDesc
 {
     size_t size;
@@ -110,6 +154,9 @@ struct BufferDesc
 };
 
 // Texture description
+/**
+ * @brief Pixel format of a texture (colour / depth).
+ */
 enum class TextureFormat
 {
     R8_UNORM,
@@ -119,12 +166,18 @@ enum class TextureFormat
     D32_SFLOAT
 };
 
+/**
+ * @brief Sampler filter mode used when sampling a texture.
+ */
 enum class TextureFilter
 {
     Nearest,
     Linear
 };
 
+/**
+ * @brief Sampler wrap mode applied outside the [0, 1] UV range.
+ */
 enum class TextureWrapMode
 {
     Repeat,
@@ -132,6 +185,9 @@ enum class TextureWrapMode
     ClampToBorder
 };
 
+/**
+ * @brief Texture description used to create a TextureHandle.
+ */
 struct TextureDesc
 {
     uint32_t width;
@@ -143,7 +199,9 @@ struct TextureDesc
     TextureWrapMode wrapV{TextureWrapMode::Repeat};
 };
 
-// Push constants data structure
+/**
+ * @brief Push-constant payload forwarded to shaders every draw call.
+ */
 struct PushConstantData
 {
     glm::mat4 viewProjection;
@@ -153,7 +211,9 @@ struct PushConstantData
     glm::mat4 modelMatrix;
 };
 
-// Draw call description
+/**
+ * @brief Description of a single draw call submitted to the backend.
+ */
 struct DrawCallDesc
 {
     PipelineHandle pipeline;
@@ -167,7 +227,14 @@ struct DrawCallDesc
     uint32_t indexCount{0}; // 0 = not using indices
 };
 
-// Entity draw group — one group per unique pipeline, used by RenderSystem → VulkanAPI
+/**
+ * @brief Per-pipeline batch of entities drawn together by the backend.
+ *
+ * One EntityDrawGroup per unique pipeline, bundling the texture to
+ * bind, the procedural vertex count, the instancing flag, and the
+ * per-entity model matrices. Produced by RenderSystem and consumed by
+ * VulkanAPI.
+ */
 struct EntityDrawGroup
 {
     PipelineHandle pipeline;

--- a/include/vigine/ecs/render/meshcomponent.h
+++ b/include/vigine/ecs/render/meshcomponent.h
@@ -1,5 +1,10 @@
 #pragma once
 
+/**
+ * @file meshcomponent.h
+ * @brief CPU-side mesh storage with GPU-buffer handles for upload.
+ */
+
 #include "graphicshandles.h"
 
 #include "vigine/base/macros.h"
@@ -13,6 +18,9 @@ namespace vigine
 namespace graphics
 {
 
+/**
+ * @brief Single mesh vertex: position, colour, and texture coordinates.
+ */
 struct Vertex
 {
     glm::vec3 position;
@@ -20,6 +28,15 @@ struct Vertex
     glm::vec2 texCoord{0.0f, 0.0f}; // UV coordinates for textures
 };
 
+/**
+ * @brief CPU-side vertex / index data paired with GPU buffer handles.
+ *
+ * Stores a vertex list and optional index list, tracks dirty state
+ * for re-upload, and carries BufferHandles for the uploaded GPU
+ * buffers. Also supports procedural-in-shader meshes, where the
+ * shader generates geometry and no CPU data is uploaded. Provides
+ * factory helpers createCube() and createPlane().
+ */
 class MeshComponent
 {
   public:

--- a/include/vigine/ecs/render/pipelinecache.h
+++ b/include/vigine/ecs/render/pipelinecache.h
@@ -1,5 +1,10 @@
 #pragma once
 
+/**
+ * @file pipelinecache.h
+ * @brief Content-addressed cache of graphics pipelines keyed by shader state.
+ */
+
 #include "graphicshandles.h"
 
 #include "vigine/base/macros.h"
@@ -17,6 +22,15 @@ namespace graphics
 class GraphicsBackend;
 class ShaderComponent;
 
+/**
+ * @brief Caches created pipelines to avoid redundant backend creation.
+ *
+ * getOrCreate() returns the pipeline for the given ShaderComponent,
+ * allocating a new one from the GraphicsBackend and caching it on
+ * first miss. Keyed on a hash computed from the ShaderComponent's
+ * pipeline-relevant state. invalidate() drops every cached pipeline
+ * (e.g. after device loss).
+ */
 class PipelineCache
 {
   public:

--- a/include/vigine/ecs/render/rendercomponent.h
+++ b/include/vigine/ecs/render/rendercomponent.h
@@ -1,5 +1,10 @@
 #pragma once
 
+/**
+ * @file rendercomponent.h
+ * @brief Per-entity renderable aggregating mesh, transform, text, and shader.
+ */
+
 #include "graphicshandles.h"
 #include "meshcomponent.h"
 #include "shadercomponent.h"
@@ -16,6 +21,16 @@ namespace vigine
 namespace graphics
 {
 
+/**
+ * @brief Render payload for one Entity.
+ *
+ * Bundles mesh, transform, optional text, and shader state for a
+ * single renderable. Exposes getters for each sub-component, a
+ * picking flag, an optional texture binding, and helpers to emit
+ * model matrices and SDF glyph quads. Also manages an incremental
+ * per-visual-line cache for SDF text layout (rebuildSdfGlyphQuads,
+ * incrementalRebuildSdf, scrollVertical, translateGlyphVertices).
+ */
 class RenderComponent
 {
   public:

--- a/include/vigine/ecs/render/rendersystem.h
+++ b/include/vigine/ecs/render/rendersystem.h
@@ -1,5 +1,10 @@
 #pragma once
 
+/**
+ * @file rendersystem.h
+ * @brief ECS system that owns the graphics backend and drives per-frame rendering.
+ */
+
 #include "vigine/base/macros.h"
 #include "vigine/ecs/abstractsystem.h"
 #include "vigine/ecs/render/camera.h"
@@ -20,7 +25,15 @@ class RenderComponent;
 class TextureComponent;
 class GraphicsBackend;
 
-// TODO: create skeleton
+/**
+ * @brief Render system that owns GraphicsBackend, Camera, and pipeline cache.
+ *
+ * Initialises the backend against a native window, resizes with the
+ * swapchain, and renders every frame via update(). Owns RenderComponent
+ * and TextureComponent per Entity, manages camera input (drag, zoom,
+ * WASD, sprint), billboard state, SDF clip planes, and picking helpers
+ * (screenPointToRay, pickFirstIntersectedEntity).
+ */
 class RenderSystem : public AbstractSystem
 {
   public:

--- a/include/vigine/ecs/render/shadercomponent.h
+++ b/include/vigine/ecs/render/shadercomponent.h
@@ -1,5 +1,10 @@
 #pragma once
 
+/**
+ * @file shadercomponent.h
+ * @brief Per-entity shader configuration: SPIR-V sources and pipeline state.
+ */
+
 #include "graphicshandles.h"
 
 #include "vigine/base/macros.h"
@@ -14,6 +19,15 @@ namespace vigine
 namespace graphics
 {
 
+/**
+ * @brief Bundles shader source paths, SPIR-V binaries, and pipeline state.
+ *
+ * Holds the vertex / fragment shader paths, loads and caches their
+ * SPIR-V binaries, and carries every pipeline-relevant setting the
+ * PipelineCache needs to key on: vertex layout, blend mode, depth
+ * test / write, topology, procedural vertex count, instancing, voxel
+ * text layout flag, and texture binding flag.
+ */
 class ShaderComponent
 {
   public:

--- a/include/vigine/ecs/render/textcomponent.h
+++ b/include/vigine/ecs/render/textcomponent.h
@@ -1,5 +1,10 @@
 #pragma once
 
+/**
+ * @file textcomponent.h
+ * @brief Text layout input for the SDF text renderer.
+ */
+
 #include <cstdint>
 #include <glm/vec2.hpp>
 #include <glm/vec3.hpp>
@@ -10,14 +15,18 @@ namespace vigine
 {
 namespace graphics
 {
-// One vertex of a glyph quad for SDF atlas rendering.
+/**
+ * @brief Single vertex of a glyph quad used by the SDF text shader.
+ */
 struct GlyphQuadVertex
 {
     glm::vec3 pos;
     glm::vec2 uv;
 };
 
-// World-space cursor position produced by the text layout pass.
+/**
+ * @brief World-space cursor position tied to a byte offset in the source text.
+ */
 struct CursorSlot
 {
     std::size_t byteOffset;
@@ -25,6 +34,14 @@ struct CursorSlot
     float worldY;
 };
 
+/**
+ * @brief Describes a renderable text string with layout and cursor state.
+ *
+ * Carries the text content, font path, pixel size, per-voxel scale,
+ * anchor / wrap parameters, cursor byte position and visibility, and
+ * optional per-character voxel offsets. Consumed by RenderComponent
+ * which converts it to glyph quads via the SDF text pipeline.
+ */
 class TextComponent
 {
   public:

--- a/include/vigine/ecs/render/transformcomponent.h
+++ b/include/vigine/ecs/render/transformcomponent.h
@@ -1,5 +1,10 @@
 #pragma once
 
+/**
+ * @file transformcomponent.h
+ * @brief Position / rotation / scale carrier with optional billboarding.
+ */
+
 #include "vigine/base/macros.h"
 
 #include <glm/glm.hpp>
@@ -13,6 +18,14 @@ namespace vigine
 namespace graphics
 {
 
+/**
+ * @brief Stores position, rotation, and scale for a renderable entity.
+ *
+ * Provides getters and setters for each axis, a rotate() helper that
+ * applies a local-axis rotation, getModelMatrix() for the standard
+ * TRS matrix, and getBillboardModelMatrix() that faces the camera
+ * when the billboard flag is enabled.
+ */
 class TransformComponent
 {
   public:

--- a/include/vigine/ecs/render/vulkanapi.h
+++ b/include/vigine/ecs/render/vulkanapi.h
@@ -1,5 +1,10 @@
 #pragma once
 
+/**
+ * @file vulkanapi.h
+ * @brief Vulkan implementation of the GraphicsBackend interface.
+ */
+
 #include "graphicsbackend.h"
 
 #include "vigine/base/macros.h"
@@ -26,6 +31,17 @@ class VulkanTextureStore;
 class VulkanPipelineStore;
 class VulkanFrameRenderer;
 
+/**
+ * @brief Vulkan-backed GraphicsBackend.
+ *
+ * Owns the Vulkan instance, physical and logical devices, surface,
+ * swapchain, and frame renderer. Implements the GraphicsBackend
+ * contract (pipeline / buffer / texture / shader creation, push
+ * constants, frame begin / end, draw submit) and adds Vulkan-specific
+ * helpers: setEntityDrawGroups, setSdfGlyphData, setSdfClipY,
+ * descriptor-set creation, and raw vk::Instance / Device accessors
+ * used during gradual refactoring.
+ */
 class VulkanAPI : public GraphicsBackend
 {
   public:

--- a/include/vigine/entitybindinghost.h
+++ b/include/vigine/entitybindinghost.h
@@ -1,9 +1,21 @@
 #pragma once
 
+/**
+ * @file entitybindinghost.h
+ * @brief Mixin that binds a class to a single Entity at a time.
+ */
+
 namespace vigine
 {
 class Entity;
 
+/**
+ * @brief Tracks a non-owning Entity pointer with bind / unbind hooks.
+ *
+ * Derived classes are notified via entityBound() / entityUnbound() when
+ * the associated Entity changes. Used by services and systems that
+ * operate against one Entity at a time.
+ */
 class EntityBindingHost
 {
   public:

--- a/include/vigine/property.h
+++ b/include/vigine/property.h
@@ -1,8 +1,21 @@
 #pragma once
 
+/**
+ * @file property.h
+ * @brief Legacy lookup-mode enum used by registries / repositories.
+ */
+
 namespace vigine
 {
 
+/**
+ * @brief Lookup policy for registry-style accessors.
+ *
+ * Exist         -- return the item if it already exists, else fail.
+ * New           -- create a new item, fail if one already exists.
+ * All           -- return all matching items.
+ * NewIfNotExist -- return the existing item, or create a new one.
+ */
 enum class Property
 {
     Exist,

--- a/include/vigine/result.h
+++ b/include/vigine/result.h
@@ -1,5 +1,10 @@
 #pragma once
 
+/**
+ * @file result.h
+ * @brief Status / error return type used across the engine API surface.
+ */
+
 #include "vigine/base/macros.h"
 
 #include <memory>
@@ -7,6 +12,13 @@
 
 namespace vigine
 {
+/**
+ * @brief Carries a status Code and an optional human-readable message.
+ *
+ * Produced by task / state / service / context operations that can
+ * fail. Code values are append-only so callers that persist or
+ * serialise a Result remain compatible across engine versions.
+ */
 class Result
 {
   public:

--- a/include/vigine/statemachine.h
+++ b/include/vigine/statemachine.h
@@ -1,5 +1,10 @@
 #pragma once
 
+/**
+ * @file statemachine.h
+ * @brief Legacy concrete StateMachine that owns states and their transitions.
+ */
+
 #include "abstractstate.h"
 #include "result.h"
 #include "statemachine/istatemachine.h"
@@ -12,6 +17,14 @@ namespace vigine
 {
 class Engine;
 
+/**
+ * @brief Owns AbstractState instances and drives transitions between them.
+ *
+ * States are added by addState(), linked by addTransition(), and
+ * executed one at a time via runCurrentState(). The current state is
+ * changed based on the Result::Code it produces and the transitions
+ * registered against it. Instances are created by Engine.
+ */
 class StateMachine : public IStateMachine
 {
     using StateUPtr           = std::unique_ptr<AbstractState>;


### PR DESCRIPTION
## Summary

Adds file-level `@file`/`@brief` blocks and per-class/struct `@brief` comments to 26 legacy and ECS public headers. Comment-only — no API or logic changes.

Refs #211, #197.

## Scope

- Root-level legacy contracts (9): `abstracttask.h`, `abstractstate.h`, `statemachine.h`, `contextholder.h`, `entitybindinghost.h`, `abstractservice.h`, `abstracttaskflow.h`, `result.h`, `property.h`.
- Legacy ECS base classes (6): `ecs/abstractcomponent.h`, `ecs/abstractentity.h`, `ecs/abstractsystem.h`, `ecs/componentmanager.h`, `ecs/entity.h`, `ecs/entitymanager.h`.
- ECS platform (2): `ecs/platform/iwindoweventhandler.h`, `ecs/platform/windowsystem.h`.
- ECS render (9): `ecs/render/graphicshandles.h`, `ecs/render/meshcomponent.h`, `ecs/render/pipelinecache.h`, `ecs/render/rendercomponent.h`, `ecs/render/rendersystem.h`, `ecs/render/shadercomponent.h`, `ecs/render/textcomponent.h`, `ecs/render/transformcomponent.h`, `ecs/render/vulkanapi.h`.

## Notes

Several of these files will be migrated or removed in later PRs in the #197 umbrella; documenting them now makes the interim state self-explanatory, and the comments travel with the file (or disappear with it).

## Test plan

- [x] `grep -L "@brief"` across all listed paths returns empty.
- [x] `cmake --build build --config Debug --target vigine example-window` builds clean.
- [x] No API / logic changes (diff is additive comment blocks only).