### PR TITLE
Move graph/ into core/graph/ (#217)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,19 +186,19 @@ set(HEADER
     ${INCLUDE_DIR}/vigine/ecs/entitymanager.h
     ${INCLUDE_DIR}/vigine/entitybindinghost.h
     ${INCLUDE_DIR}/vigine/base/constant.h
-    ${INCLUDE_DIR}/vigine/graph/nodeid.h
-    ${INCLUDE_DIR}/vigine/graph/edgeid.h
-    ${INCLUDE_DIR}/vigine/graph/traverse_mode.h
-    ${INCLUDE_DIR}/vigine/graph/visit_result.h
-    ${INCLUDE_DIR}/vigine/graph/kind.h
-    ${INCLUDE_DIR}/vigine/graph/iedgedata.h
-    ${INCLUDE_DIR}/vigine/graph/inode.h
-    ${INCLUDE_DIR}/vigine/graph/iedge.h
-    ${INCLUDE_DIR}/vigine/graph/igraphvisitor.h
-    ${INCLUDE_DIR}/vigine/graph/igraphquery.h
-    ${INCLUDE_DIR}/vigine/graph/igraph.h
-    ${INCLUDE_DIR}/vigine/graph/factory.h
-    ${INCLUDE_DIR}/vigine/graph/abstractgraph.h
+    ${INCLUDE_DIR}/vigine/core/graph/nodeid.h
+    ${INCLUDE_DIR}/vigine/core/graph/edgeid.h
+    ${INCLUDE_DIR}/vigine/core/graph/traverse_mode.h
+    ${INCLUDE_DIR}/vigine/core/graph/visit_result.h
+    ${INCLUDE_DIR}/vigine/core/graph/kind.h
+    ${INCLUDE_DIR}/vigine/core/graph/iedgedata.h
+    ${INCLUDE_DIR}/vigine/core/graph/inode.h
+    ${INCLUDE_DIR}/vigine/core/graph/iedge.h
+    ${INCLUDE_DIR}/vigine/core/graph/igraphvisitor.h
+    ${INCLUDE_DIR}/vigine/core/graph/igraphquery.h
+    ${INCLUDE_DIR}/vigine/core/graph/igraph.h
+    ${INCLUDE_DIR}/vigine/core/graph/factory.h
+    ${INCLUDE_DIR}/vigine/core/graph/abstractgraph.h
     ${INCLUDE_DIR}/vigine/core/threading/threadaffinity.h
     ${INCLUDE_DIR}/vigine/core/threading/namedthreadid.h
     ${INCLUDE_DIR}/vigine/core/threading/threadmanagerconfig.h
@@ -273,12 +273,12 @@ set(SOURCES
     ${SRC_DIR}/ecs/entitymanager.cpp
     ${SRC_DIR}/ecs/abstractsystem.cpp
     ${SRC_DIR}/entitybindinghost.cpp
-    ${SRC_DIR}/graph/abstractgraph.cpp
-    ${SRC_DIR}/graph/defaultgraph.cpp
-    ${SRC_DIR}/graph/defaultgraph_traverse.cpp
-    ${SRC_DIR}/graph/defaultgraph_query.cpp
-    ${SRC_DIR}/graph/defaultgraph_export.cpp
-    ${SRC_DIR}/graph/factory.cpp
+    ${SRC_DIR}/core/graph/abstractgraph.cpp
+    ${SRC_DIR}/core/graph/defaultgraph.cpp
+    ${SRC_DIR}/core/graph/defaultgraph_traverse.cpp
+    ${SRC_DIR}/core/graph/defaultgraph_query.cpp
+    ${SRC_DIR}/core/graph/defaultgraph_export.cpp
+    ${SRC_DIR}/core/graph/factory.cpp
     ${SRC_DIR}/core/threading/abstractthreadmanager.cpp
     ${SRC_DIR}/core/threading/threadmanager.cpp
     ${SRC_DIR}/core/threading/defaultmutex.h

--- a/doc/hypergraph_v1_1_sketch.md
+++ b/doc/hypergraph_v1_1_sketch.md
@@ -63,7 +63,7 @@ public:
     // hypergraph registration. Call `unregisterWrapper(id)` before
     // destroying the wrapped graph, otherwise meta-edges that reference
     // the freed graph become dangling.
-    virtual HyperNodeId registerWrapper(vigine::graph::IGraph *graph,
+    virtual HyperNodeId registerWrapper(vigine::core::graph::IGraph *graph,
                                         std::string_view       label) = 0;
 
     // Add a directed meta-edge between two wrapper nodes.
@@ -73,7 +73,7 @@ public:
     virtual void unregisterWrapper(HyperNodeId id) = 0;
 
     // Export the entire meta-graph in Graphviz DOT format. The signature
-    // matches `vigine::graph::IGraph::exportGraphViz` — caller-owned
+    // matches `vigine::core::graph::IGraph::exportGraphViz` — caller-owned
     // buffer, Result error path, no I/O on the interface.
     virtual vigine::Result exportGraphViz(std::string &out) const = 0;
 
@@ -83,7 +83,7 @@ public:
 
     // Iterate registered wrapper nodes.
     virtual void forEachWrapper(
-        std::function<void(HyperNodeId, vigine::graph::IGraph *)> fn) const = 0;
+        std::function<void(HyperNodeId, vigine::core::graph::IGraph *)> fn) const = 0;
 };
 
 } // namespace vigine::hypergraph

--- a/include/vigine/core/graph/abstractgraph.h
+++ b/include/vigine/core/graph/abstractgraph.h
@@ -10,18 +10,18 @@
 #include <unordered_map>
 #include <vector>
 
-#include "vigine/graph/edgeid.h"
-#include "vigine/graph/iedge.h"
-#include "vigine/graph/igraph.h"
-#include "vigine/graph/igraphquery.h"
-#include "vigine/graph/igraphvisitor.h"
-#include "vigine/graph/inode.h"
-#include "vigine/graph/kind.h"
-#include "vigine/graph/nodeid.h"
-#include "vigine/graph/traverse_mode.h"
+#include "vigine/core/graph/edgeid.h"
+#include "vigine/core/graph/iedge.h"
+#include "vigine/core/graph/igraph.h"
+#include "vigine/core/graph/igraphquery.h"
+#include "vigine/core/graph/igraphvisitor.h"
+#include "vigine/core/graph/inode.h"
+#include "vigine/core/graph/kind.h"
+#include "vigine/core/graph/nodeid.h"
+#include "vigine/core/graph/traverse_mode.h"
 #include "vigine/result.h"
 
-namespace vigine::graph
+namespace vigine::core::graph
 {
 /**
  * @brief Concrete stateful base for every in-memory @ref IGraph.
@@ -212,4 +212,4 @@ class AbstractGraph : public IGraph
     friend class QueryImpl;
 };
 
-} // namespace vigine::graph
+} // namespace vigine::core::graph

--- a/include/vigine/core/graph/edgeid.h
+++ b/include/vigine/core/graph/edgeid.h
@@ -3,7 +3,7 @@
 #include <compare>
 #include <cstdint>
 
-namespace vigine::graph
+namespace vigine::core::graph
 {
 /**
  * @brief Generational identifier of a graph edge.
@@ -26,4 +26,4 @@ struct EdgeId
     friend constexpr bool operator==(const EdgeId &, const EdgeId &)  = default;
 };
 
-} // namespace vigine::graph
+} // namespace vigine::core::graph

--- a/include/vigine/core/graph/factory.h
+++ b/include/vigine/core/graph/factory.h
@@ -2,9 +2,9 @@
 
 #include <memory>
 
-#include "vigine/graph/igraph.h"
+#include "vigine/core/graph/igraph.h"
 
-namespace vigine::graph
+namespace vigine::core::graph
 {
 /**
  * @brief Constructs the default in-memory @ref IGraph implementation.
@@ -19,4 +19,4 @@ namespace vigine::graph
  */
 [[nodiscard]] std::unique_ptr<IGraph> createGraph();
 
-} // namespace vigine::graph
+} // namespace vigine::core::graph

--- a/include/vigine/core/graph/iedge.h
+++ b/include/vigine/core/graph/iedge.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "vigine/graph/edgeid.h"
-#include "vigine/graph/iedgedata.h"
-#include "vigine/graph/kind.h"
-#include "vigine/graph/nodeid.h"
+#include "vigine/core/graph/edgeid.h"
+#include "vigine/core/graph/iedgedata.h"
+#include "vigine/core/graph/kind.h"
+#include "vigine/core/graph/nodeid.h"
 
-namespace vigine::graph
+namespace vigine::core::graph
 {
 /**
  * @brief Pure-virtual directed edge of an @ref IGraph.
@@ -61,4 +61,4 @@ class IEdge
     IEdge &operator=(IEdge &&)      = delete;
 };
 
-} // namespace vigine::graph
+} // namespace vigine::core::graph

--- a/include/vigine/core/graph/iedgedata.h
+++ b/include/vigine/core/graph/iedgedata.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-namespace vigine::graph
+namespace vigine::core::graph
 {
 /**
  * @brief Optional polymorphic payload carried by an edge.
@@ -42,4 +42,4 @@ class IEdgeData
     IEdgeData &operator=(IEdgeData &&)      = delete;
 };
 
-} // namespace vigine::graph
+} // namespace vigine::core::graph

--- a/include/vigine/core/graph/igraph.h
+++ b/include/vigine/core/graph/igraph.h
@@ -4,16 +4,16 @@
 #include <memory>
 #include <string>
 
-#include "vigine/graph/edgeid.h"
-#include "vigine/graph/iedge.h"
-#include "vigine/graph/igraphquery.h"
-#include "vigine/graph/igraphvisitor.h"
-#include "vigine/graph/inode.h"
-#include "vigine/graph/nodeid.h"
-#include "vigine/graph/traverse_mode.h"
+#include "vigine/core/graph/edgeid.h"
+#include "vigine/core/graph/iedge.h"
+#include "vigine/core/graph/igraphquery.h"
+#include "vigine/core/graph/igraphvisitor.h"
+#include "vigine/core/graph/inode.h"
+#include "vigine/core/graph/nodeid.h"
+#include "vigine/core/graph/traverse_mode.h"
 #include "vigine/result.h"
 
-namespace vigine::graph
+namespace vigine::core::graph
 {
 /**
  * @brief Pure-virtual core of the graph substrate.
@@ -157,4 +157,4 @@ class IGraph
     IGraph &operator=(IGraph &&)      = delete;
 };
 
-} // namespace vigine::graph
+} // namespace vigine::core::graph

--- a/include/vigine/core/graph/igraphquery.h
+++ b/include/vigine/core/graph/igraphquery.h
@@ -3,11 +3,11 @@
 #include <optional>
 #include <vector>
 
-#include "vigine/graph/edgeid.h"
-#include "vigine/graph/kind.h"
-#include "vigine/graph/nodeid.h"
+#include "vigine/core/graph/edgeid.h"
+#include "vigine/core/graph/kind.h"
+#include "vigine/core/graph/nodeid.h"
 
-namespace vigine::graph
+namespace vigine::core::graph
 {
 /**
  * @brief Pure-virtual read-only query surface of an @ref IGraph.
@@ -103,4 +103,4 @@ class IGraphQuery
     IGraphQuery &operator=(IGraphQuery &&)      = delete;
 };
 
-} // namespace vigine::graph
+} // namespace vigine::core::graph

--- a/include/vigine/core/graph/igraphvisitor.h
+++ b/include/vigine/core/graph/igraphvisitor.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "vigine/graph/iedge.h"
-#include "vigine/graph/inode.h"
-#include "vigine/graph/nodeid.h"
-#include "vigine/graph/visit_result.h"
+#include "vigine/core/graph/iedge.h"
+#include "vigine/core/graph/inode.h"
+#include "vigine/core/graph/nodeid.h"
+#include "vigine/core/graph/visit_result.h"
 
-namespace vigine::graph
+namespace vigine::core::graph
 {
 /**
  * @brief Pure-virtual callback consumed by @ref IGraph::traverse.
@@ -52,4 +52,4 @@ class IGraphVisitor
     IGraphVisitor &operator=(IGraphVisitor &&)      = delete;
 };
 
-} // namespace vigine::graph
+} // namespace vigine::core::graph

--- a/include/vigine/core/graph/inode.h
+++ b/include/vigine/core/graph/inode.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "vigine/graph/kind.h"
-#include "vigine/graph/nodeid.h"
+#include "vigine/core/graph/kind.h"
+#include "vigine/core/graph/nodeid.h"
 
-namespace vigine::graph
+namespace vigine::core::graph
 {
 /**
  * @brief Pure-virtual vertex of an @ref IGraph.
@@ -52,4 +52,4 @@ class INode
     INode &operator=(INode &&)      = delete;
 };
 
-} // namespace vigine::graph
+} // namespace vigine::core::graph

--- a/include/vigine/core/graph/kind.h
+++ b/include/vigine/core/graph/kind.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-namespace vigine::graph
+namespace vigine::core::graph
 {
 /**
  * @brief Byte-wide tag classifying a node.
@@ -44,4 +44,4 @@ namespace edge_kind
 inline constexpr EdgeKind Generic = 1;
 } // namespace edge_kind
 
-} // namespace vigine::graph
+} // namespace vigine::core::graph

--- a/include/vigine/core/graph/nodeid.h
+++ b/include/vigine/core/graph/nodeid.h
@@ -3,7 +3,7 @@
 #include <compare>
 #include <cstdint>
 
-namespace vigine::graph
+namespace vigine::core::graph
 {
 /**
  * @brief Generational identifier of a graph node.
@@ -36,4 +36,4 @@ struct NodeId
     friend constexpr bool operator==(const NodeId &, const NodeId &)  = default;
 };
 
-} // namespace vigine::graph
+} // namespace vigine::core::graph

--- a/include/vigine/core/graph/traverse_mode.h
+++ b/include/vigine/core/graph/traverse_mode.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-namespace vigine::graph
+namespace vigine::core::graph
 {
 /**
  * @brief Strategy passed to @ref IGraph::traverse.
@@ -22,4 +22,4 @@ enum class TraverseMode : std::uint8_t
                             ///< @ref IGraphVisitor::nextForCustom.
 };
 
-} // namespace vigine::graph
+} // namespace vigine::core::graph

--- a/include/vigine/core/graph/visit_result.h
+++ b/include/vigine/core/graph/visit_result.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-namespace vigine::graph
+namespace vigine::core::graph
 {
 /**
  * @brief Control flow directive returned by @ref IGraphVisitor.
@@ -18,4 +18,4 @@ enum class VisitResult : std::uint8_t
     Stop     = 3, ///< Stop the traversal completely (early exit).
 };
 
-} // namespace vigine::graph
+} // namespace vigine::core::graph

--- a/include/vigine/ecs/abstractecs.h
+++ b/include/vigine/ecs/abstractecs.h
@@ -24,7 +24,7 @@ class EntityWorld;
  * world — and supplies default implementations of every
  * @ref IECS lifecycle and query method so that a minimal concrete
  * ECS only needs to seal the inheritance chain. The internal entity
- * world specialises the graph substrate (@c vigine::graph::AbstractGraph)
+ * world specialises the graph substrate (@c vigine::core::graph::AbstractGraph)
  * and translates between @ref EntityId and the substrate's own
  * identifier types inside its implementation.
  *

--- a/include/vigine/ecs/kind.h
+++ b/include/vigine/ecs/kind.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <vigine/graph/kind.h>  // INV-11 EXEMPTION: kind.h maps wrapper constants onto graph substrate ranges
+#include <vigine/core/graph/kind.h>  // INV-11 EXEMPTION: kind.h maps wrapper constants onto graph substrate ranges
 
 // wrapper-kind-waiver: engine-concept kind constants in a wrapper subspace.
 
@@ -11,12 +11,12 @@ namespace vigine::ecs
  *
  * Carved out of the reserved range `[32..47]` in the graph substrate. Every
  * ECS-specific node carries one of these tags so the core graph stays free
- * of engine-specific concepts (see @ref vigine::graph::NodeKind).
+ * of engine-specific concepts (see @ref vigine::core::graph::NodeKind).
  */
 namespace kind
 {
-inline constexpr vigine::graph::NodeKind Entity = 32;    // INV-11 EXEMPTION: kind constant mapping
-inline constexpr vigine::graph::NodeKind Component = 33; // INV-11 EXEMPTION: kind constant mapping
+inline constexpr vigine::core::graph::NodeKind Entity = 32;    // INV-11 EXEMPTION: kind constant mapping
+inline constexpr vigine::core::graph::NodeKind Component = 33; // INV-11 EXEMPTION: kind constant mapping
 } // namespace kind
 
 /**
@@ -26,7 +26,7 @@ inline constexpr vigine::graph::NodeKind Component = 33; // INV-11 EXEMPTION: ki
  */
 namespace edge_kind
 {
-inline constexpr vigine::graph::EdgeKind Attached = 32;  // INV-11 EXEMPTION: kind constant mapping
+inline constexpr vigine::core::graph::EdgeKind Attached = 32;  // INV-11 EXEMPTION: kind constant mapping
 } // namespace edge_kind
 
 } // namespace vigine::ecs

--- a/include/vigine/eventscheduler/ieventscheduler.h
+++ b/include/vigine/eventscheduler/ieventscheduler.h
@@ -36,8 +36,8 @@ namespace vigine::eventscheduler
  *   - INV-1: no template parameters in the public surface.
  *   - INV-9: factory @ref createEventScheduler returns @c std::unique_ptr.
  *   - INV-10: @c I prefix for this pure-virtual interface (no state).
- *   - INV-11: no graph types (@ref vigine::graph::NodeId,
- *             @ref vigine::graph::INode, etc.) appear in this header.
+ *   - INV-11: no graph types (@ref vigine::core::graph::NodeId,
+ *             @ref vigine::core::graph::INode, etc.) appear in this header.
  *   - FF-1: @ref schedule returns @c std::unique_ptr<IEventHandle>.
  *
  * The concrete implementation (@ref DefaultEventScheduler) is private to

--- a/include/vigine/fsm/kind.h
+++ b/include/vigine/fsm/kind.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <vigine/graph/kind.h>
+#include <vigine/core/graph/kind.h>
 
 // wrapper-kind-waiver: engine-concept kind constants in a wrapper subspace.
 
@@ -11,11 +11,11 @@ namespace vigine::fsm
  *
  * Carved out of the reserved range `[48..63]` in the graph substrate. Every
  * state-machine node carries one of these tags so the core graph stays free
- * of engine-specific concepts (see @ref vigine::graph::NodeKind).
+ * of engine-specific concepts (see @ref vigine::core::graph::NodeKind).
  */
 namespace kind
 {
-inline constexpr vigine::graph::NodeKind State = 48;
+inline constexpr vigine::core::graph::NodeKind State = 48;
 } // namespace kind
 
 /**
@@ -27,8 +27,8 @@ inline constexpr vigine::graph::NodeKind State = 48;
  */
 namespace edge_kind
 {
-inline constexpr vigine::graph::EdgeKind Transition = 48;
-inline constexpr vigine::graph::EdgeKind ChildOf = 49;
+inline constexpr vigine::core::graph::EdgeKind Transition = 48;
+inline constexpr vigine::core::graph::EdgeKind ChildOf = 49;
 } // namespace edge_kind
 
 } // namespace vigine::fsm

--- a/include/vigine/messaging/abstractmessagebus.h
+++ b/include/vigine/messaging/abstractmessagebus.h
@@ -9,7 +9,7 @@
 #include <mutex>
 #include <vector>
 
-#include "vigine/graph/abstractgraph.h"  // INV-11 EXEMPTION: AbstractMessageBus inherits graph substrate for internal routing
+#include "vigine/core/graph/abstractgraph.h"  // INV-11 EXEMPTION: AbstractMessageBus inherits graph substrate for internal routing
 #include "vigine/messaging/busconfig.h"
 #include "vigine/messaging/busid.h"
 #include "vigine/messaging/connectionid.h"
@@ -39,7 +39,7 @@ class DefaultBusControlBlock;
  * @ref AbstractMessageBus is level 4 of the five-layer wrapper recipe
  * (see @c theory_wrapper_creation_recipe.md). It inherits
  * @ref IMessageBus @c public so the bus surface sits at offset zero for
- * zero-cost up-casts, and @ref vigine::graph::AbstractGraph
+ * zero-cost up-casts, and @ref vigine::core::graph::AbstractGraph
  * @c protected so the graph substrate is available to wrapper code
  * without leaking into the bus's public surface.
  *
@@ -81,7 +81,7 @@ class DefaultBusControlBlock;
  */
 class AbstractMessageBus
     : public IMessageBus
-    , protected vigine::graph::AbstractGraph  // INV-11 EXEMPTION: routing substrate is an internal implementation detail
+    , protected vigine::core::graph::AbstractGraph  // INV-11 EXEMPTION: routing substrate is an internal implementation detail
 {
   public:
     ~AbstractMessageBus() override;

--- a/include/vigine/messaging/kind.h
+++ b/include/vigine/messaging/kind.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <vigine/graph/kind.h>  // INV-11 EXEMPTION: kind.h maps wrapper constants onto graph substrate ranges
+#include <vigine/core/graph/kind.h>  // INV-11 EXEMPTION: kind.h maps wrapper constants onto graph substrate ranges
 
 // wrapper-kind-waiver: engine-concept kind constants in a wrapper subspace.
 
@@ -11,12 +11,12 @@ namespace vigine::messaging
  *
  * Carved out of the reserved range `[16..31]` in the graph substrate. Every
  * messaging-specific node carries one of these tags so the core graph stays
- * free of engine-specific concepts (see @ref vigine::graph::NodeKind).
+ * free of engine-specific concepts (see @ref vigine::core::graph::NodeKind).
  */
 namespace kind
 {
-inline constexpr vigine::graph::NodeKind Target = 16;       // INV-11 EXEMPTION: kind constant mapping
-inline constexpr vigine::graph::NodeKind Subscription = 17; // INV-11 EXEMPTION: kind constant mapping
+inline constexpr vigine::core::graph::NodeKind Target = 16;       // INV-11 EXEMPTION: kind constant mapping
+inline constexpr vigine::core::graph::NodeKind Subscription = 17; // INV-11 EXEMPTION: kind constant mapping
 } // namespace kind
 
 /**
@@ -26,7 +26,7 @@ inline constexpr vigine::graph::NodeKind Subscription = 17; // INV-11 EXEMPTION:
  */
 namespace edge_kind
 {
-inline constexpr vigine::graph::EdgeKind Subscription = 16; // INV-11 EXEMPTION: kind constant mapping
+inline constexpr vigine::core::graph::EdgeKind Subscription = 16; // INV-11 EXEMPTION: kind constant mapping
 } // namespace edge_kind
 
 } // namespace vigine::messaging

--- a/include/vigine/signalemitter/isignalemitter.h
+++ b/include/vigine/signalemitter/isignalemitter.h
@@ -43,8 +43,8 @@ namespace vigine::signalemitter
  * Invariants:
  *   - INV-1: no template parameters in the public surface.
  *   - INV-10: @c I prefix for this pure-virtual interface (no state).
- *   - INV-11: no graph types (@ref vigine::graph::NodeId,
- *             @ref vigine::graph::INode, etc.) appear in this header.
+ *   - INV-11: no graph types (@ref vigine::core::graph::NodeId,
+ *             @ref vigine::core::graph::INode, etc.) appear in this header.
  *   - FF-1: factory @ref createSignalEmitter returns @c std::unique_ptr.
  *
  * The concrete implementation (@ref DefaultSignalEmitter) is private to

--- a/include/vigine/taskflow/kind.h
+++ b/include/vigine/taskflow/kind.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <vigine/graph/kind.h>  // INV-11 EXEMPTION: kind.h maps wrapper constants onto graph substrate ranges
+#include <vigine/core/graph/kind.h>  // INV-11 EXEMPTION: kind.h maps wrapper constants onto graph substrate ranges
 
 // wrapper-kind-waiver: engine-concept kind constants in a wrapper subspace.
 
@@ -11,11 +11,11 @@ namespace vigine::taskflow
  *
  * Carved out of the reserved range `[64..79]` in the graph substrate. Every
  * task-flow node carries one of these tags so the core graph stays free of
- * engine-specific concepts (see @ref vigine::graph::NodeKind).
+ * engine-specific concepts (see @ref vigine::core::graph::NodeKind).
  */
 namespace kind
 {
-inline constexpr vigine::graph::NodeKind Task = 64;       // INV-11 EXEMPTION: kind constant mapping
+inline constexpr vigine::core::graph::NodeKind Task = 64;       // INV-11 EXEMPTION: kind constant mapping
 } // namespace kind
 
 /**
@@ -25,7 +25,7 @@ inline constexpr vigine::graph::NodeKind Task = 64;       // INV-11 EXEMPTION: k
  */
 namespace edge_kind
 {
-inline constexpr vigine::graph::EdgeKind Transition = 64; // INV-11 EXEMPTION: kind constant mapping
+inline constexpr vigine::core::graph::EdgeKind Transition = 64; // INV-11 EXEMPTION: kind constant mapping
 } // namespace edge_kind
 
 } // namespace vigine::taskflow

--- a/script/check_graph_purity.py
+++ b/script/check_graph_purity.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """check_graph_purity.py -- Static checker for graph-core purity (INV-9).
 
-Scans include/vigine/graph/ and src/graph/ for engine-layer tokens:
+Scans include/vigine/core/graph/ and src/core/graph/ for engine-layer tokens:
 forbidden include paths and engine-concept identifiers. Any match exits 1.
 
 Exit codes:
@@ -66,8 +66,8 @@ WAIVER_MARKER = "// INV-9 EXEMPTION:"
 
 # Directories scanned relative to repo root.
 SCAN_DIRS: list[str] = [
-    "include/vigine/graph",
-    "src/graph",
+    "include/vigine/core/graph",
+    "src/core/graph",
 ]
 
 # File extensions considered C++ sources / headers.

--- a/script/check_wrapper_encapsulation.py
+++ b/script/check_wrapper_encapsulation.py
@@ -72,8 +72,8 @@ _WRAPPER_IDENTIFIERS: list[str] = [
 
 # Substring tokens for Level-1 (namespace qualifiers and include paths).
 _WRAPPER_SUBSTRINGS: list[str] = [
-    "vigine::graph::",
-    "<vigine/graph/",
+    "vigine::core::graph::",
+    "<vigine/core/graph/",
 ]
 
 # Additional identifiers forbidden in Level-2 facade headers.
@@ -84,7 +84,7 @@ _FACADE_EXTRA_IDENTIFIERS: list[str] = [
 
 # Additional substring tokens for Level-2 facades.
 _FACADE_EXTRA_SUBSTRINGS: list[str] = [
-    "vigine::graph::kind::",
+    "vigine::core::graph::kind::",
 ]
 
 # ---------------------------------------------------------------------------

--- a/src/core/graph/abstractgraph.cpp
+++ b/src/core/graph/abstractgraph.cpp
@@ -1,10 +1,10 @@
-#include "vigine/graph/abstractgraph.h"
+#include "vigine/core/graph/abstractgraph.h"
 
 #include <algorithm>
 #include <mutex>
 #include <utility>
 
-namespace vigine::graph
+namespace vigine::core::graph
 {
 // ---------------------------------------------------------------------------
 // Construction / destruction.
@@ -450,4 +450,4 @@ std::vector<EdgeId> AbstractGraph::QueryImpl::inEdgesOfKind(NodeId id, EdgeKind 
     return out;
 }
 
-} // namespace vigine::graph
+} // namespace vigine::core::graph

--- a/src/core/graph/defaultgraph.cpp
+++ b/src/core/graph/defaultgraph.cpp
@@ -1,4 +1,4 @@
-#include "graph/defaultgraph.h"
+#include "core/graph/defaultgraph.h"
 
 // DefaultGraph is a thin final subclass of AbstractGraph. All storage and
 // lifecycle behaviour lives on AbstractGraph; this translation unit exists
@@ -6,6 +6,6 @@
 // linkage in case the implementation needs to migrate back out of the
 // header without churning every consumer.
 
-namespace vigine::graph
+namespace vigine::core::graph
 {
-} // namespace vigine::graph
+} // namespace vigine::core::graph

--- a/src/core/graph/defaultgraph.h
+++ b/src/core/graph/defaultgraph.h
@@ -3,15 +3,15 @@
 #include <memory>
 #include <utility>
 
-#include "vigine/graph/abstractgraph.h"
-#include "vigine/graph/edgeid.h"
-#include "vigine/graph/iedge.h"
-#include "vigine/graph/iedgedata.h"
-#include "vigine/graph/inode.h"
-#include "vigine/graph/kind.h"
-#include "vigine/graph/nodeid.h"
+#include "vigine/core/graph/abstractgraph.h"
+#include "vigine/core/graph/edgeid.h"
+#include "vigine/core/graph/iedge.h"
+#include "vigine/core/graph/iedgedata.h"
+#include "vigine/core/graph/inode.h"
+#include "vigine/core/graph/kind.h"
+#include "vigine/core/graph/nodeid.h"
 
-namespace vigine::graph
+namespace vigine::core::graph
 {
 /**
  * @brief Default concrete implementation of @ref IGraph.
@@ -106,4 +106,4 @@ class EdgeImpl final
 
 } // namespace internal
 
-} // namespace vigine::graph
+} // namespace vigine::core::graph

--- a/src/core/graph/defaultgraph_export.cpp
+++ b/src/core/graph/defaultgraph_export.cpp
@@ -1,9 +1,9 @@
-#include "vigine/graph/abstractgraph.h"
+#include "vigine/core/graph/abstractgraph.h"
 
 #include <shared_mutex>
 #include <string>
 
-namespace vigine::graph
+namespace vigine::core::graph
 {
 namespace
 {
@@ -74,4 +74,4 @@ Result AbstractGraph::exportGraphViz(std::string &out) const
     return Result();
 }
 
-} // namespace vigine::graph
+} // namespace vigine::core::graph

--- a/src/core/graph/defaultgraph_query.cpp
+++ b/src/core/graph/defaultgraph_query.cpp
@@ -1,6 +1,6 @@
-#include "vigine/graph/abstractgraph.h"
+#include "vigine/core/graph/abstractgraph.h"
 
-#include "graph/nodeid_hasher.h"
+#include "core/graph/nodeid_hasher.h"
 
 #include <algorithm>
 #include <cstdint>
@@ -11,7 +11,7 @@
 #include <utility>
 #include <vector>
 
-namespace vigine::graph
+namespace vigine::core::graph
 {
 namespace
 {
@@ -297,4 +297,4 @@ AbstractGraph::QueryImpl::topologicalOrder() const
     return order;
 }
 
-} // namespace vigine::graph
+} // namespace vigine::core::graph

--- a/src/core/graph/defaultgraph_traverse.cpp
+++ b/src/core/graph/defaultgraph_traverse.cpp
@@ -1,6 +1,6 @@
-#include "vigine/graph/abstractgraph.h"
+#include "vigine/core/graph/abstractgraph.h"
 
-#include "graph/nodeid_hasher.h"
+#include "core/graph/nodeid_hasher.h"
 
 #include <algorithm>
 #include <cstdint>
@@ -9,7 +9,7 @@
 #include <unordered_set>
 #include <vector>
 
-namespace vigine::graph
+namespace vigine::core::graph
 {
 namespace
 {
@@ -429,4 +429,4 @@ Result AbstractGraph::traverse(NodeId startNode, TraverseMode mode, IGraphVisito
     return Result(Result::Code::Error, "unknown traverse mode");
 }
 
-} // namespace vigine::graph
+} // namespace vigine::core::graph

--- a/src/core/graph/factory.cpp
+++ b/src/core/graph/factory.cpp
@@ -1,10 +1,10 @@
-#include "vigine/graph/factory.h"
+#include "vigine/core/graph/factory.h"
 
 #include <memory>
 
-#include "graph/defaultgraph.h"
+#include "core/graph/defaultgraph.h"
 
-namespace vigine::graph
+namespace vigine::core::graph
 {
 // Factory returns the default adjacency-list implementation behind the
 // pure-virtual IGraph interface. unique_ptr: the default hand-off is sole
@@ -18,4 +18,4 @@ std::unique_ptr<IGraph> createGraph()
     return std::make_unique<DefaultGraph>();
 }
 
-} // namespace vigine::graph
+} // namespace vigine::core::graph

--- a/src/core/graph/nodeid_hasher.h
+++ b/src/core/graph/nodeid_hasher.h
@@ -3,9 +3,9 @@
 #include <cstddef>
 #include <cstdint>
 
-#include "vigine/graph/nodeid.h"
+#include "vigine/core/graph/nodeid.h"
 
-namespace vigine::graph::internal
+namespace vigine::core::graph::internal
 {
 // ---------------------------------------------------------------------------
 // Hash adapter so NodeId can be a key in unordered containers.
@@ -42,4 +42,4 @@ struct NodeIdHasher
         }
     }
 };
-} // namespace vigine::graph::internal
+} // namespace vigine::core::graph::internal

--- a/src/ecs/entityworld.cpp
+++ b/src/ecs/entityworld.cpp
@@ -10,13 +10,13 @@
 #include "vigine/ecs/ecstypes.h"
 #include "vigine/ecs/iecs.h"
 #include "vigine/ecs/kind.h"
-#include "vigine/graph/abstractgraph.h"
-#include "vigine/graph/edgeid.h"
-#include "vigine/graph/iedge.h"
-#include "vigine/graph/igraphquery.h"
-#include "vigine/graph/inode.h"
-#include "vigine/graph/kind.h"
-#include "vigine/graph/nodeid.h"
+#include "vigine/core/graph/abstractgraph.h"
+#include "vigine/core/graph/edgeid.h"
+#include "vigine/core/graph/iedge.h"
+#include "vigine/core/graph/igraphquery.h"
+#include "vigine/core/graph/inode.h"
+#include "vigine/core/graph/kind.h"
+#include "vigine/core/graph/nodeid.h"
 #include "vigine/result.h"
 
 namespace vigine::ecs
@@ -40,28 +40,28 @@ namespace
  * to @c id() without a round-trip through the graph.
  */
 class EntityNode final
-    : public vigine::graph::INode
-    , public vigine::graph::AbstractGraph::IdStamp
+    : public vigine::core::graph::INode
+    , public vigine::core::graph::AbstractGraph::IdStamp
 {
   public:
     EntityNode() = default;
 
-    [[nodiscard]] vigine::graph::NodeId id() const noexcept override { return _id; }
-    [[nodiscard]] vigine::graph::NodeKind kind() const noexcept override
+    [[nodiscard]] vigine::core::graph::NodeId id() const noexcept override { return _id; }
+    [[nodiscard]] vigine::core::graph::NodeKind kind() const noexcept override
     {
         return vigine::ecs::kind::Entity;
     }
 
     void onGraphIdAssigned(
-        vigine::graph::NodeId nodeId,
-        vigine::graph::EdgeId edgeId) noexcept override
+        vigine::core::graph::NodeId nodeId,
+        vigine::core::graph::EdgeId edgeId) noexcept override
     {
         _id = nodeId;
         (void)edgeId;
     }
 
   private:
-    vigine::graph::NodeId _id{};
+    vigine::core::graph::NodeId _id{};
 };
 
 /**
@@ -72,8 +72,8 @@ class EntityNode final
  * exactly as long as the graph tracks it.
  */
 class ComponentNode final
-    : public vigine::graph::INode
-    , public vigine::graph::AbstractGraph::IdStamp
+    : public vigine::core::graph::INode
+    , public vigine::core::graph::AbstractGraph::IdStamp
 {
   public:
     explicit ComponentNode(std::unique_ptr<IComponent> component) noexcept
@@ -81,8 +81,8 @@ class ComponentNode final
     {
     }
 
-    [[nodiscard]] vigine::graph::NodeId id() const noexcept override { return _id; }
-    [[nodiscard]] vigine::graph::NodeKind kind() const noexcept override
+    [[nodiscard]] vigine::core::graph::NodeId id() const noexcept override { return _id; }
+    [[nodiscard]] vigine::core::graph::NodeKind kind() const noexcept override
     {
         return vigine::ecs::kind::Component;
     }
@@ -96,15 +96,15 @@ class ComponentNode final
     [[nodiscard]] const IComponent *component() const noexcept { return _component.get(); }
 
     void onGraphIdAssigned(
-        vigine::graph::NodeId nodeId,
-        vigine::graph::EdgeId edgeId) noexcept override
+        vigine::core::graph::NodeId nodeId,
+        vigine::core::graph::EdgeId edgeId) noexcept override
     {
         _id = nodeId;
         (void)edgeId;
     }
 
   private:
-    vigine::graph::NodeId       _id{};
+    vigine::core::graph::NodeId       _id{};
     std::unique_ptr<IComponent> _component;
 };
 
@@ -116,39 +116,39 @@ class ComponentNode final
  * component node on the @c to() end keeps the component pointer.
  */
 class AttachedEdge final
-    : public vigine::graph::IEdge
-    , public vigine::graph::AbstractGraph::IdStamp
+    : public vigine::core::graph::IEdge
+    , public vigine::core::graph::AbstractGraph::IdStamp
 {
   public:
-    AttachedEdge(vigine::graph::NodeId from, vigine::graph::NodeId to) noexcept
+    AttachedEdge(vigine::core::graph::NodeId from, vigine::core::graph::NodeId to) noexcept
         : _from{from}, _to{to}
     {
     }
 
-    [[nodiscard]] vigine::graph::EdgeId   id() const noexcept override { return _id; }
-    [[nodiscard]] vigine::graph::EdgeKind kind() const noexcept override
+    [[nodiscard]] vigine::core::graph::EdgeId   id() const noexcept override { return _id; }
+    [[nodiscard]] vigine::core::graph::EdgeKind kind() const noexcept override
     {
         return vigine::ecs::edge_kind::Attached;
     }
-    [[nodiscard]] vigine::graph::NodeId from() const noexcept override { return _from; }
-    [[nodiscard]] vigine::graph::NodeId to() const noexcept override { return _to; }
-    [[nodiscard]] const vigine::graph::IEdgeData *data() const noexcept override
+    [[nodiscard]] vigine::core::graph::NodeId from() const noexcept override { return _from; }
+    [[nodiscard]] vigine::core::graph::NodeId to() const noexcept override { return _to; }
+    [[nodiscard]] const vigine::core::graph::IEdgeData *data() const noexcept override
     {
         return nullptr;
     }
 
     void onGraphIdAssigned(
-        vigine::graph::NodeId nodeId,
-        vigine::graph::EdgeId edgeId) noexcept override
+        vigine::core::graph::NodeId nodeId,
+        vigine::core::graph::EdgeId edgeId) noexcept override
     {
         _id = edgeId;
         (void)nodeId;
     }
 
   private:
-    vigine::graph::EdgeId _id{};
-    vigine::graph::NodeId _from{};
-    vigine::graph::NodeId _to{};
+    vigine::core::graph::EdgeId _id{};
+    vigine::core::graph::NodeId _from{};
+    vigine::core::graph::NodeId _to{};
 };
 
 } // namespace
@@ -163,28 +163,28 @@ EntityWorld::~EntityWorld() = default;
 
 // ---------------------------------------------------------------------------
 // POD translation helpers. The @ref EntityId / @ref ComponentHandle
-// layouts are intentionally identical to @c vigine::graph::NodeId so the
+// layouts are intentionally identical to @c vigine::core::graph::NodeId so the
 // translation is a plain field-for-field copy; INV-11 allows it here
 // because the conversion lives entirely inside the wrapper
 // implementation.
 // ---------------------------------------------------------------------------
 
-vigine::graph::NodeId EntityWorld::toNodeId(EntityId entity) noexcept
+vigine::core::graph::NodeId EntityWorld::toNodeId(EntityId entity) noexcept
 {
-    return vigine::graph::NodeId{entity.index, entity.generation};
+    return vigine::core::graph::NodeId{entity.index, entity.generation};
 }
 
-vigine::graph::NodeId EntityWorld::toNodeId(ComponentHandle handle) noexcept
+vigine::core::graph::NodeId EntityWorld::toNodeId(ComponentHandle handle) noexcept
 {
-    return vigine::graph::NodeId{handle.index, handle.generation};
+    return vigine::core::graph::NodeId{handle.index, handle.generation};
 }
 
-EntityId EntityWorld::toEntityId(vigine::graph::NodeId node) noexcept
+EntityId EntityWorld::toEntityId(vigine::core::graph::NodeId node) noexcept
 {
     return EntityId{node.index, node.generation};
 }
 
-ComponentHandle EntityWorld::toComponentHandle(vigine::graph::NodeId node) noexcept
+ComponentHandle EntityWorld::toComponentHandle(vigine::core::graph::NodeId node) noexcept
 {
     return ComponentHandle{node.index, node.generation};
 }
@@ -200,7 +200,7 @@ EntityId EntityWorld::createEntity()
     // @c INode unique_ptr follows the IdStamp handshake — the node
     // captures the assigned id during insert.
     auto                        node = std::make_unique<EntityNode>();
-    const vigine::graph::NodeId nid  = addNode(std::move(node));
+    const vigine::core::graph::NodeId nid  = addNode(std::move(node));
 
     // If the `_entities` `push_back` throws (bad_alloc under memory
     // pressure), the graph has a live node the registry never
@@ -243,12 +243,12 @@ Result EntityWorld::removeEntity(EntityId entity)
         = query().outEdgesOfKind(nid, vigine::ecs::edge_kind::Attached);
     for (auto it = attachedEdges.rbegin(); it != attachedEdges.rend(); ++it)
     {
-        const vigine::graph::IEdge *e = edge(*it);
+        const vigine::core::graph::IEdge *e = edge(*it);
         if (e == nullptr)
         {
             continue;
         }
-        const vigine::graph::NodeId componentNode = e->to();
+        const vigine::core::graph::NodeId componentNode = e->to();
         // removeNode cascades the edge for us; calling it first on the
         // component makes ownership release order deterministic.
         (void)removeNode(componentNode);
@@ -280,7 +280,7 @@ bool EntityWorld::hasEntity(EntityId entity) const noexcept
     {
         return false;
     }
-    const vigine::graph::INode *n = node(toNodeId(entity));
+    const vigine::core::graph::INode *n = node(toNodeId(entity));
     return n != nullptr && n->kind() == vigine::ecs::kind::Entity;
 }
 
@@ -296,21 +296,21 @@ ComponentHandle EntityWorld::attachComponent(
         return ComponentHandle{};
     }
 
-    const vigine::graph::NodeId entityNode = toNodeId(entity);
+    const vigine::core::graph::NodeId entityNode = toNodeId(entity);
     if (!query().hasNode(entityNode))
     {
         return ComponentHandle{};
     }
 
     auto                        compNode = std::make_unique<ComponentNode>(std::move(component));
-    const vigine::graph::NodeId compId   = addNode(std::move(compNode));
+    const vigine::core::graph::NodeId compId   = addNode(std::move(compNode));
     if (!compId.valid())
     {
         return ComponentHandle{};
     }
 
     auto                        attachment = std::make_unique<AttachedEdge>(entityNode, compId);
-    const vigine::graph::EdgeId eid        = addEdge(std::move(attachment));
+    const vigine::core::graph::EdgeId eid        = addEdge(std::move(attachment));
     if (!eid.valid())
     {
         // Adding the edge failed — roll the component node back so the
@@ -329,7 +329,7 @@ Result EntityWorld::detachComponent(EntityId entity, ComponentTypeId typeId)
         return Result(Result::Code::Error, "invalid entity id");
     }
 
-    const vigine::graph::NodeId entityNode = toNodeId(entity);
+    const vigine::core::graph::NodeId entityNode = toNodeId(entity);
     if (!query().hasNode(entityNode))
     {
         return Result(Result::Code::Error, "stale entity id");
@@ -337,14 +337,14 @@ Result EntityWorld::detachComponent(EntityId entity, ComponentTypeId typeId)
 
     const auto attachedEdges
         = query().outEdgesOfKind(entityNode, vigine::ecs::edge_kind::Attached);
-    for (vigine::graph::EdgeId eid : attachedEdges)
+    for (vigine::core::graph::EdgeId eid : attachedEdges)
     {
-        const vigine::graph::IEdge *e = edge(eid);
+        const vigine::core::graph::IEdge *e = edge(eid);
         if (e == nullptr)
         {
             continue;
         }
-        const vigine::graph::INode *target = node(e->to());
+        const vigine::core::graph::INode *target = node(e->to());
         const auto                 *cn     = dynamic_cast<const ComponentNode *>(target);
         if (cn == nullptr || cn->component() == nullptr)
         {
@@ -368,7 +368,7 @@ const IComponent *EntityWorld::findComponent(
         return nullptr;
     }
 
-    const vigine::graph::NodeId entityNode = toNodeId(entity);
+    const vigine::core::graph::NodeId entityNode = toNodeId(entity);
     if (!query().hasNode(entityNode))
     {
         return nullptr;
@@ -376,14 +376,14 @@ const IComponent *EntityWorld::findComponent(
 
     const auto attachedEdges
         = query().outEdgesOfKind(entityNode, vigine::ecs::edge_kind::Attached);
-    for (vigine::graph::EdgeId eid : attachedEdges)
+    for (vigine::core::graph::EdgeId eid : attachedEdges)
     {
-        const vigine::graph::IEdge *e = edge(eid);
+        const vigine::core::graph::IEdge *e = edge(eid);
         if (e == nullptr)
         {
             continue;
         }
-        const vigine::graph::INode *target = node(e->to());
+        const vigine::core::graph::INode *target = node(e->to());
         const auto                 *cn     = dynamic_cast<const ComponentNode *>(target);
         if (cn == nullptr || cn->component() == nullptr)
         {
@@ -405,7 +405,7 @@ std::vector<const IComponent *> EntityWorld::componentsOf(EntityId entity) const
         return out;
     }
 
-    const vigine::graph::NodeId entityNode = toNodeId(entity);
+    const vigine::core::graph::NodeId entityNode = toNodeId(entity);
     if (!query().hasNode(entityNode))
     {
         return out;
@@ -414,14 +414,14 @@ std::vector<const IComponent *> EntityWorld::componentsOf(EntityId entity) const
     const auto attachedEdges
         = query().outEdgesOfKind(entityNode, vigine::ecs::edge_kind::Attached);
     out.reserve(attachedEdges.size());
-    for (vigine::graph::EdgeId eid : attachedEdges)
+    for (vigine::core::graph::EdgeId eid : attachedEdges)
     {
-        const vigine::graph::IEdge *e = edge(eid);
+        const vigine::core::graph::IEdge *e = edge(eid);
         if (e == nullptr)
         {
             continue;
         }
-        const vigine::graph::INode *target = node(e->to());
+        const vigine::core::graph::INode *target = node(e->to());
         const auto                 *cn     = dynamic_cast<const ComponentNode *>(target);
         if (cn == nullptr || cn->component() == nullptr)
         {
@@ -443,7 +443,7 @@ std::vector<EntityId> EntityWorld::entitiesWith(ComponentTypeId typeId) const
     // local mutex. The graph's own shared_mutex guards every per-edge
     // lookup, so concurrent attaches land under the graph's exclusive
     // lock and finish before this walk observes them.
-    std::vector<vigine::graph::NodeId> snapshot;
+    std::vector<vigine::core::graph::NodeId> snapshot;
     {
         std::shared_lock lock(_entitiesMutex);
         snapshot = _entities;
@@ -451,7 +451,7 @@ std::vector<EntityId> EntityWorld::entitiesWith(ComponentTypeId typeId) const
 
     std::vector<EntityId> out;
     out.reserve(snapshot.size());
-    for (vigine::graph::NodeId entityNode : snapshot)
+    for (vigine::core::graph::NodeId entityNode : snapshot)
     {
         if (!query().hasNode(entityNode))
         {
@@ -460,14 +460,14 @@ std::vector<EntityId> EntityWorld::entitiesWith(ComponentTypeId typeId) const
         const auto attachedEdges
             = query().outEdgesOfKind(entityNode, vigine::ecs::edge_kind::Attached);
         bool matched = false;
-        for (vigine::graph::EdgeId eid : attachedEdges)
+        for (vigine::core::graph::EdgeId eid : attachedEdges)
         {
-            const vigine::graph::IEdge *e = edge(eid);
+            const vigine::core::graph::IEdge *e = edge(eid);
             if (e == nullptr)
             {
                 continue;
             }
-            const vigine::graph::INode *target = node(e->to());
+            const vigine::core::graph::INode *target = node(e->to());
             const auto                 *cn     = dynamic_cast<const ComponentNode *>(target);
             if (cn == nullptr || cn->component() == nullptr)
             {

--- a/src/ecs/entityworld.h
+++ b/src/ecs/entityworld.h
@@ -6,8 +6,8 @@
 
 #include "vigine/ecs/ecstypes.h"
 #include "vigine/ecs/iecs.h"
-#include "vigine/graph/abstractgraph.h"
-#include "vigine/graph/nodeid.h"
+#include "vigine/core/graph/abstractgraph.h"
+#include "vigine/core/graph/nodeid.h"
 #include "vigine/result.h"
 
 namespace vigine::ecs
@@ -16,7 +16,7 @@ namespace vigine::ecs
  * @brief Internal graph specialisation that the ECS wrapper uses to
  *        hold its entity-and-component storage.
  *
- * @ref EntityWorld is a concrete @c vigine::graph::AbstractGraph
+ * @ref EntityWorld is a concrete @c vigine::core::graph::AbstractGraph
  * subtype that seals the inheritance chain for the ECS wrapper. It
  * carries the translation between the ECS's own POD handles
  * (@ref EntityId, @ref ComponentHandle) and the substrate's
@@ -25,7 +25,7 @@ namespace vigine::ecs
  * the public wrapper surface.
  *
  * This header lives under @c src/ecs on purpose: the INV-11 rule
- * forbids @c vigine::graph types from surfacing in
+ * forbids @c vigine::core::graph types from surfacing in
  * @c include/vigine/ecs. Only the wrapper implementation consumes the
  * world; callers of @ref IECS / @ref AbstractECS see neither the
  * world nor its graph base.
@@ -43,7 +43,7 @@ namespace vigine::ecs
  *   - @c vigine::ecs::edge_kind::Attached for the directed edge that
  *     ties a component node back to its owning entity.
  */
-class EntityWorld final : public vigine::graph::AbstractGraph
+class EntityWorld final : public vigine::core::graph::AbstractGraph
 {
   public:
     EntityWorld();
@@ -143,13 +143,13 @@ class EntityWorld final : public vigine::graph::AbstractGraph
      * same layout; the helper exists for type-safety, not for
      * arithmetic.
      */
-    [[nodiscard]] static vigine::graph::NodeId toNodeId(EntityId entity) noexcept;
+    [[nodiscard]] static vigine::core::graph::NodeId toNodeId(EntityId entity) noexcept;
 
     /**
      * @brief Translates an @ref ComponentHandle to the substrate's
      *        @c NodeId.
      */
-    [[nodiscard]] static vigine::graph::NodeId toNodeId(ComponentHandle handle) noexcept;
+    [[nodiscard]] static vigine::core::graph::NodeId toNodeId(ComponentHandle handle) noexcept;
 
     /**
      * @brief Translates a substrate @c NodeId back to an
@@ -158,14 +158,14 @@ class EntityWorld final : public vigine::graph::AbstractGraph
      * Only the wrapper implementation calls this; callers of the
      * public ECS API never see the substrate type.
      */
-    [[nodiscard]] static EntityId toEntityId(vigine::graph::NodeId node) noexcept;
+    [[nodiscard]] static EntityId toEntityId(vigine::core::graph::NodeId node) noexcept;
 
     /**
      * @brief Translates a substrate @c NodeId back to a
      *        @ref ComponentHandle.
      */
     [[nodiscard]] static ComponentHandle
-        toComponentHandle(vigine::graph::NodeId node) noexcept;
+        toComponentHandle(vigine::core::graph::NodeId node) noexcept;
 
   private:
     /**
@@ -187,7 +187,7 @@ class EntityWorld final : public vigine::graph::AbstractGraph
      * without probing the substrate via fragile index math. Mutated
      * only by @ref createEntity (push) and @ref removeEntity (erase).
      */
-    std::vector<vigine::graph::NodeId> _entities;
+    std::vector<vigine::core::graph::NodeId> _entities;
 };
 
 } // namespace vigine::ecs

--- a/src/service/serviceregistry.h
+++ b/src/service/serviceregistry.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "vigine/graph/abstractgraph.h"
+#include "vigine/core/graph/abstractgraph.h"
 
 namespace vigine::service
 {
@@ -8,7 +8,7 @@ namespace vigine::service
  * @brief Internal graph specialisation that the service wrapper uses
  *        to hold its service-domain storage.
  *
- * @ref ServiceRegistry is a concrete @c vigine::graph::AbstractGraph
+ * @ref ServiceRegistry is a concrete @c vigine::core::graph::AbstractGraph
  * subtype that seals the inheritance chain for the services wrapper.
  * It carries no additional state and no additional virtual methods; it
  * exists only to keep the graph substrate in a typed wrapper so
@@ -16,7 +16,7 @@ namespace vigine::service
  * a public header without leaking any graph primitives.
  *
  * This header lives under @c src/service on purpose: the INV-11 rule
- * forbids @c vigine::graph types from surfacing in
+ * forbids @c vigine::core::graph types from surfacing in
  * @c include/vigine/service. Only the wrapper implementation consumes
  * the registry; callers of @ref IService / @ref AbstractService see
  * neither the registry nor its graph base.
@@ -26,7 +26,7 @@ namespace vigine::service
  * The wrapper layer does not add any additional synchronisation on
  * top; every service-side access path funnels through the registry.
  */
-class ServiceRegistry final : public vigine::graph::AbstractGraph
+class ServiceRegistry final : public vigine::core::graph::AbstractGraph
 {
   public:
     ServiceRegistry();

--- a/src/statemachine/statetopology.cpp
+++ b/src/statemachine/statetopology.cpp
@@ -4,13 +4,13 @@
 #include <memory>
 
 #include "vigine/fsm/kind.h"
-#include "vigine/graph/abstractgraph.h"
-#include "vigine/graph/edgeid.h"
-#include "vigine/graph/iedge.h"
-#include "vigine/graph/igraphquery.h"
-#include "vigine/graph/inode.h"
-#include "vigine/graph/kind.h"
-#include "vigine/graph/nodeid.h"
+#include "vigine/core/graph/abstractgraph.h"
+#include "vigine/core/graph/edgeid.h"
+#include "vigine/core/graph/iedge.h"
+#include "vigine/core/graph/igraphquery.h"
+#include "vigine/core/graph/inode.h"
+#include "vigine/core/graph/kind.h"
+#include "vigine/core/graph/nodeid.h"
 #include "vigine/result.h"
 #include "vigine/statemachine/stateid.h"
 
@@ -35,28 +35,28 @@ namespace
  * flows back to @c id() without a round-trip through the graph.
  */
 class StateNode final
-    : public vigine::graph::INode
-    , public vigine::graph::AbstractGraph::IdStamp
+    : public vigine::core::graph::INode
+    , public vigine::core::graph::AbstractGraph::IdStamp
 {
   public:
     StateNode() = default;
 
-    [[nodiscard]] vigine::graph::NodeId id() const noexcept override { return _id; }
-    [[nodiscard]] vigine::graph::NodeKind kind() const noexcept override
+    [[nodiscard]] vigine::core::graph::NodeId id() const noexcept override { return _id; }
+    [[nodiscard]] vigine::core::graph::NodeKind kind() const noexcept override
     {
         return vigine::fsm::kind::State;
     }
 
     void onGraphIdAssigned(
-        vigine::graph::NodeId nodeId,
-        vigine::graph::EdgeId edgeId) noexcept override
+        vigine::core::graph::NodeId nodeId,
+        vigine::core::graph::EdgeId edgeId) noexcept override
     {
         _id = nodeId;
         (void)edgeId;
     }
 
   private:
-    vigine::graph::NodeId _id{};
+    vigine::core::graph::NodeId _id{};
 };
 
 /**
@@ -68,39 +68,39 @@ class StateNode final
  * @c outEdgesOfKind on the child vertex.
  */
 class ChildOfEdge final
-    : public vigine::graph::IEdge
-    , public vigine::graph::AbstractGraph::IdStamp
+    : public vigine::core::graph::IEdge
+    , public vigine::core::graph::AbstractGraph::IdStamp
 {
   public:
-    ChildOfEdge(vigine::graph::NodeId from, vigine::graph::NodeId to) noexcept
+    ChildOfEdge(vigine::core::graph::NodeId from, vigine::core::graph::NodeId to) noexcept
         : _from{from}, _to{to}
     {
     }
 
-    [[nodiscard]] vigine::graph::EdgeId id() const noexcept override { return _id; }
-    [[nodiscard]] vigine::graph::EdgeKind kind() const noexcept override
+    [[nodiscard]] vigine::core::graph::EdgeId id() const noexcept override { return _id; }
+    [[nodiscard]] vigine::core::graph::EdgeKind kind() const noexcept override
     {
         return vigine::fsm::edge_kind::ChildOf;
     }
-    [[nodiscard]] vigine::graph::NodeId from() const noexcept override { return _from; }
-    [[nodiscard]] vigine::graph::NodeId to() const noexcept override { return _to; }
-    [[nodiscard]] const vigine::graph::IEdgeData *data() const noexcept override
+    [[nodiscard]] vigine::core::graph::NodeId from() const noexcept override { return _from; }
+    [[nodiscard]] vigine::core::graph::NodeId to() const noexcept override { return _to; }
+    [[nodiscard]] const vigine::core::graph::IEdgeData *data() const noexcept override
     {
         return nullptr;
     }
 
     void onGraphIdAssigned(
-        vigine::graph::NodeId nodeId,
-        vigine::graph::EdgeId edgeId) noexcept override
+        vigine::core::graph::NodeId nodeId,
+        vigine::core::graph::EdgeId edgeId) noexcept override
     {
         _id = edgeId;
         (void)nodeId;
     }
 
   private:
-    vigine::graph::EdgeId _id{};
-    vigine::graph::NodeId _from{};
-    vigine::graph::NodeId _to{};
+    vigine::core::graph::EdgeId _id{};
+    vigine::core::graph::NodeId _from{};
+    vigine::core::graph::NodeId _to{};
 };
 
 } // namespace
@@ -115,17 +115,17 @@ StateTopology::~StateTopology() = default;
 
 // ---------------------------------------------------------------------------
 // POD translation helpers. The @ref StateId layout is intentionally
-// identical to @c vigine::graph::NodeId so the translation is a plain
+// identical to @c vigine::core::graph::NodeId so the translation is a plain
 // field-for-field copy; INV-11 allows it here because the conversion
 // lives entirely inside the wrapper implementation.
 // ---------------------------------------------------------------------------
 
-vigine::graph::NodeId StateTopology::toNodeId(StateId state) noexcept
+vigine::core::graph::NodeId StateTopology::toNodeId(StateId state) noexcept
 {
-    return vigine::graph::NodeId{state.index, state.generation};
+    return vigine::core::graph::NodeId{state.index, state.generation};
 }
 
-StateId StateTopology::toStateId(vigine::graph::NodeId node) noexcept
+StateId StateTopology::toStateId(vigine::core::graph::NodeId node) noexcept
 {
     return StateId{node.index, node.generation};
 }
@@ -141,7 +141,7 @@ StateId StateTopology::addState()
     // @c INode unique_ptr follows the IdStamp handshake — the node captures
     // the assigned id during insert.
     auto                        node = std::make_unique<StateNode>();
-    const vigine::graph::NodeId nid  = addNode(std::move(node));
+    const vigine::core::graph::NodeId nid  = addNode(std::move(node));
     return toStateId(nid);
 }
 
@@ -151,7 +151,7 @@ bool StateTopology::hasState(StateId state) const noexcept
     {
         return false;
     }
-    const vigine::graph::INode *n = node(toNodeId(state));
+    const vigine::core::graph::INode *n = node(toNodeId(state));
     return n != nullptr && n->kind() == vigine::fsm::kind::State;
 }
 
@@ -179,8 +179,8 @@ Result StateTopology::addChildEdge(StateId parent, StateId child)
     // dispatch path relies on.
     std::lock_guard<std::mutex> lock{_hierarchyMutex};
 
-    const vigine::graph::NodeId parentNode = toNodeId(parent);
-    const vigine::graph::NodeId childNode  = toNodeId(child);
+    const vigine::core::graph::NodeId parentNode = toNodeId(parent);
+    const vigine::core::graph::NodeId childNode  = toNodeId(child);
 
     if (!query().hasNode(parentNode))
     {
@@ -211,7 +211,7 @@ Result StateTopology::addChildEdge(StateId parent, StateId child)
     }
 
     auto                        edgePtr = std::make_unique<ChildOfEdge>(childNode, parentNode);
-    const vigine::graph::EdgeId eid     = addEdge(std::move(edgePtr));
+    const vigine::core::graph::EdgeId eid     = addEdge(std::move(edgePtr));
     if (!eid.valid())
     {
         return Result(Result::Code::Error, "failed to add child-of edge");
@@ -225,7 +225,7 @@ StateId StateTopology::parentOf(StateId state) const
     {
         return StateId{};
     }
-    const vigine::graph::NodeId nid = toNodeId(state);
+    const vigine::core::graph::NodeId nid = toNodeId(state);
     if (!query().hasNode(nid))
     {
         return StateId{};
@@ -236,7 +236,7 @@ StateId StateTopology::parentOf(StateId state) const
     {
         return StateId{};
     }
-    const vigine::graph::IEdge *e = edge(parents.front());
+    const vigine::core::graph::IEdge *e = edge(parents.front());
     if (e == nullptr)
     {
         return StateId{};

--- a/src/statemachine/statetopology.h
+++ b/src/statemachine/statetopology.h
@@ -4,8 +4,8 @@
 #include <cstdint>
 #include <mutex>
 
-#include "vigine/graph/abstractgraph.h"
-#include "vigine/graph/nodeid.h"
+#include "vigine/core/graph/abstractgraph.h"
+#include "vigine/core/graph/nodeid.h"
 #include "vigine/result.h"
 #include "vigine/statemachine/stateid.h"
 
@@ -15,7 +15,7 @@ namespace vigine::statemachine
  * @brief Internal graph specialisation that the state machine wrapper
  *        uses to hold its state-and-hierarchy storage.
  *
- * @ref StateTopology is a concrete @c vigine::graph::AbstractGraph
+ * @ref StateTopology is a concrete @c vigine::core::graph::AbstractGraph
  * subtype that seals the inheritance chain for the state machine
  * wrapper. It carries the translation between the wrapper's own POD
  * handle (@ref StateId) and the substrate's generational @c NodeId
@@ -24,7 +24,7 @@ namespace vigine::statemachine
  * wrapper surface.
  *
  * This header lives under @c src/statemachine on purpose: the INV-11
- * rule forbids @c vigine::graph types from surfacing in
+ * rule forbids @c vigine::core::graph types from surfacing in
  * @c include/vigine/statemachine. Only the wrapper implementation
  * consumes the topology; callers of @ref IStateMachine /
  * @ref AbstractStateMachine see neither the topology nor its graph
@@ -47,7 +47,7 @@ namespace vigine::statemachine
  *     leaf that wires the machine to the message bus; this leaf
  *     only maintains the hierarchy.
  */
-class StateTopology final : public vigine::graph::AbstractGraph
+class StateTopology final : public vigine::core::graph::AbstractGraph
 {
   public:
     StateTopology();
@@ -126,7 +126,7 @@ class StateTopology final : public vigine::graph::AbstractGraph
      * same layout; the helper exists for type-safety, not for
      * arithmetic.
      */
-    [[nodiscard]] static vigine::graph::NodeId toNodeId(StateId state) noexcept;
+    [[nodiscard]] static vigine::core::graph::NodeId toNodeId(StateId state) noexcept;
 
     /**
      * @brief Translates a substrate @c NodeId back to a
@@ -135,7 +135,7 @@ class StateTopology final : public vigine::graph::AbstractGraph
      * Only the wrapper implementation calls this; callers of the
      * public state machine API never see the substrate type.
      */
-    [[nodiscard]] static StateId toStateId(vigine::graph::NodeId node) noexcept;
+    [[nodiscard]] static StateId toStateId(vigine::core::graph::NodeId node) noexcept;
 
   private:
     /**

--- a/src/taskflow/taskorchestrator.cpp
+++ b/src/taskflow/taskorchestrator.cpp
@@ -3,14 +3,14 @@
 #include <cstdint>
 #include <memory>
 
-#include "vigine/graph/abstractgraph.h"
-#include "vigine/graph/edgeid.h"
-#include "vigine/graph/iedge.h"
-#include "vigine/graph/iedgedata.h"
-#include "vigine/graph/igraphquery.h"
-#include "vigine/graph/inode.h"
-#include "vigine/graph/kind.h"
-#include "vigine/graph/nodeid.h"
+#include "vigine/core/graph/abstractgraph.h"
+#include "vigine/core/graph/edgeid.h"
+#include "vigine/core/graph/iedge.h"
+#include "vigine/core/graph/iedgedata.h"
+#include "vigine/core/graph/igraphquery.h"
+#include "vigine/core/graph/inode.h"
+#include "vigine/core/graph/kind.h"
+#include "vigine/core/graph/nodeid.h"
 #include "vigine/result.h"
 #include "vigine/taskflow/kind.h"
 #include "vigine/taskflow/resultcode.h"
@@ -38,7 +38,7 @@ namespace
  * unit can accidentally collide with it. The value is arbitrary within
  * the space of @c std::uint32_t; the only contract is that every
  * transition edge reports exactly this value from its
- * @ref vigine::graph::IEdgeData::dataTypeId override.
+ * @ref vigine::core::graph::IEdgeData::dataTypeId override.
  */
 inline constexpr std::uint32_t kTransitionDataTypeId = 0x74665452U; // "tfTR"
 
@@ -50,28 +50,28 @@ inline constexpr std::uint32_t kTransitionDataTypeId = 0x74665452U; // "tfTR"
  * flows back to @c id() without a round-trip through the graph.
  */
 class TaskNode final
-    : public vigine::graph::INode
-    , public vigine::graph::AbstractGraph::IdStamp
+    : public vigine::core::graph::INode
+    , public vigine::core::graph::AbstractGraph::IdStamp
 {
   public:
     TaskNode() = default;
 
-    [[nodiscard]] vigine::graph::NodeId id() const noexcept override { return _id; }
-    [[nodiscard]] vigine::graph::NodeKind kind() const noexcept override
+    [[nodiscard]] vigine::core::graph::NodeId id() const noexcept override { return _id; }
+    [[nodiscard]] vigine::core::graph::NodeKind kind() const noexcept override
     {
         return vigine::taskflow::kind::Task;
     }
 
     void onGraphIdAssigned(
-        vigine::graph::NodeId nodeId,
-        vigine::graph::EdgeId edgeId) noexcept override
+        vigine::core::graph::NodeId nodeId,
+        vigine::core::graph::EdgeId edgeId) noexcept override
     {
         _id = nodeId;
         (void)edgeId;
     }
 
   private:
-    vigine::graph::NodeId _id{};
+    vigine::core::graph::NodeId _id{};
 };
 
 /**
@@ -84,7 +84,7 @@ class TaskNode final
  * registration to enforce the "one @ref RouteMode per pair"
  * invariant.
  */
-class TransitionData final : public vigine::graph::IEdgeData
+class TransitionData final : public vigine::core::graph::IEdgeData
 {
   public:
     TransitionData(ResultCode code, RouteMode mode) noexcept
@@ -114,13 +114,13 @@ class TransitionData final : public vigine::graph::IEdgeData
  * the @ref ResultCode and @ref RouteMode back during queries.
  */
 class TransitionEdge final
-    : public vigine::graph::IEdge
-    , public vigine::graph::AbstractGraph::IdStamp
+    : public vigine::core::graph::IEdge
+    , public vigine::core::graph::AbstractGraph::IdStamp
 {
   public:
     TransitionEdge(
-        vigine::graph::NodeId from,
-        vigine::graph::NodeId to,
+        vigine::core::graph::NodeId from,
+        vigine::core::graph::NodeId to,
         ResultCode            code,
         RouteMode             mode) noexcept
         : _from{from}
@@ -129,30 +129,30 @@ class TransitionEdge final
     {
     }
 
-    [[nodiscard]] vigine::graph::EdgeId id() const noexcept override { return _id; }
-    [[nodiscard]] vigine::graph::EdgeKind kind() const noexcept override
+    [[nodiscard]] vigine::core::graph::EdgeId id() const noexcept override { return _id; }
+    [[nodiscard]] vigine::core::graph::EdgeKind kind() const noexcept override
     {
         return vigine::taskflow::edge_kind::Transition;
     }
-    [[nodiscard]] vigine::graph::NodeId from() const noexcept override { return _from; }
-    [[nodiscard]] vigine::graph::NodeId to() const noexcept override { return _to; }
-    [[nodiscard]] const vigine::graph::IEdgeData *data() const noexcept override
+    [[nodiscard]] vigine::core::graph::NodeId from() const noexcept override { return _from; }
+    [[nodiscard]] vigine::core::graph::NodeId to() const noexcept override { return _to; }
+    [[nodiscard]] const vigine::core::graph::IEdgeData *data() const noexcept override
     {
         return &_data;
     }
 
     void onGraphIdAssigned(
-        vigine::graph::NodeId nodeId,
-        vigine::graph::EdgeId edgeId) noexcept override
+        vigine::core::graph::NodeId nodeId,
+        vigine::core::graph::EdgeId edgeId) noexcept override
     {
         _id = edgeId;
         (void)nodeId;
     }
 
   private:
-    vigine::graph::EdgeId _id{};
-    vigine::graph::NodeId _from{};
-    vigine::graph::NodeId _to{};
+    vigine::core::graph::EdgeId _id{};
+    vigine::core::graph::NodeId _from{};
+    vigine::core::graph::NodeId _to{};
     TransitionData        _data;
 };
 
@@ -168,17 +168,17 @@ TaskOrchestrator::~TaskOrchestrator() = default;
 
 // ---------------------------------------------------------------------------
 // POD translation helpers. The @ref TaskId layout is intentionally
-// identical to @c vigine::graph::NodeId so the translation is a plain
+// identical to @c vigine::core::graph::NodeId so the translation is a plain
 // field-for-field copy; INV-11 allows it here because the conversion
 // lives entirely inside the wrapper implementation.
 // ---------------------------------------------------------------------------
 
-vigine::graph::NodeId TaskOrchestrator::toNodeId(TaskId task) noexcept
+vigine::core::graph::NodeId TaskOrchestrator::toNodeId(TaskId task) noexcept
 {
-    return vigine::graph::NodeId{task.index, task.generation};
+    return vigine::core::graph::NodeId{task.index, task.generation};
 }
 
-TaskId TaskOrchestrator::toTaskId(vigine::graph::NodeId node) noexcept
+TaskId TaskOrchestrator::toTaskId(vigine::core::graph::NodeId node) noexcept
 {
     return TaskId{node.index, node.generation};
 }
@@ -194,7 +194,7 @@ TaskId TaskOrchestrator::addTask()
     // @c INode unique_ptr follows the IdStamp handshake — the node captures
     // the assigned id during insert.
     auto                        node = std::make_unique<TaskNode>();
-    const vigine::graph::NodeId nid  = addNode(std::move(node));
+    const vigine::core::graph::NodeId nid  = addNode(std::move(node));
     return toTaskId(nid);
 }
 
@@ -204,7 +204,7 @@ bool TaskOrchestrator::hasTask(TaskId task) const noexcept
     {
         return false;
     }
-    const vigine::graph::INode *n = node(toNodeId(task));
+    const vigine::core::graph::INode *n = node(toNodeId(task));
     return n != nullptr && n->kind() == vigine::taskflow::kind::Task;
 }
 
@@ -217,7 +217,7 @@ RouteMode TaskOrchestrator::storedModeFor(
     ResultCode code,
     RouteMode  fallback) const
 {
-    const vigine::graph::NodeId srcNode = toNodeId(source);
+    const vigine::core::graph::NodeId srcNode = toNodeId(source);
     if (!query().hasNode(srcNode))
     {
         return fallback;
@@ -231,12 +231,12 @@ RouteMode TaskOrchestrator::storedModeFor(
         = query().outEdgesOfKind(srcNode, vigine::taskflow::edge_kind::Transition);
     for (const auto eid : edges)
     {
-        const vigine::graph::IEdge *e = edge(eid);
+        const vigine::core::graph::IEdge *e = edge(eid);
         if (e == nullptr)
         {
             continue;
         }
-        const vigine::graph::IEdgeData *d = e->data();
+        const vigine::core::graph::IEdgeData *d = e->data();
         if (d == nullptr || d->dataTypeId() != kTransitionDataTypeId)
         {
             continue;
@@ -265,8 +265,8 @@ Result TaskOrchestrator::addTransition(
         return Result(Result::Code::Error, "task cannot transition to itself");
     }
 
-    const vigine::graph::NodeId srcNode  = toNodeId(source);
-    const vigine::graph::NodeId nextNode = toNodeId(next);
+    const vigine::core::graph::NodeId srcNode  = toNodeId(source);
+    const vigine::core::graph::NodeId nextNode = toNodeId(next);
 
     if (!query().hasNode(srcNode))
     {
@@ -291,7 +291,7 @@ Result TaskOrchestrator::addTransition(
 
     auto edgePtr
         = std::make_unique<TransitionEdge>(srcNode, nextNode, code, mode);
-    const vigine::graph::EdgeId eid = addEdge(std::move(edgePtr));
+    const vigine::core::graph::EdgeId eid = addEdge(std::move(edgePtr));
     if (!eid.valid())
     {
         return Result(Result::Code::Error, "failed to add transition edge");

--- a/src/taskflow/taskorchestrator.h
+++ b/src/taskflow/taskorchestrator.h
@@ -3,9 +3,9 @@
 #include <cstddef>
 #include <cstdint>
 
-#include "vigine/graph/abstractgraph.h"
-#include "vigine/graph/edgeid.h"
-#include "vigine/graph/nodeid.h"
+#include "vigine/core/graph/abstractgraph.h"
+#include "vigine/core/graph/edgeid.h"
+#include "vigine/core/graph/nodeid.h"
 #include "vigine/result.h"
 #include "vigine/taskflow/resultcode.h"
 #include "vigine/taskflow/routemode.h"
@@ -17,7 +17,7 @@ namespace vigine::taskflow
  * @brief Internal graph specialisation that the task flow wrapper uses
  *        to hold its tasks and their transitions.
  *
- * @ref TaskOrchestrator is a concrete @c vigine::graph::AbstractGraph
+ * @ref TaskOrchestrator is a concrete @c vigine::core::graph::AbstractGraph
  * subtype that seals the inheritance chain for the task flow wrapper.
  * It carries the translation between the wrapper's own POD handle
  * (@ref TaskId) and the substrate's generational @c NodeId so every
@@ -26,7 +26,7 @@ namespace vigine::taskflow
  * surface.
  *
  * This header lives under @c src/taskflow on purpose: the INV-11 rule
- * forbids @c vigine::graph types from surfacing in
+ * forbids @c vigine::core::graph types from surfacing in
  * @c include/vigine/taskflow. Only the wrapper implementation
  * consumes the orchestrator; callers of @ref ITaskFlow /
  * @ref AbstractTaskFlow see neither the orchestrator nor its graph
@@ -50,7 +50,7 @@ namespace vigine::taskflow
  *     edges registered against the same
  *     @c (source, resultCode) pair.
  */
-class TaskOrchestrator final : public vigine::graph::AbstractGraph
+class TaskOrchestrator final : public vigine::core::graph::AbstractGraph
 {
   public:
     TaskOrchestrator();
@@ -69,7 +69,7 @@ class TaskOrchestrator final : public vigine::graph::AbstractGraph
      *
      * The returned handle is always valid; the underlying graph never
      * returns an invalid generation from
-     * @ref vigine::graph::AbstractGraph::addNode.
+     * @ref vigine::core::graph::AbstractGraph::addNode.
      */
     [[nodiscard]] TaskId addTask();
 
@@ -109,7 +109,7 @@ class TaskOrchestrator final : public vigine::graph::AbstractGraph
      * same layout; the helper exists for type-safety, not for
      * arithmetic.
      */
-    [[nodiscard]] static vigine::graph::NodeId toNodeId(TaskId task) noexcept;
+    [[nodiscard]] static vigine::core::graph::NodeId toNodeId(TaskId task) noexcept;
 
     /**
      * @brief Translates a substrate @c NodeId back to a
@@ -118,7 +118,7 @@ class TaskOrchestrator final : public vigine::graph::AbstractGraph
      * Only the wrapper implementation calls this; callers of the
      * public task flow API never see the substrate type.
      */
-    [[nodiscard]] static TaskId toTaskId(vigine::graph::NodeId node) noexcept;
+    [[nodiscard]] static TaskId toTaskId(vigine::core::graph::NodeId node) noexcept;
 
   private:
     /**

--- a/test/graph/contract_async_timeout.cpp
+++ b/test/graph/contract_async_timeout.cpp
@@ -1,13 +1,13 @@
 #include "fixtures/graph_fixture_7n10e.h"
 
-#include "vigine/graph/iedge.h"
-#include "vigine/graph/igraph.h"
-#include "vigine/graph/igraphvisitor.h"
-#include "vigine/graph/inode.h"
-#include "vigine/graph/kind.h"
-#include "vigine/graph/nodeid.h"
-#include "vigine/graph/traverse_mode.h"
-#include "vigine/graph/visit_result.h"
+#include "vigine/core/graph/iedge.h"
+#include "vigine/core/graph/igraph.h"
+#include "vigine/core/graph/igraphvisitor.h"
+#include "vigine/core/graph/inode.h"
+#include "vigine/core/graph/kind.h"
+#include "vigine/core/graph/nodeid.h"
+#include "vigine/core/graph/traverse_mode.h"
+#include "vigine/core/graph/visit_result.h"
 #include "vigine/result.h"
 
 #include <gtest/gtest.h>
@@ -35,7 +35,7 @@
 // properties a wrapper would build on.
 // =============================================================================
 
-namespace vigine::graph::contract
+namespace vigine::core::graph::contract
 {
 namespace
 {
@@ -109,4 +109,4 @@ INSTANTIATE_TEST_SUITE_P(contract_async_timeout,
                          ::testing::Values(defaultGraphFactory()),
                          GraphFactoryNamer{});
 
-} // namespace vigine::graph::contract
+} // namespace vigine::core::graph::contract

--- a/test/graph/contract_fanout.cpp
+++ b/test/graph/contract_fanout.cpp
@@ -1,15 +1,15 @@
 #include "fixtures/graph_fixture_7n10e.h"
 
-#include "vigine/graph/edgeid.h"
-#include "vigine/graph/iedge.h"
-#include "vigine/graph/igraph.h"
-#include "vigine/graph/igraphquery.h"
-#include "vigine/graph/igraphvisitor.h"
-#include "vigine/graph/inode.h"
-#include "vigine/graph/kind.h"
-#include "vigine/graph/nodeid.h"
-#include "vigine/graph/traverse_mode.h"
-#include "vigine/graph/visit_result.h"
+#include "vigine/core/graph/edgeid.h"
+#include "vigine/core/graph/iedge.h"
+#include "vigine/core/graph/igraph.h"
+#include "vigine/core/graph/igraphquery.h"
+#include "vigine/core/graph/igraphvisitor.h"
+#include "vigine/core/graph/inode.h"
+#include "vigine/core/graph/kind.h"
+#include "vigine/core/graph/nodeid.h"
+#include "vigine/core/graph/traverse_mode.h"
+#include "vigine/core/graph/visit_result.h"
 #include "vigine/result.h"
 
 #include <gtest/gtest.h>
@@ -31,7 +31,7 @@
 // at depth one.
 // =============================================================================
 
-namespace vigine::graph::contract
+namespace vigine::core::graph::contract
 {
 namespace
 {
@@ -141,4 +141,4 @@ INSTANTIATE_TEST_SUITE_P(contract_fanout,
                          ::testing::Values(defaultGraphFactory()),
                          GraphFactoryNamer{});
 
-} // namespace vigine::graph::contract
+} // namespace vigine::core::graph::contract

--- a/test/graph/contract_generational_id.cpp
+++ b/test/graph/contract_generational_id.cpp
@@ -1,10 +1,10 @@
 #include "fixtures/graph_fixture_7n10e.h"
 
-#include "vigine/graph/edgeid.h"
-#include "vigine/graph/iedge.h"
-#include "vigine/graph/igraph.h"
-#include "vigine/graph/inode.h"
-#include "vigine/graph/nodeid.h"
+#include "vigine/core/graph/edgeid.h"
+#include "vigine/core/graph/iedge.h"
+#include "vigine/core/graph/igraph.h"
+#include "vigine/core/graph/inode.h"
+#include "vigine/core/graph/nodeid.h"
 
 #include <gtest/gtest.h>
 
@@ -30,7 +30,7 @@
 // graph with generational ids (as required by plan_01 / plan_02) passes.
 // =============================================================================
 
-namespace vigine::graph::contract
+namespace vigine::core::graph::contract
 {
 namespace
 {
@@ -164,4 +164,4 @@ INSTANTIATE_TEST_SUITE_P(contract_generational_id,
                          ::testing::Values(defaultGraphFactory()),
                          GraphFactoryNamer{});
 
-} // namespace vigine::graph::contract
+} // namespace vigine::core::graph::contract

--- a/test/graph/contract_hsm_bubble.cpp
+++ b/test/graph/contract_hsm_bubble.cpp
@@ -1,15 +1,15 @@
 #include "fixtures/graph_fixture_7n10e.h"
 
-#include "vigine/graph/edgeid.h"
-#include "vigine/graph/iedge.h"
-#include "vigine/graph/igraph.h"
-#include "vigine/graph/igraphquery.h"
-#include "vigine/graph/igraphvisitor.h"
-#include "vigine/graph/inode.h"
-#include "vigine/graph/kind.h"
-#include "vigine/graph/nodeid.h"
-#include "vigine/graph/traverse_mode.h"
-#include "vigine/graph/visit_result.h"
+#include "vigine/core/graph/edgeid.h"
+#include "vigine/core/graph/iedge.h"
+#include "vigine/core/graph/igraph.h"
+#include "vigine/core/graph/igraphquery.h"
+#include "vigine/core/graph/igraphvisitor.h"
+#include "vigine/core/graph/inode.h"
+#include "vigine/core/graph/kind.h"
+#include "vigine/core/graph/nodeid.h"
+#include "vigine/core/graph/traverse_mode.h"
+#include "vigine/core/graph/visit_result.h"
 #include "vigine/result.h"
 
 #include <gtest/gtest.h>
@@ -35,7 +35,7 @@
 //     early-exit signal, not a fault.
 // =============================================================================
 
-namespace vigine::graph::contract
+namespace vigine::core::graph::contract
 {
 namespace
 {
@@ -165,4 +165,4 @@ INSTANTIATE_TEST_SUITE_P(contract_hsm_bubble,
                          ::testing::Values(defaultGraphFactory()),
                          GraphFactoryNamer{});
 
-} // namespace vigine::graph::contract
+} // namespace vigine::core::graph::contract

--- a/test/graph/contract_iedge.cpp
+++ b/test/graph/contract_iedge.cpp
@@ -1,9 +1,9 @@
 #include "fixtures/graph_fixture_7n10e.h"
 
-#include "vigine/graph/edgeid.h"
-#include "vigine/graph/iedge.h"
-#include "vigine/graph/kind.h"
-#include "vigine/graph/nodeid.h"
+#include "vigine/core/graph/edgeid.h"
+#include "vigine/core/graph/iedge.h"
+#include "vigine/core/graph/kind.h"
+#include "vigine/core/graph/nodeid.h"
 
 #include <gtest/gtest.h>
 
@@ -19,7 +19,7 @@
 // guarantee.
 // =============================================================================
 
-namespace vigine::graph::contract
+namespace vigine::core::graph::contract
 {
 
 using EdgeContract = ContractFixture;
@@ -122,4 +122,4 @@ INSTANTIATE_TEST_SUITE_P(contract_iedge,
                          ::testing::Values(defaultGraphFactory()),
                          GraphFactoryNamer{});
 
-} // namespace vigine::graph::contract
+} // namespace vigine::core::graph::contract

--- a/test/graph/contract_igraph.cpp
+++ b/test/graph/contract_igraph.cpp
@@ -1,9 +1,9 @@
 #include "fixtures/graph_fixture_7n10e.h"
 
-#include "vigine/graph/factory.h"
-#include "vigine/graph/igraph.h"
-#include "vigine/graph/kind.h"
-#include "vigine/graph/nodeid.h"
+#include "vigine/core/graph/factory.h"
+#include "vigine/core/graph/igraph.h"
+#include "vigine/core/graph/kind.h"
+#include "vigine/core/graph/nodeid.h"
 #include "vigine/result.h"
 
 #include <gtest/gtest.h>
@@ -16,12 +16,12 @@
 //
 // Exercises the IGraph public surface through a GraphFactory parameter.
 // Every test in this file works against any concrete IGraph that honours
-// the surface declared in include/vigine/graph/; the factory registered
+// the surface declared in include/vigine/core/graph/; the factory registered
 // at the bottom is the engine's own createGraph, and a second concrete
 // graph wires into the same suite by adding another INSTANTIATE_TEST_SUITE_P.
 // =============================================================================
 
-namespace vigine::graph::contract
+namespace vigine::core::graph::contract
 {
 
 using LifecycleContract = ContractFixture;
@@ -335,4 +335,4 @@ INSTANTIATE_TEST_SUITE_P(contract_igraph,
                          ::testing::Values(defaultGraphFactory()),
                          GraphFactoryNamer{});
 
-} // namespace vigine::graph::contract
+} // namespace vigine::core::graph::contract

--- a/test/graph/contract_inode.cpp
+++ b/test/graph/contract_inode.cpp
@@ -1,8 +1,8 @@
 #include "fixtures/graph_fixture_7n10e.h"
 
-#include "vigine/graph/inode.h"
-#include "vigine/graph/kind.h"
-#include "vigine/graph/nodeid.h"
+#include "vigine/core/graph/inode.h"
+#include "vigine/core/graph/kind.h"
+#include "vigine/core/graph/nodeid.h"
 
 #include <gtest/gtest.h>
 
@@ -15,7 +15,7 @@
 // IGraph, plus the type-level pinning guarantee (copy / move deleted).
 // =============================================================================
 
-namespace vigine::graph::contract
+namespace vigine::core::graph::contract
 {
 
 using NodeContract = ContractFixture;
@@ -85,4 +85,4 @@ INSTANTIATE_TEST_SUITE_P(contract_inode,
                          ::testing::Values(defaultGraphFactory()),
                          GraphFactoryNamer{});
 
-} // namespace vigine::graph::contract
+} // namespace vigine::core::graph::contract

--- a/test/graph/contract_query.cpp
+++ b/test/graph/contract_query.cpp
@@ -1,12 +1,12 @@
 #include "fixtures/graph_fixture_7n10e.h"
 
-#include "vigine/graph/edgeid.h"
-#include "vigine/graph/iedge.h"
-#include "vigine/graph/igraph.h"
-#include "vigine/graph/igraphquery.h"
-#include "vigine/graph/inode.h"
-#include "vigine/graph/kind.h"
-#include "vigine/graph/nodeid.h"
+#include "vigine/core/graph/edgeid.h"
+#include "vigine/core/graph/iedge.h"
+#include "vigine/core/graph/igraph.h"
+#include "vigine/core/graph/igraphquery.h"
+#include "vigine/core/graph/inode.h"
+#include "vigine/core/graph/kind.h"
+#include "vigine/core/graph/nodeid.h"
 
 #include <gtest/gtest.h>
 
@@ -20,7 +20,7 @@
 // (undirected), hasCycle, topologicalOrder.
 // =============================================================================
 
-namespace vigine::graph::contract
+namespace vigine::core::graph::contract
 {
 namespace
 {
@@ -299,4 +299,4 @@ INSTANTIATE_TEST_SUITE_P(contract_query,
                          ::testing::Values(defaultGraphFactory()),
                          GraphFactoryNamer{});
 
-} // namespace vigine::graph::contract
+} // namespace vigine::core::graph::contract

--- a/test/graph/contract_result_deferred.cpp
+++ b/test/graph/contract_result_deferred.cpp
@@ -1,12 +1,12 @@
 #include "fixtures/graph_fixture_7n10e.h"
 
-#include "vigine/graph/iedge.h"
-#include "vigine/graph/igraph.h"
-#include "vigine/graph/igraphvisitor.h"
-#include "vigine/graph/inode.h"
-#include "vigine/graph/nodeid.h"
-#include "vigine/graph/traverse_mode.h"
-#include "vigine/graph/visit_result.h"
+#include "vigine/core/graph/iedge.h"
+#include "vigine/core/graph/igraph.h"
+#include "vigine/core/graph/igraphvisitor.h"
+#include "vigine/core/graph/inode.h"
+#include "vigine/core/graph/nodeid.h"
+#include "vigine/core/graph/traverse_mode.h"
+#include "vigine/core/graph/visit_result.h"
 #include "vigine/result.h"
 
 #include <gtest/gtest.h>
@@ -33,7 +33,7 @@
 // a wrapper needs.
 // =============================================================================
 
-namespace vigine::graph::contract
+namespace vigine::core::graph::contract
 {
 namespace
 {
@@ -141,4 +141,4 @@ INSTANTIATE_TEST_SUITE_P(contract_result_deferred,
                          ::testing::Values(defaultGraphFactory()),
                          GraphFactoryNamer{});
 
-} // namespace vigine::graph::contract
+} // namespace vigine::core::graph::contract

--- a/test/graph/contract_traversal.cpp
+++ b/test/graph/contract_traversal.cpp
@@ -1,14 +1,14 @@
 #include "fixtures/graph_fixture_7n10e.h"
 
-#include "vigine/graph/edgeid.h"
-#include "vigine/graph/iedge.h"
-#include "vigine/graph/igraph.h"
-#include "vigine/graph/igraphvisitor.h"
-#include "vigine/graph/inode.h"
-#include "vigine/graph/kind.h"
-#include "vigine/graph/nodeid.h"
-#include "vigine/graph/traverse_mode.h"
-#include "vigine/graph/visit_result.h"
+#include "vigine/core/graph/edgeid.h"
+#include "vigine/core/graph/iedge.h"
+#include "vigine/core/graph/igraph.h"
+#include "vigine/core/graph/igraphvisitor.h"
+#include "vigine/core/graph/inode.h"
+#include "vigine/core/graph/kind.h"
+#include "vigine/core/graph/nodeid.h"
+#include "vigine/core/graph/traverse_mode.h"
+#include "vigine/core/graph/visit_result.h"
 #include "vigine/result.h"
 
 #include <gtest/gtest.h>
@@ -35,7 +35,7 @@
 // success-on-Stop shape below.
 // =============================================================================
 
-namespace vigine::graph::contract
+namespace vigine::core::graph::contract
 {
 namespace
 {
@@ -436,4 +436,4 @@ INSTANTIATE_TEST_SUITE_P(contract_traversal,
                          ::testing::Values(defaultGraphFactory()),
                          GraphFactoryNamer{});
 
-} // namespace vigine::graph::contract
+} // namespace vigine::core::graph::contract

--- a/test/graph/fixtures/graph_fixture_7n10e.h
+++ b/test/graph/fixtures/graph_fixture_7n10e.h
@@ -1,13 +1,13 @@
 #pragma once
 
-#include "vigine/graph/edgeid.h"
-#include "vigine/graph/factory.h"
-#include "vigine/graph/iedge.h"
-#include "vigine/graph/iedgedata.h"
-#include "vigine/graph/igraph.h"
-#include "vigine/graph/inode.h"
-#include "vigine/graph/kind.h"
-#include "vigine/graph/nodeid.h"
+#include "vigine/core/graph/edgeid.h"
+#include "vigine/core/graph/factory.h"
+#include "vigine/core/graph/iedge.h"
+#include "vigine/core/graph/iedgedata.h"
+#include "vigine/core/graph/igraph.h"
+#include "vigine/core/graph/inode.h"
+#include "vigine/core/graph/kind.h"
+#include "vigine/core/graph/nodeid.h"
 
 #include <gtest/gtest.h>
 
@@ -18,7 +18,7 @@
 #include <utility>
 #include <vector>
 
-namespace vigine::graph::contract
+namespace vigine::core::graph::contract
 {
 /**
  * @brief Factory returning a new concrete IGraph behind the public API.
@@ -318,4 +318,4 @@ struct GraphFactoryNamer
     }
 };
 
-} // namespace vigine::graph::contract
+} // namespace vigine::core::graph::contract

--- a/test/script/test_check_graph_purity.py
+++ b/test/script/test_check_graph_purity.py
@@ -45,9 +45,9 @@ def run(argv: list[str]) -> int:
 
 def test_no_violation(tmp_path: Path) -> None:
     """A directory with only clean headers exits 0 and reports 0 violations."""
-    include_dir = tmp_path / "include" / "vigine" / "graph"
+    include_dir = tmp_path / "include" / "vigine" / "core" / "graph"
     include_dir.mkdir(parents=True)
-    src_dir = tmp_path / "src" / "graph"
+    src_dir = tmp_path / "src" / "core" / "graph"
     src_dir.mkdir(parents=True)
     write_header(
         include_dir,
@@ -55,7 +55,7 @@ def test_no_violation(tmp_path: Path) -> None:
         """\
         #pragma once
         #include <cstdint>
-        namespace vigine::graph { class INode {}; }
+        namespace vigine::core::graph { class INode {}; }
         """,
     )
     code = run(["--root", str(tmp_path), "--quiet"])
@@ -69,7 +69,7 @@ def test_no_violation(tmp_path: Path) -> None:
 
 def test_one_violation_forbidden_include(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
     """A single forbidden include in a header triggers exit 1."""
-    graph_dir = tmp_path / "include" / "vigine" / "graph"
+    graph_dir = tmp_path / "include" / "vigine" / "core" / "graph"
     graph_dir.mkdir(parents=True)
     write_header(
         graph_dir,
@@ -77,7 +77,7 @@ def test_one_violation_forbidden_include(tmp_path: Path, capsys: pytest.CaptureF
         """\
         #pragma once
         #include <vigine/messaging/kind.h>
-        namespace vigine::graph {}
+        namespace vigine::core::graph {}
         """,
     )
     code = run(["--root", str(tmp_path)])
@@ -94,7 +94,7 @@ def test_one_violation_forbidden_include(tmp_path: Path, capsys: pytest.CaptureF
 
 def test_multiple_violations(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
     """Multiple forbidden tokens in one file are all reported, exit 1."""
-    graph_dir = tmp_path / "include" / "vigine" / "graph"
+    graph_dir = tmp_path / "include" / "vigine" / "core" / "graph"
     graph_dir.mkdir(parents=True)
     write_header(
         graph_dir,
@@ -103,7 +103,7 @@ def test_multiple_violations(tmp_path: Path, capsys: pytest.CaptureFixture) -> N
         #pragma once
         #include <vigine/ecs/entity.h>
         #include <vigine/fsm/state.h>
-        namespace vigine::graph {}
+        namespace vigine::core::graph {}
         """,
     )
     code = run(["--root", str(tmp_path)])
@@ -121,9 +121,9 @@ def test_multiple_violations(tmp_path: Path, capsys: pytest.CaptureFixture) -> N
 
 def test_waiver_respected(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
     """Lines containing // INV-9 EXEMPTION: are not reported as violations."""
-    graph_dir = tmp_path / "include" / "vigine" / "graph"
+    graph_dir = tmp_path / "include" / "vigine" / "core" / "graph"
     graph_dir.mkdir(parents=True)
-    src_dir = tmp_path / "src" / "graph"
+    src_dir = tmp_path / "src" / "core" / "graph"
     src_dir.mkdir(parents=True)
     write_header(
         graph_dir,
@@ -131,7 +131,7 @@ def test_waiver_respected(tmp_path: Path, capsys: pytest.CaptureFixture) -> None
         """\
         #pragma once
         #include <vigine/messaging/bus.h>  // INV-9 EXEMPTION: justified by design doc
-        namespace vigine::graph {}
+        namespace vigine::core::graph {}
         """,
     )
     code = run(["--root", str(tmp_path), "--quiet"])


### PR DESCRIPTION
Relocates the graph substrate under the kernel layer:

- `include/vigine/graph/` -> `include/vigine/core/graph/`
- `src/graph/` -> `src/core/graph/`
- `vigine::graph` -> `vigine::core::graph` across every caller
- CMakeLists and the two static checkers (`check_graph_purity`,
  `check_wrapper_encapsulation`) follow the new layout.

Refs #217, part of #197.

### Scope

- 21 files moved via `git mv` (13 headers + 8 sources).
- 61 files touched for includes / namespace renames.
- Zero class renames -- `IGraph`, `AbstractGraph`, `Graph` already
  conform to R-Naming.

### Acceptance

- `test ! -d include/vigine/graph` OK.
- `test -d include/vigine/core/graph` OK.
- `grep -rln "vigine::graph::" include/ src/ test/ example/` empty.
- `grep -rln "#include <vigine/graph/" include/ src/ test/ example/` empty.
- `python script/check_graph_purity.py --root .` -> 21 files scanned,
  0 violations.
- `pytest test/script/test_check_graph_purity.py -q` -> 5 passed.
- Full CMake build + ctest are run by CI (local host has no CMake).