### PR TITLE
Move threading/ into core/threading/ and rename to ThreadManager (#218)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,19 +200,19 @@ set(HEADER
     ${INCLUDE_DIR}/vigine/graph/igraph.h
     ${INCLUDE_DIR}/vigine/graph/factory.h
     ${INCLUDE_DIR}/vigine/graph/abstractgraph.h
-    ${INCLUDE_DIR}/vigine/threading/threadaffinity.h
-    ${INCLUDE_DIR}/vigine/threading/namedthreadid.h
-    ${INCLUDE_DIR}/vigine/threading/threadmanagerconfig.h
-    ${INCLUDE_DIR}/vigine/threading/irunnable.h
-    ${INCLUDE_DIR}/vigine/threading/itaskhandle.h
-    ${INCLUDE_DIR}/vigine/threading/imutex.h
-    ${INCLUDE_DIR}/vigine/threading/isemaphore.h
-    ${INCLUDE_DIR}/vigine/threading/ibarrier.h
-    ${INCLUDE_DIR}/vigine/threading/imessagechannel.h
-    ${INCLUDE_DIR}/vigine/threading/ithreadmanager.h
-    ${INCLUDE_DIR}/vigine/threading/abstractthreadmanager.h
-    ${INCLUDE_DIR}/vigine/threading/defaultthreadmanager.h
-    ${INCLUDE_DIR}/vigine/threading/factory.h
+    ${INCLUDE_DIR}/vigine/core/threading/threadaffinity.h
+    ${INCLUDE_DIR}/vigine/core/threading/namedthreadid.h
+    ${INCLUDE_DIR}/vigine/core/threading/threadmanagerconfig.h
+    ${INCLUDE_DIR}/vigine/core/threading/irunnable.h
+    ${INCLUDE_DIR}/vigine/core/threading/itaskhandle.h
+    ${INCLUDE_DIR}/vigine/core/threading/imutex.h
+    ${INCLUDE_DIR}/vigine/core/threading/isemaphore.h
+    ${INCLUDE_DIR}/vigine/core/threading/ibarrier.h
+    ${INCLUDE_DIR}/vigine/core/threading/imessagechannel.h
+    ${INCLUDE_DIR}/vigine/core/threading/ithreadmanager.h
+    ${INCLUDE_DIR}/vigine/core/threading/abstractthreadmanager.h
+    ${INCLUDE_DIR}/vigine/core/threading/threadmanager.h
+    ${INCLUDE_DIR}/vigine/core/threading/factory.h
     ${INCLUDE_DIR}/vigine/payload/payloadtypeid.h
     ${INCLUDE_DIR}/vigine/payload/payloadrange.h
     ${INCLUDE_DIR}/vigine/payload/ipayloadregistry.h
@@ -280,18 +280,18 @@ set(SOURCES
     ${SRC_DIR}/graph/defaultgraph_query.cpp
     ${SRC_DIR}/graph/defaultgraph_export.cpp
     ${SRC_DIR}/graph/factory.cpp
-    ${SRC_DIR}/threading/abstractthreadmanager.cpp
-    ${SRC_DIR}/threading/defaultthreadmanager.cpp
-    ${SRC_DIR}/threading/defaultmutex.h
-    ${SRC_DIR}/threading/defaultmutex.cpp
-    ${SRC_DIR}/threading/defaultsemaphore.h
-    ${SRC_DIR}/threading/defaultsemaphore.cpp
-    ${SRC_DIR}/threading/defaultbarrier.h
-    ${SRC_DIR}/threading/defaultbarrier.cpp
-    ${SRC_DIR}/threading/defaultmessagechannel.h
-    ${SRC_DIR}/threading/defaultmessagechannel.cpp
-    ${SRC_DIR}/threading/defaultthreadmanager_factories.cpp
-    ${SRC_DIR}/threading/factory.cpp
+    ${SRC_DIR}/core/threading/abstractthreadmanager.cpp
+    ${SRC_DIR}/core/threading/threadmanager.cpp
+    ${SRC_DIR}/core/threading/defaultmutex.h
+    ${SRC_DIR}/core/threading/defaultmutex.cpp
+    ${SRC_DIR}/core/threading/defaultsemaphore.h
+    ${SRC_DIR}/core/threading/defaultsemaphore.cpp
+    ${SRC_DIR}/core/threading/defaultbarrier.h
+    ${SRC_DIR}/core/threading/defaultbarrier.cpp
+    ${SRC_DIR}/core/threading/defaultmessagechannel.h
+    ${SRC_DIR}/core/threading/defaultmessagechannel.cpp
+    ${SRC_DIR}/core/threading/defaultthreadmanager_factories.cpp
+    ${SRC_DIR}/core/threading/factory.cpp
     ${SRC_DIR}/payload/abstractpayloadregistry.h
     ${SRC_DIR}/payload/abstractpayloadregistry.cpp
     ${SRC_DIR}/payload/defaultpayloadregistry.h

--- a/example/window/main.cpp
+++ b/example/window/main.cpp
@@ -27,8 +27,8 @@
 #include <vigine/payload/payloadtypeid.h>
 #include <vigine/signalemitter/defaultsignalemitter.h>
 #include <vigine/signalemitter/isignalemitter.h>
-#include <vigine/threading/ithreadmanager.h>
-#include <vigine/threading/threadaffinity.h>
+#include <vigine/core/threading/ithreadmanager.h>
+#include <vigine/core/threading/threadaffinity.h>
 
 #include <vigine/context.h>
 
@@ -86,10 +86,10 @@ std::unique_ptr<TaskFlow> createInitTaskFlow(signalemitter::ISignalEmitter *sign
     // stall rendering if the handler grows heavier later.
     static_cast<void>(taskFlow->signal(runWindow, processInputEventTask,
                                        kMouseButtonDownPayloadTypeId,
-                                       threading::ThreadAffinity::Pool));
+                                       core::threading::ThreadAffinity::Pool));
     static_cast<void>(taskFlow->signal(runWindow, processInputEventTask,
                                        kKeyDownPayloadTypeId,
-                                       threading::ThreadAffinity::Pool));
+                                       core::threading::ThreadAffinity::Pool));
 
     taskFlow->changeCurrentTaskTo(initWindow);
 

--- a/include/vigine/actorhost/abstractactorhost.h
+++ b/include/vigine/actorhost/abstractactorhost.h
@@ -2,7 +2,7 @@
 
 #include "vigine/actorhost/iactorhost.h"
 #include "vigine/messaging/imessagebus.h"
-#include "vigine/threading/ithreadmanager.h"
+#include "vigine/core/threading/ithreadmanager.h"
 
 namespace vigine::actorhost
 {
@@ -13,7 +13,7 @@ namespace vigine::actorhost
  * @ref AbstractActorHost is Level-4 of the five-layer wrapper recipe.  It
  * inherits @ref IActorHost @c public so the actor surface sits at offset zero
  * for zero-cost up-casts, and holds references to the underlying
- * @ref vigine::messaging::IMessageBus and @ref vigine::threading::IThreadManager
+ * @ref vigine::messaging::IMessageBus and @ref vigine::core::threading::IThreadManager
  * @c protected so subclass wiring can reach them without exposing the raw
  * surfaces in the public actor-host API.
  *
@@ -50,7 +50,7 @@ class AbstractActorHost : public IActorHost
      * this facade instance.
      */
     AbstractActorHost(vigine::messaging::IMessageBus    &bus,
-                      vigine::threading::IThreadManager &threadManager);
+                      vigine::core::threading::IThreadManager &threadManager);
 
     /**
      * @brief Returns the underlying bus reference for subclass wiring.
@@ -60,11 +60,11 @@ class AbstractActorHost : public IActorHost
     /**
      * @brief Returns the thread manager reference for subclass wiring.
      */
-    [[nodiscard]] vigine::threading::IThreadManager &threadManager() noexcept;
+    [[nodiscard]] vigine::core::threading::IThreadManager &threadManager() noexcept;
 
   private:
     vigine::messaging::IMessageBus    &_bus;
-    vigine::threading::IThreadManager &_threadManager;
+    vigine::core::threading::IThreadManager &_threadManager;
 };
 
 } // namespace vigine::actorhost

--- a/include/vigine/actorhost/defaultactorhost.h
+++ b/include/vigine/actorhost/defaultactorhost.h
@@ -43,7 +43,7 @@ class DefaultActorHost final : public AbstractActorHost
      * Both @p bus and @p threadManager must outlive this facade instance.
      */
     DefaultActorHost(vigine::messaging::IMessageBus    &bus,
-                     vigine::threading::IThreadManager &threadManager);
+                     vigine::core::threading::IThreadManager &threadManager);
 
     ~DefaultActorHost() override;
 
@@ -79,6 +79,6 @@ class DefaultActorHost final : public AbstractActorHost
  */
 [[nodiscard]] std::unique_ptr<IActorHost>
     createActorHost(vigine::messaging::IMessageBus    &bus,
-                    vigine::threading::IThreadManager &threadManager);
+                    vigine::core::threading::IThreadManager &threadManager);
 
 } // namespace vigine::actorhost

--- a/include/vigine/actorhost/factory.h
+++ b/include/vigine/actorhost/factory.h
@@ -9,10 +9,10 @@ namespace vigine::messaging
 class IMessageBus;
 } // namespace vigine::messaging
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 class IThreadManager;
-} // namespace vigine::threading
+} // namespace vigine::core::threading
 
 namespace vigine::actorhost
 {
@@ -34,6 +34,6 @@ namespace vigine::actorhost
  */
 [[nodiscard]] std::unique_ptr<IActorHost>
     createActorHost(vigine::messaging::IMessageBus    &bus,
-                    vigine::threading::IThreadManager &threadManager);
+                    vigine::core::threading::IThreadManager &threadManager);
 
 } // namespace vigine::actorhost

--- a/include/vigine/actorhost/iactorhost.h
+++ b/include/vigine/actorhost/iactorhost.h
@@ -18,7 +18,7 @@ namespace vigine::actorhost
  * R.3.3.2.3).  It manages a collection of isolated @ref IActor instances, each
  * with its own FIFO mailbox processed by a single dedicated thread.  The
  * invariant that @ref IActor::receive is never called concurrently for the same
- * actor is enforced by the host through @ref vigine::threading::IThreadManager.
+ * actor is enforced by the host through @ref vigine::core::threading::IThreadManager.
  *
  * Ownership:
  *   - @ref spawn takes unique ownership of the supplied @ref IActor and returns

--- a/include/vigine/context.h
+++ b/include/vigine/context.h
@@ -13,10 +13,10 @@
 namespace vigine
 {
 
-namespace threading
+namespace core::threading
 {
 class IThreadManager;
-} // namespace threading
+} // namespace core::threading
 
 enum class Property;
 class EntityManager;
@@ -63,7 +63,7 @@ class Context : public IContext
     [[nodiscard]] statemachine::IStateMachine &stateMachine() override;
     [[nodiscard]] taskflow::ITaskFlow         &taskFlow() override;
 
-    [[nodiscard]] threading::IThreadManager &threadManager() override;
+    [[nodiscard]] core::threading::IThreadManager &threadManager() override;
 
     [[nodiscard]] std::shared_ptr<service::IService>
         service(service::ServiceId id) const override;
@@ -75,7 +75,7 @@ class Context : public IContext
     [[nodiscard]] bool isFrozen() const noexcept override;
 
   private:
-    Context(EntityManager *entityManager, threading::IThreadManager *threadManager);
+    Context(EntityManager *entityManager, core::threading::IThreadManager *threadManager);
     AbstractServiceUPtr createService(const ServiceId &id, const Name &name);
     AbstractSystemUPtr createSystem(const SystemId &id, const SystemName &name);
 
@@ -88,7 +88,7 @@ class Context : public IContext
     // callers through threadManager() so TaskFlow::signal's non-Any
     // path and any other context-driven scheduling works on the
     // legacy Engine front door.
-    threading::IThreadManager *_threadManager{nullptr};
+    core::threading::IThreadManager *_threadManager{nullptr};
     // Atomic because `isFrozen()` is documented as safe from any
     // thread and runs alongside lifecycle transitions. A plain bool
     // here would be a TSAN-observable data race even though the

--- a/include/vigine/context/abstractcontext.h
+++ b/include/vigine/context/abstractcontext.h
@@ -17,7 +17,7 @@
 #include "vigine/service/serviceid.h"
 #include "vigine/statemachine/istatemachine.h"
 #include "vigine/taskflow/itaskflow.h"
-#include "vigine/threading/ithreadmanager.h"
+#include "vigine/core/threading/ithreadmanager.h"
 
 namespace vigine::context
 {
@@ -40,7 +40,7 @@ namespace vigine::context
  *
  * Construction order (encoded by member declaration order in the
  * private block below):
- *   1. @ref threading::IThreadManager -- created first so every
+ *   1. @ref core::threading::IThreadManager -- created first so every
  *      downstream component can depend on it.
  *   2. @ref messaging::IMessageBus (system) -- created second; takes
  *      a reference to the thread manager.
@@ -99,7 +99,7 @@ class AbstractContext : public IContext
 
     // ------ IContext: threading ------
 
-    [[nodiscard]] threading::IThreadManager &threadManager() override;
+    [[nodiscard]] core::threading::IThreadManager &threadManager() override;
 
     // ------ IContext: service registry ------
 
@@ -171,7 +171,7 @@ class AbstractContext : public IContext
      * bus workers and sync primitives before the thread manager joins
      * its pool.
      */
-    std::unique_ptr<threading::IThreadManager> _threadManager;
+    std::unique_ptr<core::threading::IThreadManager> _threadManager;
 
     /**
      * @brief Second member: the engine-wide system bus.

--- a/include/vigine/context/contextconfig.h
+++ b/include/vigine/context/contextconfig.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "vigine/messaging/busconfig.h"
-#include "vigine/threading/threadmanagerconfig.h"
+#include "vigine/core/threading/threadmanagerconfig.h"
 
 namespace vigine::context
 {
@@ -33,7 +33,7 @@ struct ContextConfig
     /**
      * @brief Threading substrate configuration consumed first.
      */
-    threading::ThreadManagerConfig threading{};
+    core::threading::ThreadManagerConfig threading{};
 
     /**
      * @brief System bus configuration consumed second.

--- a/include/vigine/context/icontext.h
+++ b/include/vigine/context/icontext.h
@@ -32,10 +32,10 @@ namespace vigine::taskflow
 class ITaskFlow;
 } // namespace vigine::taskflow
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 class IThreadManager;
-} // namespace vigine::threading
+} // namespace vigine::core::threading
 
 namespace vigine
 {
@@ -64,7 +64,7 @@ namespace vigine
  *     available.
  *
  * Strict construction order (AD-5 C8, encoded by @ref AbstractContext):
- *   1. @ref threading::IThreadManager (created first).
+ *   1. @ref core::threading::IThreadManager (created first).
  *   2. system @ref messaging::IMessageBus (needs the thread manager).
  *   3. Level-1 wrappers (ECS, state machine, task flow).
  *   4. services registered through @ref registerService.
@@ -167,7 +167,7 @@ class IContext
      * construction and destruction orders in @ref AbstractContext are
      * strict.
      */
-    [[nodiscard]] virtual threading::IThreadManager &threadManager() = 0;
+    [[nodiscard]] virtual core::threading::IThreadManager &threadManager() = 0;
 
     // ------ Service registry ------
 

--- a/include/vigine/core/threading/abstractthreadmanager.h
+++ b/include/vigine/core/threading/abstractthreadmanager.h
@@ -11,15 +11,15 @@
 #include <vector>
 
 #include "vigine/result.h"
-#include "vigine/threading/ibarrier.h"
-#include "vigine/threading/imessagechannel.h"
-#include "vigine/threading/imutex.h"
-#include "vigine/threading/isemaphore.h"
-#include "vigine/threading/ithreadmanager.h"
-#include "vigine/threading/namedthreadid.h"
-#include "vigine/threading/threadmanagerconfig.h"
+#include "vigine/core/threading/ibarrier.h"
+#include "vigine/core/threading/imessagechannel.h"
+#include "vigine/core/threading/imutex.h"
+#include "vigine/core/threading/isemaphore.h"
+#include "vigine/core/threading/ithreadmanager.h"
+#include "vigine/core/threading/namedthreadid.h"
+#include "vigine/core/threading/threadmanagerconfig.h"
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 /**
  * @brief Concrete stateful base for every in-process @ref IThreadManager.
@@ -30,13 +30,13 @@ namespace vigine::threading
  * atomic shut-down flag. It implements the parts of @ref IThreadManager
  * that are identical across every implementation — registry bookkeeping
  * and observability — and leaves the scheduling and pump mechanics
- * abstract for @ref DefaultThreadManager to provide.
+ * abstract for @ref ThreadManager to provide.
  *
  * The class carries state, so it follows the project's @c Abstract
  * naming convention rather than the @c I pure-virtual prefix. It is
  * abstract only in the logical sense — users do not instantiate it
  * directly; @ref createThreadManager returns a @c final subclass
- * (@ref DefaultThreadManager) that closes the inheritance chain.
+ * (@ref ThreadManager) that closes the inheritance chain.
  *
  * Thread-safety: every mutating entry point on the registry takes
  * an exclusive lock on an internal @c std::mutex. The shut-down flag
@@ -193,4 +193,4 @@ class AbstractThreadManager : public IThreadManager
     std::atomic<std::uint32_t>     _nextNamedGeneration{1};
 };
 
-} // namespace vigine::threading
+} // namespace vigine::core::threading

--- a/include/vigine/core/threading/factory.h
+++ b/include/vigine/core/threading/factory.h
@@ -2,10 +2,10 @@
 
 #include <memory>
 
-#include "vigine/threading/ithreadmanager.h"
-#include "vigine/threading/threadmanagerconfig.h"
+#include "vigine/core/threading/ithreadmanager.h"
+#include "vigine/core/threading/threadmanagerconfig.h"
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 /**
  * @brief Constructs the default @ref IThreadManager implementation.
@@ -30,4 +30,4 @@ namespace vigine::threading
 [[nodiscard]] std::unique_ptr<IThreadManager>
     createThreadManager(const ThreadManagerConfig &config = {});
 
-} // namespace vigine::threading
+} // namespace vigine::core::threading

--- a/include/vigine/core/threading/ibarrier.h
+++ b/include/vigine/core/threading/ibarrier.h
@@ -5,7 +5,7 @@
 
 #include "vigine/result.h"
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 /**
  * @brief Pure-virtual reusable barrier produced by
@@ -78,4 +78,4 @@ class IBarrier
     IBarrier() = default;
 };
 
-} // namespace vigine::threading
+} // namespace vigine::core::threading

--- a/include/vigine/core/threading/imessagechannel.h
+++ b/include/vigine/core/threading/imessagechannel.h
@@ -8,7 +8,7 @@
 #include "vigine/payload/payloadtypeid.h"
 #include "vigine/result.h"
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 /**
  * @brief Owning wrapper around one payload byte buffer carried through
@@ -181,4 +181,4 @@ class IMessageChannel
     IMessageChannel() = default;
 };
 
-} // namespace vigine::threading
+} // namespace vigine::core::threading

--- a/include/vigine/core/threading/imutex.h
+++ b/include/vigine/core/threading/imutex.h
@@ -4,7 +4,7 @@
 
 #include "vigine/result.h"
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 /**
  * @brief Pure-virtual engine-level mutual-exclusion primitive.
@@ -78,4 +78,4 @@ class IMutex
     IMutex() = default;
 };
 
-} // namespace vigine::threading
+} // namespace vigine::core::threading

--- a/include/vigine/core/threading/irunnable.h
+++ b/include/vigine/core/threading/irunnable.h
@@ -2,7 +2,7 @@
 
 #include "vigine/result.h"
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 /**
  * @brief Pure-virtual interface for any unit of work posted to the thread
@@ -46,4 +46,4 @@ class IRunnable
     IRunnable() = default;
 };
 
-} // namespace vigine::threading
+} // namespace vigine::core::threading

--- a/include/vigine/core/threading/isemaphore.h
+++ b/include/vigine/core/threading/isemaphore.h
@@ -5,7 +5,7 @@
 
 #include "vigine/result.h"
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 /**
  * @brief Pure-virtual counting semaphore produced by
@@ -80,4 +80,4 @@ class ISemaphore
     ISemaphore() = default;
 };
 
-} // namespace vigine::threading
+} // namespace vigine::core::threading

--- a/include/vigine/core/threading/itaskhandle.h
+++ b/include/vigine/core/threading/itaskhandle.h
@@ -4,7 +4,7 @@
 
 #include "vigine/result.h"
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 /**
  * @brief Caller-held handle to a scheduled @ref IRunnable.
@@ -77,4 +77,4 @@ class ITaskHandle
     ITaskHandle() = default;
 };
 
-} // namespace vigine::threading
+} // namespace vigine::core::threading

--- a/include/vigine/core/threading/ithreadmanager.h
+++ b/include/vigine/core/threading/ithreadmanager.h
@@ -5,16 +5,16 @@
 #include <string_view>
 
 #include "vigine/result.h"
-#include "vigine/threading/ibarrier.h"
-#include "vigine/threading/imessagechannel.h"
-#include "vigine/threading/imutex.h"
-#include "vigine/threading/irunnable.h"
-#include "vigine/threading/isemaphore.h"
-#include "vigine/threading/itaskhandle.h"
-#include "vigine/threading/namedthreadid.h"
-#include "vigine/threading/threadaffinity.h"
+#include "vigine/core/threading/ibarrier.h"
+#include "vigine/core/threading/imessagechannel.h"
+#include "vigine/core/threading/imutex.h"
+#include "vigine/core/threading/irunnable.h"
+#include "vigine/core/threading/isemaphore.h"
+#include "vigine/core/threading/itaskhandle.h"
+#include "vigine/core/threading/namedthreadid.h"
+#include "vigine/core/threading/threadaffinity.h"
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 /**
  * @brief Pure-virtual core of the threading substrate.
@@ -208,4 +208,4 @@ class IThreadManager
     IThreadManager() = default;
 };
 
-} // namespace vigine::threading
+} // namespace vigine::core::threading

--- a/include/vigine/core/threading/namedthreadid.h
+++ b/include/vigine/core/threading/namedthreadid.h
@@ -3,7 +3,7 @@
 #include <compare>
 #include <cstdint>
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 /**
  * @brief Generational identifier of a named thread registered with
@@ -38,4 +38,4 @@ struct NamedThreadId
     friend constexpr bool operator==(const NamedThreadId &, const NamedThreadId &)  = default;
 };
 
-} // namespace vigine::threading
+} // namespace vigine::core::threading

--- a/include/vigine/core/threading/threadaffinity.h
+++ b/include/vigine/core/threading/threadaffinity.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 /**
  * @brief Closed enumeration of scheduling targets accepted by @ref IThreadManager.
@@ -42,4 +42,4 @@ enum class ThreadAffinity : std::uint8_t
     Named = 4,
 };
 
-} // namespace vigine::threading
+} // namespace vigine::core::threading

--- a/include/vigine/core/threading/threadmanager.h
+++ b/include/vigine/core/threading/threadmanager.h
@@ -2,14 +2,14 @@
 
 #include <memory>
 
-#include "vigine/threading/abstractthreadmanager.h"
-#include "vigine/threading/irunnable.h"
-#include "vigine/threading/itaskhandle.h"
-#include "vigine/threading/namedthreadid.h"
-#include "vigine/threading/threadaffinity.h"
-#include "vigine/threading/threadmanagerconfig.h"
+#include "vigine/core/threading/abstractthreadmanager.h"
+#include "vigine/core/threading/irunnable.h"
+#include "vigine/core/threading/itaskhandle.h"
+#include "vigine/core/threading/namedthreadid.h"
+#include "vigine/core/threading/threadaffinity.h"
+#include "vigine/core/threading/threadmanagerconfig.h"
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 /**
  * @brief Default concrete @ref IThreadManager implementation.
@@ -32,11 +32,11 @@ namespace vigine::threading
  * object returns. Explicit @ref shutdown is equivalent; calling it more
  * than once is a no-op.
  */
-class DefaultThreadManager final : public AbstractThreadManager
+class ThreadManager final : public AbstractThreadManager
 {
   public:
-    explicit DefaultThreadManager(ThreadManagerConfig config);
-    ~DefaultThreadManager() override;
+    explicit ThreadManager(ThreadManagerConfig config);
+    ~ThreadManager() override;
 
     [[nodiscard]] std::unique_ptr<ITaskHandle>
         schedule(std::unique_ptr<IRunnable> runnable, ThreadAffinity affinity) override;
@@ -56,4 +56,4 @@ class DefaultThreadManager final : public AbstractThreadManager
     std::unique_ptr<Impl> _impl;
 };
 
-} // namespace vigine::threading
+} // namespace vigine::core::threading

--- a/include/vigine/core/threading/threadmanagerconfig.h
+++ b/include/vigine/core/threading/threadmanagerconfig.h
@@ -2,7 +2,7 @@
 
 #include <cstddef>
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 /**
  * @brief Configuration POD consumed by the threading factory.
@@ -51,4 +51,4 @@ struct ThreadManagerConfig
     std::size_t maxNamedThreads{1024};
 };
 
-} // namespace vigine::threading
+} // namespace vigine::core::threading

--- a/include/vigine/ecs/factory.h
+++ b/include/vigine/ecs/factory.h
@@ -21,7 +21,7 @@ namespace vigine::ecs
  * call site; shared ownership is not the factory's concern. This
  * mirrors the shape used by the service factory
  * (@ref vigine::service::createService), the thread manager factory
- * (@ref vigine::threading::createThreadManager), the payload registry
+ * (@ref vigine::core::threading::createThreadManager), the payload registry
  * factory, and the message bus factory
  * (@ref vigine::messaging::createMessageBus).
  *

--- a/include/vigine/engine/engineconfig.h
+++ b/include/vigine/engine/engineconfig.h
@@ -17,7 +17,7 @@ namespace vigine::engine
  *                       OS main thread) on the thread manager's main
  *                       pump until @ref IEngine::shutdown returns. Every
  *                       post-back submitted through
- *                       @ref threading::IThreadManager::postToMainThread
+ *                       @ref core::threading::IThreadManager::postToMainThread
  *                       is drained by the pump tick.
  *   - @c Background  -- same pump semantics as @c Foreground, but the
  *                       caller is expected to be a dedicated worker

--- a/include/vigine/eventscheduler/abstracteventscheduler.h
+++ b/include/vigine/eventscheduler/abstracteventscheduler.h
@@ -3,10 +3,10 @@
 #include "vigine/messaging/abstractmessagebus.h"
 #include "vigine/eventscheduler/ieventscheduler.h"
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 class IThreadManager;
-} // namespace vigine::threading
+} // namespace vigine::core::threading
 
 namespace vigine::eventscheduler
 {
@@ -60,7 +60,7 @@ class AbstractEventScheduler : public IEventScheduler, protected AbstractMessage
      *        @ref vigine::messaging::AbstractMessageBus.
      */
     AbstractEventScheduler(vigine::messaging::BusConfig      config,
-                           vigine::threading::IThreadManager &threadManager);
+                           vigine::core::threading::IThreadManager &threadManager);
 };
 
 } // namespace vigine::eventscheduler

--- a/include/vigine/eventscheduler/factory.h
+++ b/include/vigine/eventscheduler/factory.h
@@ -6,10 +6,10 @@
 #include "vigine/eventscheduler/iossignalsource.h"
 #include "vigine/eventscheduler/itimersource.h"
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 class IThreadManager;
-} // namespace vigine::threading
+} // namespace vigine::core::threading
 
 namespace vigine::eventscheduler
 {
@@ -31,7 +31,7 @@ namespace vigine::eventscheduler
  *   unsubscribe.
  */
 [[nodiscard]] std::unique_ptr<IEventScheduler>
-    createEventScheduler(vigine::threading::IThreadManager &threadManager,
+    createEventScheduler(vigine::core::threading::IThreadManager &threadManager,
                          ITimerSource                      &timerSource,
                          IOsSignalSource                   &osSignalSource);
 

--- a/include/vigine/messaging/abstractmessagebus.h
+++ b/include/vigine/messaging/abstractmessagebus.h
@@ -22,10 +22,10 @@
 #include "vigine/messaging/subscriptionslot.h"
 #include "vigine/result.h"
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 class IThreadManager;
-} // namespace vigine::threading
+} // namespace vigine::core::threading
 
 namespace vigine::messaging
 {
@@ -47,7 +47,7 @@ class DefaultBusControlBlock;
  * naming convention rather than the @c I pure-virtual prefix. Everything
  * is @c private: the control block, the subscription registry, the
  * queue, the dispatch mutex, the shutdown flag, and the handle to the
- * injected @ref vigine::threading::IThreadManager. Concrete subclasses
+ * injected @ref vigine::core::threading::IThreadManager. Concrete subclasses
  * extend the chain (for example @ref SystemMessageBus) to pin a specific
  * @ref BusConfig shape; they do not override behaviour.
  *
@@ -63,7 +63,7 @@ class DefaultBusControlBlock;
  *     a safe no-op on destruction. When a subscriber or target is
  *     destroyed first, its token drains its slot through the control
  *     block so the bus's registries never see a dangling pointer.
- *   - The injected @ref vigine::threading::IThreadManager is referenced
+ *   - The injected @ref vigine::core::threading::IThreadManager is referenced
  *     by pointer; the engine guarantees the manager outlives every bus
  *     it hands a reference to.
  *
@@ -108,7 +108,7 @@ class AbstractMessageBus
      * lifetime of the bus; the caller (typically the engine) guarantees
      * the manager outlives every bus it owns.
      */
-    AbstractMessageBus(BusConfig config, vigine::threading::IThreadManager &threadManager);
+    AbstractMessageBus(BusConfig config, vigine::core::threading::IThreadManager &threadManager);
 
     // Forwarded to subclasses so concrete constructors can inspect the
     // chosen config before falling through to user code (for example
@@ -235,7 +235,7 @@ class AbstractMessageBus
     // ------ State ------
 
     BusConfig                                      _config;
-    vigine::threading::IThreadManager             *_threadManager;
+    vigine::core::threading::IThreadManager             *_threadManager;
     // The control block owns BOTH registries: the connection (target)
     // registry AND the subscription registry. The bus keeps this
     // shared_ptr alive for the lifetime of the bus; every

--- a/include/vigine/messaging/factory.h
+++ b/include/vigine/messaging/factory.h
@@ -5,10 +5,10 @@
 #include "vigine/messaging/busconfig.h"
 #include "vigine/messaging/imessagebus.h"
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 class IThreadManager;
-} // namespace vigine::threading
+} // namespace vigine::core::threading
 
 namespace vigine::messaging
 {
@@ -29,7 +29,7 @@ namespace vigine::messaging
  * shared ownership wrap the result in a @c std::shared_ptr at the call
  * site; shared ownership is not the factory's concern. This mirrors the
  * thread manager's factory (see
- * @ref vigine::threading::createThreadManager) and the payload
+ * @ref vigine::core::threading::createThreadManager) and the payload
  * registry's factory (see @ref vigine::payload::createPayloadRegistry).
  *
  * Lifetime: the returned bus retains a reference to @p threadManager.
@@ -39,6 +39,6 @@ namespace vigine::messaging
  */
 [[nodiscard]] std::unique_ptr<IMessageBus>
     createMessageBus(const BusConfig                  &config,
-                     vigine::threading::IThreadManager &threadManager);
+                     vigine::core::threading::IThreadManager &threadManager);
 
 } // namespace vigine::messaging

--- a/include/vigine/messaging/systemmessagebus.h
+++ b/include/vigine/messaging/systemmessagebus.h
@@ -3,10 +3,10 @@
 #include "vigine/messaging/abstractmessagebus.h"
 #include "vigine/messaging/busconfig.h"
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 class IThreadManager;
-} // namespace vigine::threading
+} // namespace vigine::core::threading
 
 namespace vigine::messaging
 {
@@ -39,7 +39,7 @@ class SystemMessageBus final : public AbstractMessageBus
      * engine's single system bus; use @ref createMessageBus for user
      * buses with arbitrary configs.
      */
-    explicit SystemMessageBus(vigine::threading::IThreadManager &threadManager);
+    explicit SystemMessageBus(vigine::core::threading::IThreadManager &threadManager);
 
     /**
      * @brief Builds the bus with @p config verbatim.
@@ -50,7 +50,7 @@ class SystemMessageBus final : public AbstractMessageBus
      * sentinel zero end up with an auto-assigned id.
      */
     SystemMessageBus(BusConfig                          config,
-                     vigine::threading::IThreadManager &threadManager);
+                     vigine::core::threading::IThreadManager &threadManager);
 
     ~SystemMessageBus() override = default;
 

--- a/include/vigine/pipelinebuilder/abstractpipelinebuilder.h
+++ b/include/vigine/pipelinebuilder/abstractpipelinebuilder.h
@@ -3,7 +3,7 @@
 #include "vigine/channelfactory/ichannelfactory.h"
 #include "vigine/messaging/imessagebus.h"
 #include "vigine/pipelinebuilder/ipipelinebuilder.h"
-#include "vigine/threading/ithreadmanager.h"
+#include "vigine/core/threading/ithreadmanager.h"
 
 namespace vigine::pipelinebuilder
 {
@@ -15,7 +15,7 @@ namespace vigine::pipelinebuilder
  * recipe.  It inherits @ref IPipelineBuilder @c public so the builder
  * surface sits at offset zero for zero-cost up-casts, and holds
  * references to the underlying @ref vigine::messaging::IMessageBus,
- * @ref vigine::threading::IThreadManager, and
+ * @ref vigine::core::threading::IThreadManager, and
  * @ref vigine::channelfactory::IChannelFactory @c protected so subclass
  * wiring can reach them without exposing the raw surfaces in the public
  * builder API.
@@ -54,7 +54,7 @@ class AbstractPipelineBuilder : public IPipelineBuilder
      * references outlive this facade instance.
      */
     AbstractPipelineBuilder(vigine::messaging::IMessageBus       &bus,
-                            vigine::threading::IThreadManager    &threadManager,
+                            vigine::core::threading::IThreadManager    &threadManager,
                             vigine::channelfactory::IChannelFactory &channelFactory);
 
     /**
@@ -65,7 +65,7 @@ class AbstractPipelineBuilder : public IPipelineBuilder
     /**
      * @brief Returns the thread manager reference for subclass wiring.
      */
-    [[nodiscard]] vigine::threading::IThreadManager &threadManager() noexcept;
+    [[nodiscard]] vigine::core::threading::IThreadManager &threadManager() noexcept;
 
     /**
      * @brief Returns the channel factory reference for subclass wiring.
@@ -74,7 +74,7 @@ class AbstractPipelineBuilder : public IPipelineBuilder
 
   private:
     vigine::messaging::IMessageBus       &_bus;
-    vigine::threading::IThreadManager    &_threadManager;
+    vigine::core::threading::IThreadManager    &_threadManager;
     vigine::channelfactory::IChannelFactory &_channelFactory;
 };
 

--- a/include/vigine/pipelinebuilder/defaultpipelinebuilder.h
+++ b/include/vigine/pipelinebuilder/defaultpipelinebuilder.h
@@ -43,7 +43,7 @@ class DefaultPipelineBuilder final : public AbstractPipelineBuilder
      * All three references must outlive this builder instance.
      */
     DefaultPipelineBuilder(vigine::messaging::IMessageBus       &bus,
-                           vigine::threading::IThreadManager    &threadManager,
+                           vigine::core::threading::IThreadManager    &threadManager,
                            vigine::channelfactory::IChannelFactory &channelFactory);
 
     ~DefaultPipelineBuilder() override;

--- a/include/vigine/pipelinebuilder/factory.h
+++ b/include/vigine/pipelinebuilder/factory.h
@@ -5,7 +5,7 @@
 #include "vigine/channelfactory/ichannelfactory.h"
 #include "vigine/messaging/imessagebus.h"
 #include "vigine/pipelinebuilder/defaultpipelinebuilder.h"
-#include "vigine/threading/ithreadmanager.h"
+#include "vigine/core/threading/ithreadmanager.h"
 
 // factory.h is a convenience header that re-exports createPipelineBuilder
 // so callers can include a single predictable factory header rather than
@@ -29,7 +29,7 @@ namespace vigine::pipelinebuilder
  */
 [[nodiscard]] std::unique_ptr<IPipelineBuilder>
     createPipelineBuilder(vigine::messaging::IMessageBus       &bus,
-                          vigine::threading::IThreadManager    &threadManager,
+                          vigine::core::threading::IThreadManager    &threadManager,
                           vigine::channelfactory::IChannelFactory &channelFactory);
 
 } // namespace vigine::pipelinebuilder

--- a/include/vigine/reactivestream/defaultreactivestream.h
+++ b/include/vigine/reactivestream/defaultreactivestream.h
@@ -5,10 +5,10 @@
 #include "vigine/reactivestream/abstractreactivestream.h"
 #include "vigine/reactivestream/ireactivesubscription.h"
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 class IThreadManager;
-} // namespace vigine::threading
+} // namespace vigine::core::threading
 
 namespace vigine::reactivestream
 {
@@ -53,7 +53,7 @@ class DefaultReactiveStream final : public AbstractReactiveStream
      * @p bus and @p threadManager must outlive this facade instance.
      */
     DefaultReactiveStream(vigine::messaging::IMessageBus    &bus,
-                          vigine::threading::IThreadManager &threadManager);
+                          vigine::core::threading::IThreadManager &threadManager);
 
     ~DefaultReactiveStream() override;
 

--- a/include/vigine/reactivestream/factory.h
+++ b/include/vigine/reactivestream/factory.h
@@ -9,10 +9,10 @@ namespace vigine::messaging
 class IMessageBus;
 } // namespace vigine::messaging
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 class IThreadManager;
-} // namespace vigine::threading
+} // namespace vigine::core::threading
 
 namespace vigine::reactivestream
 {
@@ -36,6 +36,6 @@ namespace vigine::reactivestream
  */
 [[nodiscard]] std::unique_ptr<IReactiveStream>
     createReactiveStream(vigine::messaging::IMessageBus    &bus,
-                         vigine::threading::IThreadManager &threadManager);
+                         vigine::core::threading::IThreadManager &threadManager);
 
 } // namespace vigine::reactivestream

--- a/include/vigine/requestbus/defaultrequestbus.h
+++ b/include/vigine/requestbus/defaultrequestbus.h
@@ -4,10 +4,10 @@
 
 #include "vigine/requestbus/abstractrequestbus.h"
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 class IThreadManager;
-} // namespace vigine::threading
+} // namespace vigine::core::threading
 
 namespace vigine::requestbus
 {
@@ -27,7 +27,7 @@ namespace vigine::requestbus
  *     @c MessageKind::TopicPublish with known correlation ids and
  *     resolves the matching promise.
  *   - TTL cleanup: after the effective TTL (UD-5 configurable, default
- *     @c timeout * 2) a task posted via @ref vigine::threading::IThreadManager
+ *     @c timeout * 2) a task posted via @ref vigine::core::threading::IThreadManager
  *     removes the correlation id so late replies are dropped.
  *
  * Callers obtain instances exclusively through @ref createRequestBus --
@@ -51,7 +51,7 @@ class DefaultRequestBus final : public AbstractRequestBus
      * @p bus and @p threadManager must outlive this facade instance.
      */
     DefaultRequestBus(vigine::messaging::IMessageBus           &bus,
-                      vigine::threading::IThreadManager        &threadManager);
+                      vigine::core::threading::IThreadManager        &threadManager);
 
     ~DefaultRequestBus() override;
 
@@ -90,6 +90,6 @@ class DefaultRequestBus final : public AbstractRequestBus
  */
 [[nodiscard]] std::unique_ptr<IRequestBus>
     createRequestBus(vigine::messaging::IMessageBus    &bus,
-                     vigine::threading::IThreadManager &threadManager);
+                     vigine::core::threading::IThreadManager &threadManager);
 
 } // namespace vigine::requestbus

--- a/include/vigine/service/factory.h
+++ b/include/vigine/service/factory.h
@@ -23,7 +23,7 @@ namespace vigine::service
  * shared ownership wrap the result in a @c std::shared_ptr at the
  * call site; shared ownership is not the factory's concern. This
  * mirrors the shape used by the thread manager factory
- * (@ref vigine::threading::createThreadManager), the payload registry
+ * (@ref vigine::core::threading::createThreadManager), the payload registry
  * factory, and the message bus factory
  * (@ref vigine::messaging::createMessageBus).
  *

--- a/include/vigine/signalemitter/abstractsignalemitter.h
+++ b/include/vigine/signalemitter/abstractsignalemitter.h
@@ -30,7 +30,7 @@ using AbstractMessageBus = vigine::messaging::AbstractMessageBus;
  *
  * Concrete subclasses (for example @ref DefaultSignalEmitter) close the
  * chain by providing a concrete @ref vigine::messaging::BusConfig and
- * wiring a @ref vigine::threading::IThreadManager. Callers never name
+ * wiring a @ref vigine::core::threading::IThreadManager. Callers never name
  * those types directly.
  *
  * Invariants:
@@ -75,7 +75,7 @@ class AbstractSignalEmitter : public ISignalEmitter, protected AbstractMessageBu
      *        @ref vigine::messaging::AbstractMessageBus.
      */
     AbstractSignalEmitter(vigine::messaging::BusConfig               config,
-                          vigine::threading::IThreadManager          &threadManager);
+                          vigine::core::threading::IThreadManager          &threadManager);
 };
 
 } // namespace vigine::signalemitter

--- a/include/vigine/signalemitter/defaultsignalemitter.h
+++ b/include/vigine/signalemitter/defaultsignalemitter.h
@@ -5,10 +5,10 @@
 #include "vigine/messaging/busconfig.h"
 #include "vigine/signalemitter/abstractsignalemitter.h"
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 class IThreadManager;
-} // namespace vigine::threading
+} // namespace vigine::core::threading
 
 namespace vigine::signalemitter
 {
@@ -43,7 +43,7 @@ class DefaultSignalEmitter final : public AbstractSignalEmitter
      * synchronous on the caller's thread, which is the historical
      * default and the shape exercised by the facade contract case.
      */
-    explicit DefaultSignalEmitter(vigine::threading::IThreadManager &threadManager);
+    explicit DefaultSignalEmitter(vigine::core::threading::IThreadManager &threadManager);
 
     /**
      * @brief Constructs the emitter using the caller-supplied @p config
@@ -53,7 +53,7 @@ class DefaultSignalEmitter final : public AbstractSignalEmitter
      * example the config returned by @ref sharedBusConfig to put dispatch
      * on the thread manager's shared worker pool.
      */
-    DefaultSignalEmitter(vigine::threading::IThreadManager &threadManager,
+    DefaultSignalEmitter(vigine::core::threading::IThreadManager &threadManager,
                          vigine::messaging::BusConfig       config);
 
     ~DefaultSignalEmitter() override = default;
@@ -91,8 +91,8 @@ class DefaultSignalEmitter final : public AbstractSignalEmitter
  * queues on the posting thread (the dedicated worker pump is deferred
  * to a later lifecycle change). A caller that needs a guaranteed
  * thread hop should pair this config with a deliberate
- * @ref vigine::threading::IThreadManager::schedule on the producer
- * side, or use the non-@c Any @ref threading::ThreadAffinity path on
+ * @ref vigine::core::threading::IThreadManager::schedule on the producer
+ * side, or use the non-@c Any @ref core::threading::ThreadAffinity path on
  * @ref TaskFlow::signal which wraps the subscription in an adapter
  * that re-posts onto the thread manager.
  */
@@ -107,7 +107,7 @@ class DefaultSignalEmitter final : public AbstractSignalEmitter
  * must outlive the returned emitter.
  */
 [[nodiscard]] std::unique_ptr<ISignalEmitter>
-    createSignalEmitter(vigine::threading::IThreadManager &threadManager);
+    createSignalEmitter(vigine::core::threading::IThreadManager &threadManager);
 
 /**
  * @brief Factory overload that creates a signal-emitter facade with a
@@ -118,7 +118,7 @@ class DefaultSignalEmitter final : public AbstractSignalEmitter
  * emitter. @p threadManager must outlive the returned emitter.
  */
 [[nodiscard]] std::unique_ptr<ISignalEmitter>
-    createSignalEmitter(vigine::threading::IThreadManager &threadManager,
+    createSignalEmitter(vigine::core::threading::IThreadManager &threadManager,
                         vigine::messaging::BusConfig       config);
 
 } // namespace vigine::signalemitter

--- a/include/vigine/statemachine/factory.h
+++ b/include/vigine/statemachine/factory.h
@@ -23,7 +23,7 @@ namespace vigine::statemachine
  * mirrors the shape used by the ECS factory
  * (@ref vigine::ecs::createECS), the service factory
  * (@ref vigine::service::createService), the thread manager factory
- * (@ref vigine::threading::createThreadManager), the payload registry
+ * (@ref vigine::core::threading::createThreadManager), the payload registry
  * factory, and the message bus factory
  * (@ref vigine::messaging::createMessageBus).
  *

--- a/include/vigine/taskflow.h
+++ b/include/vigine/taskflow.h
@@ -3,7 +3,7 @@
 #include "abstracttask.h"
 #include "payload/payloadtypeid.h"
 #include "result.h"
-#include "threading/threadaffinity.h"
+#include "core/threading/threadaffinity.h"
 
 #include <memory>
 #include <unordered_map>
@@ -83,26 +83,26 @@ class TaskFlow
      * with a matching @c PayloadTypeId.
      *
      * Threading:
-     *   - @p affinity defaults to @ref threading::ThreadAffinity::Any.
+     *   - @p affinity defaults to @ref core::threading::ThreadAffinity::Any.
      *     Inside @c TaskFlow::signal, @c Any is re-interpreted as
      *     "run the handler synchronously on the emitter's thread, with no
-     *     @ref threading::IThreadManager involvement". This is a local
+     *     @ref core::threading::IThreadManager involvement". This is a local
      *     re-definition of the generic "engine picks a fast worker"
-     *     meaning documented on @ref threading::ThreadAffinity::Any for
-     *     @ref threading::IThreadManager::schedule; see that header for
+     *     meaning documented on @ref core::threading::ThreadAffinity::Any for
+     *     @ref core::threading::IThreadManager::schedule; see that header for
      *     the dispatch-time semantics.
      *   - Any other @p affinity value wraps @p to in an internal
      *     subscriber adapter that, on delivery from the emitter, re-posts
      *     the handler call through
-     *     @ref threading::IThreadManager::schedule. The emitter thread
+     *     @ref core::threading::IThreadManager::schedule. The emitter thread
      *     therefore does not block on the handler.
      *
      * Failures:
      *   - Null @p from or @p to, or @p from / @p to not registered with
      *     this flow, returns an error @ref Result.
-     *   - A @ref threading::ThreadAffinity::Named value returns an error;
-     *     @c Named affinities require a @ref threading::NamedThreadId and
-     *     are routed through @ref threading::IThreadManager::scheduleOnNamed
+     *   - A @ref core::threading::ThreadAffinity::Named value returns an error;
+     *     @c Named affinities require a @ref core::threading::NamedThreadId and
+     *     are routed through @ref core::threading::IThreadManager::scheduleOnNamed
      *     instead of @c schedule.
      *   - No @ref signalemitter::ISignalEmitter installed via
      *     @ref setSignalEmitter returns an error.
@@ -122,8 +122,8 @@ class TaskFlow
     [[nodiscard]] Result signal(AbstractTask            *from,
                                 AbstractTask            *to,
                                 payload::PayloadTypeId   signalType,
-                                threading::ThreadAffinity affinity
-                                = threading::ThreadAffinity::Any);
+                                core::threading::ThreadAffinity affinity
+                                = core::threading::ThreadAffinity::Any);
 
     // Change current task
     void changeCurrentTaskTo(AbstractTask *newTask);

--- a/include/vigine/taskflow/factory.h
+++ b/include/vigine/taskflow/factory.h
@@ -23,7 +23,7 @@ namespace vigine::taskflow
  * (@ref vigine::ecs::createECS), the service factory
  * (@ref vigine::service::createService), the state machine factory
  * (@ref vigine::statemachine::createStateMachine), the thread manager
- * factory (@ref vigine::threading::createThreadManager), the payload
+ * factory (@ref vigine::core::threading::createThreadManager), the payload
  * registry factory, and the message bus factory
  * (@ref vigine::messaging::createMessageBus).
  *

--- a/include/vigine/vigine.h
+++ b/include/vigine/vigine.h
@@ -13,10 +13,10 @@ class IStateMachine;
 class IContext;
 class IEntityManager;
 
-namespace threading
+namespace core::threading
 {
 class IThreadManager;
-} // namespace threading
+} // namespace core::threading
 
 namespace messaging
 {
@@ -62,7 +62,7 @@ class Engine
     // Messaging / threading substrate -- introduced here, left null.
     // Their concrete wiring lands in later leaves (plan_09 for the
     // message bus core, plan_23 for the final construction order).
-    std::unique_ptr<threading::IThreadManager>            _threadManager;
+    std::unique_ptr<core::threading::IThreadManager>            _threadManager;
     std::shared_ptr<messaging::IMessageBus>               _systemBus;
     std::vector<std::shared_ptr<messaging::IMessageBus>>  _userBuses;
 

--- a/src/actorhost/abstractactorhost.cpp
+++ b/src/actorhost/abstractactorhost.cpp
@@ -4,7 +4,7 @@ namespace vigine::actorhost
 {
 
 AbstractActorHost::AbstractActorHost(vigine::messaging::IMessageBus    &bus,
-                                     vigine::threading::IThreadManager &threadManager)
+                                     vigine::core::threading::IThreadManager &threadManager)
     : _bus(bus)
     , _threadManager(threadManager)
 {
@@ -15,7 +15,7 @@ vigine::messaging::IMessageBus &AbstractActorHost::bus() noexcept
     return _bus;
 }
 
-vigine::threading::IThreadManager &AbstractActorHost::threadManager() noexcept
+vigine::core::threading::IThreadManager &AbstractActorHost::threadManager() noexcept
 {
     return _threadManager;
 }

--- a/src/actorhost/defaultactorhost.cpp
+++ b/src/actorhost/defaultactorhost.cpp
@@ -22,10 +22,10 @@
 #include "vigine/messaging/messagekind.h"
 #include "vigine/messaging/routemode.h"
 #include "vigine/result.h"
-#include "vigine/threading/itaskhandle.h"
-#include "vigine/threading/ithreadmanager.h"
-#include "vigine/threading/irunnable.h"
-#include "vigine/threading/namedthreadid.h"
+#include "vigine/core/threading/itaskhandle.h"
+#include "vigine/core/threading/ithreadmanager.h"
+#include "vigine/core/threading/irunnable.h"
+#include "vigine/core/threading/namedthreadid.h"
 
 namespace vigine::actorhost
 {
@@ -88,8 +88,8 @@ struct ActorEntry
     ActorId                                   id;
     std::unique_ptr<IActor>                   actor;
     std::shared_ptr<ActorMailQueue>           queue;
-    vigine::threading::NamedThreadId          namedThread;
-    std::unique_ptr<vigine::threading::ITaskHandle> taskHandle;
+    vigine::core::threading::NamedThreadId          namedThread;
+    std::unique_ptr<vigine::core::threading::ITaskHandle> taskHandle;
     std::atomic<bool>                         stopped{false};
 };
 
@@ -97,7 +97,7 @@ struct ActorEntry
 // MailboxRunnable — the drain loop executed on the actor's named thread.
 // ---------------------------------------------------------------------------
 
-class MailboxRunnable final : public vigine::threading::IRunnable
+class MailboxRunnable final : public vigine::core::threading::IRunnable
 {
   public:
     MailboxRunnable(std::shared_ptr<ActorMailQueue> queue,
@@ -250,7 +250,7 @@ class DefaultActorMailbox final : public IActorMailbox
 struct DefaultActorHost::Impl
 {
     vigine::messaging::IMessageBus    &bus;
-    vigine::threading::IThreadManager &threadManager;
+    vigine::core::threading::IThreadManager &threadManager;
 
     mutable std::mutex                              registryMutex;
     std::unordered_map<std::uint32_t, ActorEntry *> registry; // ActorId::value -> entry
@@ -258,7 +258,7 @@ struct DefaultActorHost::Impl
     std::atomic<bool>                               shutdownFlag{false};
 
     explicit Impl(vigine::messaging::IMessageBus    &bus_,
-                  vigine::threading::IThreadManager &tm_)
+                  vigine::core::threading::IThreadManager &tm_)
         : bus(bus_)
         , threadManager(tm_)
     {
@@ -276,7 +276,7 @@ struct DefaultActorHost::Impl
 // ---------------------------------------------------------------------------
 
 DefaultActorHost::DefaultActorHost(vigine::messaging::IMessageBus    &bus,
-                                   vigine::threading::IThreadManager &threadManager)
+                                   vigine::core::threading::IThreadManager &threadManager)
     : AbstractActorHost(bus, threadManager)
     , _impl(std::make_unique<Impl>(bus, threadManager))
 {
@@ -511,7 +511,7 @@ void DefaultActorHost::shutdown()
 
 std::unique_ptr<IActorHost>
 createActorHost(vigine::messaging::IMessageBus    &bus,
-                vigine::threading::IThreadManager &threadManager)
+                vigine::core::threading::IThreadManager &threadManager)
 {
     return std::make_unique<DefaultActorHost>(bus, threadManager);
 }

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -17,7 +17,7 @@
 #include "vigine/service/platformservice.h"
 #include "vigine/statemachine/istatemachine.h"
 #include "vigine/taskflow/itaskflow.h"
-#include "vigine/threading/ithreadmanager.h"
+#include "vigine/core/threading/ithreadmanager.h"
 
 #include <algorithm>
 #include <stdexcept>
@@ -60,7 +60,7 @@ vigine::AbstractSystem *vigine::Context::system(const SystemId id, const SystemN
 }
 
 vigine::Context::Context(EntityManager            *entityManager,
-                         threading::IThreadManager *threadManager)
+                         core::threading::IThreadManager *threadManager)
 {
     _entityManager  = entityManager;
     _threadManager  = threadManager;
@@ -211,7 +211,7 @@ vigine::taskflow::ITaskFlow &vigine::Context::taskFlow()
         "legacy vigine::Context has no Level-1 task flow wrapper; use vigine::context::createContext"};
 }
 
-vigine::threading::IThreadManager &vigine::Context::threadManager()
+vigine::core::threading::IThreadManager &vigine::Context::threadManager()
 {
     if (_threadManager == nullptr)
     {

--- a/src/context/abstractcontext.cpp
+++ b/src/context/abstractcontext.cpp
@@ -8,7 +8,7 @@
 #include "vigine/service/abstractservice.h"
 #include "vigine/statemachine/factory.h"
 #include "vigine/taskflow/factory.h"
-#include "vigine/threading/factory.h"
+#include "vigine/core/threading/factory.h"
 
 namespace vigine::context
 {
@@ -17,7 +17,7 @@ AbstractContext::AbstractContext(const ContextConfig &config)
     // Step 1: thread manager first. Built before the initialiser list
     // touches any other wrapper so every downstream step has a live
     // thread manager reference to bind to.
-    : _threadManager{threading::createThreadManager(config.threading)}
+    : _threadManager{core::threading::createThreadManager(config.threading)}
     // Step 2: system bus next. Takes the thread manager by reference so
     // its dispatch worker can schedule on the engine pool. The factory
     // returns a unique_ptr; we lift it into a shared_ptr so facades
@@ -140,7 +140,7 @@ taskflow::ITaskFlow &AbstractContext::taskFlow()
 // Threading
 // ---------------------------------------------------------------------
 
-threading::IThreadManager &AbstractContext::threadManager()
+core::threading::IThreadManager &AbstractContext::threadManager()
 {
     return *_threadManager;
 }

--- a/src/core/threading/abstractthreadmanager.cpp
+++ b/src/core/threading/abstractthreadmanager.cpp
@@ -1,4 +1,4 @@
-#include "vigine/threading/abstractthreadmanager.h"
+#include "vigine/core/threading/abstractthreadmanager.h"
 
 #include <algorithm>
 #include <cstddef>
@@ -7,7 +7,7 @@
 #include <thread>
 #include <utility>
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 namespace
 {
@@ -237,4 +237,4 @@ void AbstractThreadManager::releaseDedicatedSlot() noexcept
     }
 }
 
-} // namespace vigine::threading
+} // namespace vigine::core::threading

--- a/src/core/threading/defaultbarrier.cpp
+++ b/src/core/threading/defaultbarrier.cpp
@@ -4,7 +4,7 @@
 #include <cstdint>
 #include <mutex>
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 namespace
 {
@@ -96,4 +96,4 @@ std::size_t DefaultBarrier::pendingParties() const
     return _pending;
 }
 
-} // namespace vigine::threading
+} // namespace vigine::core::threading

--- a/src/core/threading/defaultbarrier.h
+++ b/src/core/threading/defaultbarrier.h
@@ -7,9 +7,9 @@
 #include <mutex>
 
 #include "vigine/result.h"
-#include "vigine/threading/ibarrier.h"
+#include "vigine/core/threading/ibarrier.h"
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 /**
  * @brief Default @ref IBarrier implementation — a reusable generation-
@@ -52,4 +52,4 @@ class DefaultBarrier final : public IBarrier
     std::uint64_t           _generation;
 };
 
-} // namespace vigine::threading
+} // namespace vigine::core::threading

--- a/src/core/threading/defaultmessagechannel.cpp
+++ b/src/core/threading/defaultmessagechannel.cpp
@@ -4,7 +4,7 @@
 #include <mutex>
 #include <utility>
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 namespace
 {
@@ -149,4 +149,4 @@ std::size_t DefaultMessageChannel::capacity() const
     return _capacity;
 }
 
-} // namespace vigine::threading
+} // namespace vigine::core::threading

--- a/src/core/threading/defaultmessagechannel.h
+++ b/src/core/threading/defaultmessagechannel.h
@@ -7,9 +7,9 @@
 #include <mutex>
 
 #include "vigine/result.h"
-#include "vigine/threading/imessagechannel.h"
+#include "vigine/core/threading/imessagechannel.h"
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 /**
  * @brief Default @ref IMessageChannel implementation — a bounded FIFO
@@ -62,4 +62,4 @@ class DefaultMessageChannel final : public IMessageChannel
     bool                    _closed;
 };
 
-} // namespace vigine::threading
+} // namespace vigine::core::threading

--- a/src/core/threading/defaultmutex.cpp
+++ b/src/core/threading/defaultmutex.cpp
@@ -2,7 +2,7 @@
 
 #include <chrono>
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 DefaultMutex::DefaultMutex() noexcept = default;
 
@@ -37,4 +37,4 @@ void DefaultMutex::unlock()
     _mutex.unlock();
 }
 
-} // namespace vigine::threading
+} // namespace vigine::core::threading

--- a/src/core/threading/defaultmutex.h
+++ b/src/core/threading/defaultmutex.h
@@ -4,9 +4,9 @@
 #include <mutex>
 
 #include "vigine/result.h"
-#include "vigine/threading/imutex.h"
+#include "vigine/core/threading/imutex.h"
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 /**
  * @brief Default @ref IMutex implementation over @c std::timed_mutex.
@@ -38,4 +38,4 @@ class DefaultMutex final : public IMutex
     std::timed_mutex _mutex;
 };
 
-} // namespace vigine::threading
+} // namespace vigine::core::threading

--- a/src/core/threading/defaultsemaphore.cpp
+++ b/src/core/threading/defaultsemaphore.cpp
@@ -3,7 +3,7 @@
 #include <chrono>
 #include <mutex>
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 DefaultSemaphore::DefaultSemaphore(std::size_t initialCount) noexcept
     : _count{initialCount}
@@ -56,4 +56,4 @@ std::size_t DefaultSemaphore::count() const
     return _count;
 }
 
-} // namespace vigine::threading
+} // namespace vigine::core::threading

--- a/src/core/threading/defaultsemaphore.h
+++ b/src/core/threading/defaultsemaphore.h
@@ -6,9 +6,9 @@
 #include <mutex>
 
 #include "vigine/result.h"
-#include "vigine/threading/isemaphore.h"
+#include "vigine/core/threading/isemaphore.h"
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 /**
  * @brief Default @ref ISemaphore implementation built on
@@ -43,4 +43,4 @@ class DefaultSemaphore final : public ISemaphore
     std::size_t             _count;
 };
 
-} // namespace vigine::threading
+} // namespace vigine::core::threading

--- a/src/core/threading/defaultthreadmanager_factories.cpp
+++ b/src/core/threading/defaultthreadmanager_factories.cpp
@@ -3,7 +3,7 @@
 // The definitions live in a dedicated TU rather than inside
 // abstractthreadmanager.cpp so that extending the primitive catalogue
 // in a later leaf does not force a recompile of the registry/lifecycle
-// bookkeeping code. DefaultThreadManager inherits these definitions
+// bookkeeping code. ThreadManager inherits these definitions
 // unchanged — it does not override any of them.
 
 #include <cstddef>
@@ -13,13 +13,13 @@
 #include "defaultmessagechannel.h"
 #include "defaultmutex.h"
 #include "defaultsemaphore.h"
-#include "vigine/threading/abstractthreadmanager.h"
-#include "vigine/threading/ibarrier.h"
-#include "vigine/threading/imessagechannel.h"
-#include "vigine/threading/imutex.h"
-#include "vigine/threading/isemaphore.h"
+#include "vigine/core/threading/abstractthreadmanager.h"
+#include "vigine/core/threading/ibarrier.h"
+#include "vigine/core/threading/imessagechannel.h"
+#include "vigine/core/threading/imutex.h"
+#include "vigine/core/threading/isemaphore.h"
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 std::unique_ptr<IMutex> AbstractThreadManager::createMutex()
 {
@@ -44,4 +44,4 @@ AbstractThreadManager::createMessageChannel(std::size_t capacity)
     return std::make_unique<DefaultMessageChannel>(capacity);
 }
 
-} // namespace vigine::threading
+} // namespace vigine::core::threading

--- a/src/core/threading/factory.cpp
+++ b/src/core/threading/factory.cpp
@@ -1,12 +1,12 @@
-#include "vigine/threading/factory.h"
+#include "vigine/core/threading/factory.h"
 
 #include <memory>
 
-#include "vigine/threading/defaultthreadmanager.h"
-#include "vigine/threading/ithreadmanager.h"
-#include "vigine/threading/threadmanagerconfig.h"
+#include "vigine/core/threading/threadmanager.h"
+#include "vigine/core/threading/ithreadmanager.h"
+#include "vigine/core/threading/threadmanagerconfig.h"
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 // The factory is intentionally non-templated. unique_ptr ownership —
 // not shared_ptr — because the thread manager is a singular owner
@@ -16,7 +16,7 @@ namespace vigine::threading
 
 std::unique_ptr<IThreadManager> createThreadManager(const ThreadManagerConfig &config)
 {
-    return std::make_unique<DefaultThreadManager>(config);
+    return std::make_unique<ThreadManager>(config);
 }
 
-} // namespace vigine::threading
+} // namespace vigine::core::threading

--- a/src/core/threading/threadmanager.cpp
+++ b/src/core/threading/threadmanager.cpp
@@ -1,4 +1,4 @@
-#include "vigine/threading/defaultthreadmanager.h"
+#include "vigine/core/threading/threadmanager.h"
 
 #include <algorithm>
 #include <atomic>
@@ -17,14 +17,14 @@
 #include <vector>
 
 #include "vigine/result.h"
-#include "vigine/threading/abstractthreadmanager.h"
-#include "vigine/threading/irunnable.h"
-#include "vigine/threading/itaskhandle.h"
-#include "vigine/threading/namedthreadid.h"
-#include "vigine/threading/threadaffinity.h"
-#include "vigine/threading/threadmanagerconfig.h"
+#include "vigine/core/threading/abstractthreadmanager.h"
+#include "vigine/core/threading/irunnable.h"
+#include "vigine/core/threading/itaskhandle.h"
+#include "vigine/core/threading/namedthreadid.h"
+#include "vigine/core/threading/threadaffinity.h"
+#include "vigine/core/threading/threadmanagerconfig.h"
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 namespace
 {
@@ -272,7 +272,7 @@ void drainStoppedQueue(WorkQueue &queue, const char *reason)
 // =========================================================================
 // Impl — the per-manager state, kept opaque to the header.
 // =========================================================================
-struct DefaultThreadManager::Impl
+struct ThreadManager::Impl
 {
     // Worker pool: N identical workers draining the same queue.
     WorkQueue                pool;
@@ -320,7 +320,7 @@ struct DefaultThreadManager::Impl
 // =========================================================================
 // Construction / destruction.
 // =========================================================================
-DefaultThreadManager::DefaultThreadManager(ThreadManagerConfig config)
+ThreadManager::ThreadManager(ThreadManagerConfig config)
     : AbstractThreadManager(config), _impl{std::make_unique<Impl>()}
 {
     const std::size_t workers = AbstractThreadManager::config().poolSize;
@@ -331,7 +331,7 @@ DefaultThreadManager::DefaultThreadManager(ThreadManagerConfig config)
     }
 }
 
-DefaultThreadManager::~DefaultThreadManager()
+ThreadManager::~ThreadManager()
 {
     // shutdown() is idempotent and handles the already-shut-down case;
     // calling it from the dtor guarantees deterministic cleanup.
@@ -341,7 +341,7 @@ DefaultThreadManager::~DefaultThreadManager()
 // =========================================================================
 // IThreadManager: schedule.
 // =========================================================================
-std::unique_ptr<ITaskHandle> DefaultThreadManager::schedule(
+std::unique_ptr<ITaskHandle> ThreadManager::schedule(
     std::unique_ptr<IRunnable> runnable, ThreadAffinity affinity)
 {
     auto handle = std::make_shared<TaskHandle>();
@@ -456,7 +456,7 @@ std::unique_ptr<ITaskHandle> DefaultThreadManager::schedule(
     return result;
 }
 
-std::unique_ptr<ITaskHandle> DefaultThreadManager::scheduleOnNamed(
+std::unique_ptr<ITaskHandle> ThreadManager::scheduleOnNamed(
     std::unique_ptr<IRunnable> runnable, NamedThreadId named)
 {
     auto handle = std::make_shared<TaskHandle>();
@@ -512,7 +512,7 @@ std::unique_ptr<ITaskHandle> DefaultThreadManager::scheduleOnNamed(
 // =========================================================================
 // IThreadManager: main-thread pump.
 // =========================================================================
-void DefaultThreadManager::postToMainThread(std::unique_ptr<IRunnable> runnable)
+void ThreadManager::postToMainThread(std::unique_ptr<IRunnable> runnable)
 {
     // `postToMainThread` returns `void` — callers cannot observe
     // success, failure, or completion through the function boundary.
@@ -541,7 +541,7 @@ void DefaultThreadManager::postToMainThread(std::unique_ptr<IRunnable> runnable)
     _impl->mainQueue.push_back(std::move(entry));
 }
 
-void DefaultThreadManager::runMainThreadPump()
+void ThreadManager::runMainThreadPump()
 {
     std::deque<QueueEntry> drained;
     {
@@ -558,7 +558,7 @@ void DefaultThreadManager::runMainThreadPump()
 // Named unregister: forward to the base for registry bookkeeping, then
 // tear down the associated queue/worker.
 // =========================================================================
-void DefaultThreadManager::unregisterNamedThread(NamedThreadId id)
+void ThreadManager::unregisterNamedThread(NamedThreadId id)
 {
     // Capture the slot index before the base forgets the generation.
     const std::size_t slotIndex = resolveNamedSlot(id);
@@ -595,7 +595,7 @@ void DefaultThreadManager::unregisterNamedThread(NamedThreadId id)
 // =========================================================================
 // Shutdown.
 // =========================================================================
-void DefaultThreadManager::shutdown()
+void ThreadManager::shutdown()
 {
     if (!_impl)
     {
@@ -692,4 +692,4 @@ void DefaultThreadManager::shutdown()
     // the CAS, not via a plain load after the teardown completes.
 }
 
-} // namespace vigine::threading
+} // namespace vigine::core::threading

--- a/src/engine/abstractengine.cpp
+++ b/src/engine/abstractengine.cpp
@@ -4,7 +4,7 @@
 
 #include "vigine/context/factory.h"
 #include "vigine/context/icontext.h"
-#include "vigine/threading/ithreadmanager.h"
+#include "vigine/core/threading/ithreadmanager.h"
 
 namespace vigine::engine
 {
@@ -93,7 +93,7 @@ Result AbstractEngine::run()
     // cannot be lost) and once lock-free before each drain (so a
     // shutdown that arrives during the drain is observed at the next
     // predicate check).
-    threading::IThreadManager &tm = _context->threadManager();
+    core::threading::IThreadManager &tm = _context->threadManager();
     const auto tick = std::chrono::milliseconds{pumpTickMilliseconds()};
 
     while (!_shutdownRequested.load(std::memory_order_acquire))

--- a/src/eventscheduler/abstracteventscheduler.cpp
+++ b/src/eventscheduler/abstracteventscheduler.cpp
@@ -7,7 +7,7 @@ namespace vigine::eventscheduler
 
 AbstractEventScheduler::AbstractEventScheduler(
     vigine::messaging::BusConfig      config,
-    vigine::threading::IThreadManager &threadManager)
+    vigine::core::threading::IThreadManager &threadManager)
     : vigine::messaging::AbstractMessageBus{std::move(config), threadManager}
 {
 }

--- a/src/eventscheduler/defaulteventscheduler.cpp
+++ b/src/eventscheduler/defaulteventscheduler.cpp
@@ -19,7 +19,7 @@
 #include "vigine/messaging/routemode.h"
 #include "vigine/payload/payloadtypeid.h"
 #include "vigine/result.h"
-#include "vigine/threading/ithreadmanager.h"
+#include "vigine/core/threading/ithreadmanager.h"
 
 namespace vigine::eventscheduler
 {
@@ -222,7 +222,7 @@ struct DefaultEventScheduler::Impl
 // -----------------------------------------------------------------
 
 DefaultEventScheduler::DefaultEventScheduler(
-    vigine::threading::IThreadManager &threadManager,
+    vigine::core::threading::IThreadManager &threadManager,
     ITimerSource                      &timerSource,
     IOsSignalSource                   &osSignalSource)
     : AbstractEventScheduler{inlineBusConfig(), threadManager}
@@ -421,7 +421,7 @@ void DefaultEventScheduler::onOsSignal(OsSignal signal)
 // -----------------------------------------------------------------
 
 std::unique_ptr<IEventScheduler>
-createEventScheduler(vigine::threading::IThreadManager &threadManager,
+createEventScheduler(vigine::core::threading::IThreadManager &threadManager,
                      ITimerSource                      &timerSource,
                      IOsSignalSource                   &osSignalSource)
 {

--- a/src/eventscheduler/defaulteventscheduler.h
+++ b/src/eventscheduler/defaulteventscheduler.h
@@ -7,10 +7,10 @@
 #include "vigine/eventscheduler/iossignalsource.h"
 #include "vigine/eventscheduler/itimersource.h"
 
-namespace vigine::threading
+namespace vigine::core::threading
 {
 class IThreadManager;
-} // namespace vigine::threading
+} // namespace vigine::core::threading
 
 namespace vigine::eventscheduler
 {
@@ -50,7 +50,7 @@ class DefaultEventScheduler final
      * @p osSignalSource provides OS-signal subscribe / unsubscribe
      *                   (owned by caller).
      */
-    explicit DefaultEventScheduler(vigine::threading::IThreadManager &threadManager,
+    explicit DefaultEventScheduler(vigine::core::threading::IThreadManager &threadManager,
                                    ITimerSource                      &timerSource,
                                    IOsSignalSource                   &osSignalSource);
 

--- a/src/messaging/abstractmessagebus.cpp
+++ b/src/messaging/abstractmessagebus.cpp
@@ -16,7 +16,7 @@
 #include "vigine/messaging/imessage.h"
 #include "vigine/messaging/isubscriber.h"
 #include "vigine/result.h"
-#include "vigine/threading/ithreadmanager.h"
+#include "vigine/core/threading/ithreadmanager.h"
 
 #include "messaging/ibuscontrolblock_default.h"
 
@@ -108,7 +108,7 @@ bool AbstractMessageBus::SubscriptionToken::active() const noexcept
 // ---------------------------------------------------------------------------
 
 AbstractMessageBus::AbstractMessageBus(BusConfig                          config,
-                                       vigine::threading::IThreadManager &threadManager)
+                                       vigine::core::threading::IThreadManager &threadManager)
     : _config(std::move(config))
     , _threadManager(&threadManager)
     , _control(std::make_shared<DefaultBusControlBlock>())

--- a/src/messaging/createmessagebus.cpp
+++ b/src/messaging/createmessagebus.cpp
@@ -37,7 +37,7 @@ std::atomic<std::uint32_t> &busIdCounter() noexcept
 
 std::unique_ptr<IMessageBus>
     createMessageBus(const BusConfig                  &config,
-                     vigine::threading::IThreadManager &threadManager)
+                     vigine::core::threading::IThreadManager &threadManager)
 {
     BusConfig resolved = resolveBusId(config);
     return std::make_unique<SystemMessageBus>(std::move(resolved), threadManager);

--- a/src/messaging/systemmessagebus.cpp
+++ b/src/messaging/systemmessagebus.cpp
@@ -28,13 +28,13 @@ namespace
 }
 } // namespace
 
-SystemMessageBus::SystemMessageBus(vigine::threading::IThreadManager &threadManager)
+SystemMessageBus::SystemMessageBus(vigine::core::threading::IThreadManager &threadManager)
     : AbstractMessageBus{systemPreset(), threadManager}
 {
 }
 
 SystemMessageBus::SystemMessageBus(BusConfig                          config,
-                                   vigine::threading::IThreadManager &threadManager)
+                                   vigine::core::threading::IThreadManager &threadManager)
     : AbstractMessageBus{std::move(config), threadManager}
 {
 }

--- a/src/pipelinebuilder/abstractpipelinebuilder.cpp
+++ b/src/pipelinebuilder/abstractpipelinebuilder.cpp
@@ -5,7 +5,7 @@ namespace vigine::pipelinebuilder
 
 AbstractPipelineBuilder::AbstractPipelineBuilder(
     vigine::messaging::IMessageBus       &bus,
-    vigine::threading::IThreadManager    &threadManager,
+    vigine::core::threading::IThreadManager    &threadManager,
     vigine::channelfactory::IChannelFactory &channelFactory)
     : _bus(bus)
     , _threadManager(threadManager)
@@ -18,7 +18,7 @@ vigine::messaging::IMessageBus &AbstractPipelineBuilder::bus() noexcept
     return _bus;
 }
 
-vigine::threading::IThreadManager &AbstractPipelineBuilder::threadManager() noexcept
+vigine::core::threading::IThreadManager &AbstractPipelineBuilder::threadManager() noexcept
 {
     return _threadManager;
 }

--- a/src/pipelinebuilder/defaultpipelinebuilder.cpp
+++ b/src/pipelinebuilder/defaultpipelinebuilder.cpp
@@ -190,7 +190,7 @@ struct DefaultPipelineBuilder::Impl
 
 DefaultPipelineBuilder::DefaultPipelineBuilder(
     vigine::messaging::IMessageBus       &bus,
-    vigine::threading::IThreadManager    &threadManager,
+    vigine::core::threading::IThreadManager    &threadManager,
     vigine::channelfactory::IChannelFactory &channelFactory)
     : AbstractPipelineBuilder(bus, threadManager, channelFactory)
     , _impl(std::make_unique<Impl>())
@@ -293,7 +293,7 @@ std::unique_ptr<IPipeline> DefaultPipelineBuilder::build(vigine::Result *outResu
 
 std::unique_ptr<IPipelineBuilder>
 createPipelineBuilder(vigine::messaging::IMessageBus       &bus,
-                      vigine::threading::IThreadManager    &threadManager,
+                      vigine::core::threading::IThreadManager    &threadManager,
                       vigine::channelfactory::IChannelFactory &channelFactory)
 {
     return std::make_unique<DefaultPipelineBuilder>(bus, threadManager, channelFactory);

--- a/src/reactivestream/defaultreactivestream.cpp
+++ b/src/reactivestream/defaultreactivestream.cpp
@@ -18,7 +18,7 @@
 #include "vigine/reactivestream/ireactivesubscriber.h"
 #include "vigine/reactivestream/ireactivesubscription.h"
 #include "vigine/result.h"
-#include "vigine/threading/ithreadmanager.h"
+#include "vigine/core/threading/ithreadmanager.h"
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -183,7 +183,7 @@ class BusSubscriber final : public vigine::messaging::ISubscriber
 struct DefaultReactiveStream::Impl
 {
     vigine::messaging::IMessageBus    &bus;
-    vigine::threading::IThreadManager &threadManager;
+    vigine::core::threading::IThreadManager &threadManager;
 
     std::mutex                                                                registryMutex;
     std::unordered_map<std::uint64_t, std::shared_ptr<SubscriptionState>>    subscriptions;
@@ -195,7 +195,7 @@ struct DefaultReactiveStream::Impl
     std::atomic<bool> shutdownFlag{false};
 
     explicit Impl(vigine::messaging::IMessageBus    &bus_,
-                  vigine::threading::IThreadManager &tm_)
+                  vigine::core::threading::IThreadManager &tm_)
         : bus(bus_)
         , threadManager(tm_)
     {
@@ -228,7 +228,7 @@ struct DefaultReactiveStream::Impl
 // ---------------------------------------------------------------------------
 
 DefaultReactiveStream::DefaultReactiveStream(vigine::messaging::IMessageBus    &bus,
-                                             vigine::threading::IThreadManager &threadManager)
+                                             vigine::core::threading::IThreadManager &threadManager)
     : AbstractReactiveStream(bus)
     , _impl(std::make_unique<Impl>(bus, threadManager))
 {
@@ -422,7 +422,7 @@ vigine::Result DefaultReactiveStream::shutdown()
 
 std::unique_ptr<IReactiveStream>
 createReactiveStream(vigine::messaging::IMessageBus    &bus,
-                     vigine::threading::IThreadManager &threadManager)
+                     vigine::core::threading::IThreadManager &threadManager)
 {
     return std::make_unique<DefaultReactiveStream>(bus, threadManager);
 }

--- a/src/requestbus/defaultrequestbus.cpp
+++ b/src/requestbus/defaultrequestbus.cpp
@@ -23,8 +23,8 @@
 #include "vigine/requestbus/ifuture.h"
 #include "vigine/requestbus/requestconfig.h"
 #include "vigine/result.h"
-#include "vigine/threading/ithreadmanager.h"
-#include "vigine/threading/irunnable.h"
+#include "vigine/core/threading/ithreadmanager.h"
+#include "vigine/core/threading/irunnable.h"
 #include "vigine/topicbus/topicid.h"
 
 namespace vigine::requestbus
@@ -437,7 +437,7 @@ class ReplyMessage final : public vigine::messaging::IMessage
 // logs at debug.
 // -----------------------------------------------------------------
 
-class TtlCleanupRunnable final : public vigine::threading::IRunnable
+class TtlCleanupRunnable final : public vigine::core::threading::IRunnable
 {
   public:
     TtlCleanupRunnable(std::weak_ptr<PendingRegistry>  registry,
@@ -487,7 +487,7 @@ class TtlCleanupRunnable final : public vigine::threading::IRunnable
 
 struct DefaultRequestBus::Impl
 {
-    vigine::threading::IThreadManager &threadManager;
+    vigine::core::threading::IThreadManager &threadManager;
 
     std::atomic<std::uint64_t>   corrCounter{1};
     std::atomic<bool>            shutdown{false};
@@ -562,7 +562,7 @@ struct DefaultRequestBus::Impl
     ReplySubscriber                                    replySubscriber;
     std::unique_ptr<vigine::messaging::ISubscriptionToken> replyToken;
 
-    explicit Impl(vigine::threading::IThreadManager &tm) : threadManager(tm)
+    explicit Impl(vigine::core::threading::IThreadManager &tm) : threadManager(tm)
     {
         replySubscriber.owner = this;
     }
@@ -573,7 +573,7 @@ struct DefaultRequestBus::Impl
 // -----------------------------------------------------------------
 
 DefaultRequestBus::DefaultRequestBus(vigine::messaging::IMessageBus    &bus,
-                                     vigine::threading::IThreadManager  &threadManager)
+                                     vigine::core::threading::IThreadManager  &threadManager)
     : AbstractRequestBus{bus}
     , _impl(std::make_unique<Impl>(threadManager))
 {
@@ -773,7 +773,7 @@ vigine::Result DefaultRequestBus::shutdown()
 
 std::unique_ptr<IRequestBus>
 createRequestBus(vigine::messaging::IMessageBus    &bus,
-                 vigine::threading::IThreadManager &threadManager)
+                 vigine::core::threading::IThreadManager &threadManager)
 {
     return std::make_unique<DefaultRequestBus>(bus, threadManager);
 }

--- a/src/signalemitter/abstractsignalemitter.cpp
+++ b/src/signalemitter/abstractsignalemitter.cpp
@@ -12,7 +12,7 @@ namespace vigine::signalemitter
 
 AbstractSignalEmitter::AbstractSignalEmitter(
     vigine::messaging::BusConfig      config,
-    vigine::threading::IThreadManager &threadManager)
+    vigine::core::threading::IThreadManager &threadManager)
     : vigine::messaging::AbstractMessageBus{std::move(config), threadManager}
 {
 }

--- a/src/signalemitter/defaultsignalemitter.cpp
+++ b/src/signalemitter/defaultsignalemitter.cpp
@@ -14,7 +14,7 @@
 #include "vigine/payload/payloadtypeid.h"
 #include "vigine/result.h"
 #include "vigine/signalemitter/isignalpayload.h"
-#include "vigine/threading/ithreadmanager.h"
+#include "vigine/core/threading/ithreadmanager.h"
 
 namespace vigine::signalemitter
 {
@@ -140,13 +140,13 @@ vigine::messaging::BusConfig sharedBusConfig() noexcept
 // -----------------------------------------------------------------
 
 DefaultSignalEmitter::DefaultSignalEmitter(
-    vigine::threading::IThreadManager &threadManager)
+    vigine::core::threading::IThreadManager &threadManager)
     : AbstractSignalEmitter{inlineBusConfig(), threadManager}
 {
 }
 
 DefaultSignalEmitter::DefaultSignalEmitter(
-    vigine::threading::IThreadManager &threadManager,
+    vigine::core::threading::IThreadManager &threadManager,
     vigine::messaging::BusConfig       config)
     : AbstractSignalEmitter{std::move(config), threadManager}
 {
@@ -199,13 +199,13 @@ DefaultSignalEmitter::subscribeSignal(
 // -----------------------------------------------------------------
 
 std::unique_ptr<ISignalEmitter>
-createSignalEmitter(vigine::threading::IThreadManager &threadManager)
+createSignalEmitter(vigine::core::threading::IThreadManager &threadManager)
 {
     return std::make_unique<DefaultSignalEmitter>(threadManager);
 }
 
 std::unique_ptr<ISignalEmitter>
-createSignalEmitter(vigine::threading::IThreadManager &threadManager,
+createSignalEmitter(vigine::core::threading::IThreadManager &threadManager,
                     vigine::messaging::BusConfig       config)
 {
     return std::make_unique<DefaultSignalEmitter>(threadManager, std::move(config));

--- a/src/taskflow.cpp
+++ b/src/taskflow.cpp
@@ -9,9 +9,9 @@
 #include <vigine/payload/payloadtypeid.h>
 #include <vigine/signalemitter/isignalemitter.h>
 #include <vigine/taskflow.h>
-#include <vigine/threading/irunnable.h>
-#include <vigine/threading/ithreadmanager.h>
-#include <vigine/threading/threadaffinity.h>
+#include <vigine/core/threading/irunnable.h>
+#include <vigine/core/threading/ithreadmanager.h>
+#include <vigine/core/threading/threadaffinity.h>
 
 #include <algorithm>
 #include <atomic>
@@ -139,7 +139,7 @@ private:
 //   process is not terminated.
 // ---------------------------------------------------------------------
 
-class DeliverRunnable final : public threading::IRunnable {
+class DeliverRunnable final : public core::threading::IRunnable {
 public:
   DeliverRunnable(messaging::ISubscriber *target,
                   std::unique_ptr<ScheduledEnvelope> envelope,
@@ -222,8 +222,8 @@ private:
 class TaskFlow::ScheduledDelivery final : public messaging::ISubscriber {
 public:
   ScheduledDelivery(messaging::ISubscriber *target,
-                    threading::IThreadManager &threadManager,
-                    threading::ThreadAffinity affinity)
+                    core::threading::IThreadManager &threadManager,
+                    core::threading::ThreadAffinity affinity)
       : _target(target), _threadManager(threadManager), _affinity(affinity),
         _alive(std::make_shared<std::atomic<bool>>(true)) {}
 
@@ -270,8 +270,8 @@ public:
 
 private:
   messaging::ISubscriber *_target;
-  threading::IThreadManager &_threadManager;
-  threading::ThreadAffinity _affinity;
+  core::threading::IThreadManager &_threadManager;
+  core::threading::ThreadAffinity _affinity;
   // Shared alive-flag passed into every runnable this adapter schedules.
   // The flag is flipped to false in the adapter destructor; runnables
   // still pending on the thread manager observe the flip through an
@@ -353,7 +353,7 @@ Result TaskFlow::route(AbstractTask *from, AbstractTask *to,
 
 Result TaskFlow::signal(AbstractTask *from, AbstractTask *to,
                         payload::PayloadTypeId signalType,
-                        threading::ThreadAffinity affinity) {
+                        core::threading::ThreadAffinity affinity) {
   if (!from || !to)
     return Result(Result::Code::Error,
                   "Invalid pointer provided for signal transition");
@@ -369,7 +369,7 @@ Result TaskFlow::signal(AbstractTask *from, AbstractTask *to,
   // purpose and the caller must use scheduleOnNamed instead. TaskFlow
   // does not yet carry a NamedThreadId parameter on signal(), so the
   // edge is rejected outright.
-  if (affinity == threading::ThreadAffinity::Named)
+  if (affinity == core::threading::ThreadAffinity::Named)
     return Result(Result::Code::Error,
                   "ThreadAffinity::Named is not supported on signal edges");
 
@@ -390,7 +390,7 @@ Result TaskFlow::signal(AbstractTask *from, AbstractTask *to,
   filter.kind = messaging::MessageKind::Signal;
   filter.typeId = signalType;
 
-  if (affinity == threading::ThreadAffinity::Any) {
+  if (affinity == core::threading::ThreadAffinity::Any) {
     // Local re-interpretation of ThreadAffinity::Any: run the handler
     // synchronously on the emitter's thread. No scheduler involvement.
     // The subscriber is wired directly to the bus; the bus's
@@ -412,7 +412,7 @@ Result TaskFlow::signal(AbstractTask *from, AbstractTask *to,
                   "No context installed; threaded signal edges require "
                   "IThreadManager from IContext::threadManager");
 
-  threading::IThreadManager &threadManager = _context->threadManager();
+  core::threading::IThreadManager &threadManager = _context->threadManager();
 
   auto delivery = std::make_unique<ScheduledDelivery>(subscriber, threadManager,
                                                       affinity);

--- a/src/vigine.cpp
+++ b/src/vigine.cpp
@@ -3,8 +3,8 @@
 #include "vigine/context.h"
 #include "vigine/ecs/entitymanager.h"
 #include "vigine/statemachine.h"
-#include "vigine/threading/factory.h"
-#include "vigine/threading/ithreadmanager.h"
+#include "vigine/core/threading/factory.h"
+#include "vigine/core/threading/ithreadmanager.h"
 
 namespace vigine
 {
@@ -12,7 +12,7 @@ namespace vigine
 Engine::Engine()
 {
     _entityManager.reset(new EntityManager());
-    _threadManager = threading::createThreadManager();
+    _threadManager = core::threading::createThreadManager();
     _context.reset(new Context(_entityManager.get(), _threadManager.get()));
     _stateMachine.reset(new StateMachine(_context.get()));
 }

--- a/test/actorhost/smoke_test.cpp
+++ b/test/actorhost/smoke_test.cpp
@@ -11,9 +11,9 @@
 #include "vigine/messaging/routemode.h"
 #include "vigine/payload/payloadtypeid.h"
 #include "vigine/result.h"
-#include "vigine/threading/factory.h"
-#include "vigine/threading/ithreadmanager.h"
-#include "vigine/threading/threadmanagerconfig.h"
+#include "vigine/core/threading/factory.h"
+#include "vigine/core/threading/ithreadmanager.h"
+#include "vigine/core/threading/threadmanagerconfig.h"
 
 #include <gtest/gtest.h>
 
@@ -187,7 +187,7 @@ class ActorHostSmoke : public ::testing::Test
   protected:
     void SetUp() override
     {
-        _tm = vigine::threading::createThreadManager({});
+        _tm = vigine::core::threading::createThreadManager({});
 
         vigine::messaging::BusConfig cfg;
         cfg.threading    = vigine::messaging::ThreadingPolicy::InlineOnly;
@@ -213,7 +213,7 @@ class ActorHostSmoke : public ::testing::Test
         }
     }
 
-    std::unique_ptr<vigine::threading::IThreadManager> _tm;
+    std::unique_ptr<vigine::core::threading::IThreadManager> _tm;
     std::unique_ptr<vigine::messaging::IMessageBus>    _bus;
     std::unique_ptr<IActorHost>                        _host;
 };

--- a/test/channelfactory/smoke_test.cpp
+++ b/test/channelfactory/smoke_test.cpp
@@ -9,9 +9,9 @@
 #include "vigine/messaging/imessagebus.h"
 #include "vigine/payload/payloadtypeid.h"
 #include "vigine/result.h"
-#include "vigine/threading/factory.h"
-#include "vigine/threading/ithreadmanager.h"
-#include "vigine/threading/threadmanagerconfig.h"
+#include "vigine/core/threading/factory.h"
+#include "vigine/core/threading/ithreadmanager.h"
+#include "vigine/core/threading/threadmanagerconfig.h"
 
 #include <gtest/gtest.h>
 
@@ -73,7 +73,7 @@ class ChannelFactorySmoke : public ::testing::Test
 
     void SetUp() override
     {
-        _tm = vigine::threading::createThreadManager({});
+        _tm = vigine::core::threading::createThreadManager({});
 
         BusConfig cfg;
         cfg.threading    = ThreadingPolicy::InlineOnly;
@@ -99,7 +99,7 @@ class ChannelFactorySmoke : public ::testing::Test
         }
     }
 
-    std::unique_ptr<vigine::threading::IThreadManager> _tm;
+    std::unique_ptr<vigine::core::threading::IThreadManager> _tm;
     std::unique_ptr<IMessageBus>                       _bus;
     std::unique_ptr<IChannelFactory>                   _factory;
 };

--- a/test/contract/fixtures/engine_fixture.h
+++ b/test/contract/fixtures/engine_fixture.h
@@ -40,9 +40,9 @@
 #include "vigine/messaging/busconfig.h"
 #include "vigine/messaging/factory.h"
 #include "vigine/messaging/imessagebus.h"
-#include "vigine/threading/factory.h"
-#include "vigine/threading/ithreadmanager.h"
-#include "vigine/threading/threadmanagerconfig.h"
+#include "vigine/core/threading/factory.h"
+#include "vigine/core/threading/ithreadmanager.h"
+#include "vigine/core/threading/threadmanagerconfig.h"
 
 #include <gtest/gtest.h>
 
@@ -63,7 +63,7 @@ class PrivateStack
   public:
     PrivateStack() = default;
 
-    PrivateStack(std::unique_ptr<vigine::threading::IThreadManager> tm,
+    PrivateStack(std::unique_ptr<vigine::core::threading::IThreadManager> tm,
                  std::unique_ptr<vigine::messaging::IMessageBus>    bus) noexcept
         : _tm(std::move(tm))
         , _bus(std::move(bus))
@@ -83,7 +83,7 @@ class PrivateStack
     PrivateStack(PrivateStack &&) noexcept        = default;
     PrivateStack &operator=(PrivateStack &&) noexcept = default;
 
-    [[nodiscard]] vigine::threading::IThreadManager &threadManager() noexcept
+    [[nodiscard]] vigine::core::threading::IThreadManager &threadManager() noexcept
     {
         return *_tm;
     }
@@ -99,7 +99,7 @@ class PrivateStack
     }
 
   private:
-    std::unique_ptr<vigine::threading::IThreadManager> _tm;
+    std::unique_ptr<vigine::core::threading::IThreadManager> _tm;
     std::unique_ptr<vigine::messaging::IMessageBus>    _bus;
 };
 
@@ -136,8 +136,8 @@ class EngineFixture : public ::testing::Test
      */
     [[nodiscard]] PrivateStack makePrivateStack(bool inlineOnly = true)
     {
-        vigine::threading::ThreadManagerConfig tmCfg{};
-        auto tm = vigine::threading::createThreadManager(tmCfg);
+        vigine::core::threading::ThreadManagerConfig tmCfg{};
+        auto tm = vigine::core::threading::createThreadManager(tmCfg);
         if (!tm)
         {
             return {};

--- a/test/contract/scenario_01_engine_lifecycle.cpp
+++ b/test/contract/scenario_01_engine_lifecycle.cpp
@@ -16,7 +16,7 @@
 #include "vigine/messaging/imessagebus.h"
 #include "vigine/statemachine/istatemachine.h"
 #include "vigine/taskflow/itaskflow.h"
-#include "vigine/threading/ithreadmanager.h"
+#include "vigine/core/threading/ithreadmanager.h"
 #include "vigine/vigine.h"
 
 #include <gtest/gtest.h>

--- a/test/contract/scenario_02_threading_primitives.cpp
+++ b/test/contract/scenario_02_threading_primitives.cpp
@@ -14,13 +14,13 @@
 
 #include "vigine/context/icontext.h"
 #include "vigine/result.h"
-#include "vigine/threading/ibarrier.h"
-#include "vigine/threading/imessagechannel.h"
-#include "vigine/threading/imutex.h"
-#include "vigine/threading/irunnable.h"
-#include "vigine/threading/isemaphore.h"
-#include "vigine/threading/itaskhandle.h"
-#include "vigine/threading/ithreadmanager.h"
+#include "vigine/core/threading/ibarrier.h"
+#include "vigine/core/threading/imessagechannel.h"
+#include "vigine/core/threading/imutex.h"
+#include "vigine/core/threading/irunnable.h"
+#include "vigine/core/threading/isemaphore.h"
+#include "vigine/core/threading/itaskhandle.h"
+#include "vigine/core/threading/ithreadmanager.h"
 
 #include <gtest/gtest.h>
 
@@ -39,7 +39,7 @@ namespace
 using ThreadingRoundTrip = EngineFixture;
 
 // Minimal IRunnable that flips a flag and returns Success.
-class FlagRunnable final : public vigine::threading::IRunnable
+class FlagRunnable final : public vigine::core::threading::IRunnable
 {
   public:
     explicit FlagRunnable(std::atomic<bool> *flag) noexcept : _flag(flag) {}
@@ -144,7 +144,7 @@ TEST_F(ThreadingRoundTrip, MessageChannelSendReceive)
     // Single-value round-trip: payload-less Message carrying only a
     // type id tag. The buffer stays empty on purpose -- the contract
     // tests the ownership transfer, not the encoding path.
-    vigine::threading::Message outbound{};
+    vigine::core::threading::Message outbound{};
     outbound.typeId = vigine::payload::PayloadTypeId{0xBEEF};
 
     const vigine::Result sent =
@@ -152,7 +152,7 @@ TEST_F(ThreadingRoundTrip, MessageChannelSendReceive)
     EXPECT_TRUE(sent.isSuccess())
         << "empty slot send must succeed; got: " << sent.message();
 
-    vigine::threading::Message inbound{};
+    vigine::core::threading::Message inbound{};
     const vigine::Result received =
         channel->receive(inbound, std::chrono::milliseconds{100});
     EXPECT_TRUE(received.isSuccess());

--- a/test/contract/scenario_04_signal_emitter.cpp
+++ b/test/contract/scenario_04_signal_emitter.cpp
@@ -30,10 +30,10 @@
 #include "vigine/signalemitter/defaultsignalemitter.h"
 #include "vigine/signalemitter/isignalemitter.h"
 #include "vigine/signalemitter/isignalpayload.h"
-#include "vigine/threading/irunnable.h"
-#include "vigine/threading/itaskhandle.h"
-#include "vigine/threading/ithreadmanager.h"
-#include "vigine/threading/threadaffinity.h"
+#include "vigine/core/threading/irunnable.h"
+#include "vigine/core/threading/itaskhandle.h"
+#include "vigine/core/threading/ithreadmanager.h"
+#include "vigine/core/threading/threadaffinity.h"
 
 #include <gtest/gtest.h>
 
@@ -117,7 +117,7 @@ class ThreadRecordingSubscriber final : public vigine::messaging::ISubscriber
  * non-owning raw pointer kept stable by the test fixture's stack-local
  * unique_ptr.
  */
-class EmitRunnable final : public vigine::threading::IRunnable
+class EmitRunnable final : public vigine::core::threading::IRunnable
 {
   public:
     EmitRunnable(vigine::signalemitter::ISignalEmitter *emitter,
@@ -205,7 +205,7 @@ TEST_F(SignalEmitter, AsyncDeliveryCrossesThreadBoundaries)
     // thread throughout the dispatch, and that caller can be a worker.
     auto handle = context().threadManager().schedule(
         std::make_unique<EmitRunnable>(emitter.get(), kTestPayloadTypeId),
-        vigine::threading::ThreadAffinity::Pool);
+        vigine::core::threading::ThreadAffinity::Pool);
     ASSERT_NE(handle, nullptr);
 
     // Bounded wait on the scheduled emit. 1 s is generous; the pool

--- a/test/contract/scenario_05_event_scheduler.cpp
+++ b/test/contract/scenario_05_event_scheduler.cpp
@@ -31,7 +31,7 @@
 #include "vigine/eventscheduler/itimersource.h"
 #include "vigine/eventscheduler/ossignal.h"
 #include "vigine/result.h"
-#include "vigine/threading/ithreadmanager.h"
+#include "vigine/core/threading/ithreadmanager.h"
 
 #include <gtest/gtest.h>
 

--- a/test/contract/scenario_08_request_response.cpp
+++ b/test/contract/scenario_08_request_response.cpp
@@ -36,7 +36,7 @@
 #include "vigine/requestbus/irequestbus.h"
 #include "vigine/requestbus/requestconfig.h"
 #include "vigine/result.h"
-#include "vigine/threading/ithreadmanager.h"
+#include "vigine/core/threading/ithreadmanager.h"
 #include "vigine/topicbus/topicid.h"
 
 #include <gtest/gtest.h>

--- a/test/contract/scenario_09_reactive_pipeline.cpp
+++ b/test/contract/scenario_09_reactive_pipeline.cpp
@@ -36,7 +36,7 @@
 #include "vigine/reactivestream/ireactivesubscriber.h"
 #include "vigine/reactivestream/ireactivesubscription.h"
 #include "vigine/result.h"
-#include "vigine/threading/ithreadmanager.h"
+#include "vigine/core/threading/ithreadmanager.h"
 
 #include <gtest/gtest.h>
 

--- a/test/contract/scenario_10_actor_host.cpp
+++ b/test/contract/scenario_10_actor_host.cpp
@@ -32,7 +32,7 @@
 #include "vigine/messaging/routemode.h"
 #include "vigine/payload/payloadtypeid.h"
 #include "vigine/result.h"
-#include "vigine/threading/ithreadmanager.h"
+#include "vigine/core/threading/ithreadmanager.h"
 
 #include <gtest/gtest.h>
 

--- a/test/engine/smoke_test.cpp
+++ b/test/engine/smoke_test.cpp
@@ -4,8 +4,8 @@
 #include "vigine/engine/factory.h"
 #include "vigine/engine/iengine.h"
 #include "vigine/result.h"
-#include "vigine/threading/irunnable.h"
-#include "vigine/threading/ithreadmanager.h"
+#include "vigine/core/threading/irunnable.h"
+#include "vigine/core/threading/ithreadmanager.h"
 
 #include <gtest/gtest.h>
 
@@ -62,7 +62,7 @@ using namespace vigine::engine;
 // queue without leaking captured state through the IRunnable contract.
 // ---------------------------------------------------------------------------
 
-class CallbackRunnable final : public threading::IRunnable
+class CallbackRunnable final : public core::threading::IRunnable
 {
   public:
     explicit CallbackRunnable(std::function<void()> fn) : _fn(std::move(fn)) {}

--- a/test/eventscheduler/smoke_test.cpp
+++ b/test/eventscheduler/smoke_test.cpp
@@ -11,9 +11,9 @@
 #include "vigine/messaging/messagekind.h"
 #include "vigine/messaging/targetkind.h"
 #include "vigine/result.h"
-#include "vigine/threading/factory.h"
-#include "vigine/threading/ithreadmanager.h"
-#include "vigine/threading/threadmanagerconfig.h"
+#include "vigine/core/threading/factory.h"
+#include "vigine/core/threading/ithreadmanager.h"
+#include "vigine/core/threading/threadmanagerconfig.h"
 
 #include <gtest/gtest.h>
 
@@ -176,11 +176,11 @@ class CountingTarget final : public vigine::messaging::AbstractMessageTarget
 };
 
 // Helper: create a thread manager for tests.
-std::unique_ptr<vigine::threading::IThreadManager> makeThreadManager()
+std::unique_ptr<vigine::core::threading::IThreadManager> makeThreadManager()
 {
-    vigine::threading::ThreadManagerConfig cfg;
+    vigine::core::threading::ThreadManagerConfig cfg;
     cfg.poolSize = 1;
-    return vigine::threading::createThreadManager(cfg);
+    return vigine::core::threading::createThreadManager(cfg);
 }
 
 // ---------------------------------------------------------------------------

--- a/test/messaging/smoke_test.cpp
+++ b/test/messaging/smoke_test.cpp
@@ -12,9 +12,9 @@
 #include "vigine/messaging/systemmessagebus.h"
 #include "vigine/payload/payloadtypeid.h"
 #include "vigine/result.h"
-#include "vigine/threading/factory.h"
-#include "vigine/threading/ithreadmanager.h"
-#include "vigine/threading/threadmanagerconfig.h"
+#include "vigine/core/threading/factory.h"
+#include "vigine/core/threading/ithreadmanager.h"
+#include "vigine/core/threading/threadmanagerconfig.h"
 
 #include <gtest/gtest.h>
 
@@ -144,8 +144,8 @@ struct MessagingSmoke : public ::testing::Test
 {
     void SetUp() override
     {
-        _threadManager = vigine::threading::createThreadManager(
-            vigine::threading::ThreadManagerConfig{});
+        _threadManager = vigine::core::threading::createThreadManager(
+            vigine::core::threading::ThreadManagerConfig{});
         ASSERT_TRUE(_threadManager);
     }
 
@@ -165,7 +165,7 @@ struct MessagingSmoke : public ::testing::Test
         return cfg;
     }
 
-    std::unique_ptr<vigine::threading::IThreadManager> _threadManager;
+    std::unique_ptr<vigine::core::threading::IThreadManager> _threadManager;
 };
 
 // ---------------------------------------------------------------------------

--- a/test/pipelinebuilder/smoke_test.cpp
+++ b/test/pipelinebuilder/smoke_test.cpp
@@ -12,9 +12,9 @@
 #include "vigine/pipelinebuilder/ipipelinebuilder.h"
 #include "vigine/pipelinebuilder/ipipelinestage.h"
 #include "vigine/result.h"
-#include "vigine/threading/factory.h"
-#include "vigine/threading/ithreadmanager.h"
-#include "vigine/threading/threadmanagerconfig.h"
+#include "vigine/core/threading/factory.h"
+#include "vigine/core/threading/ithreadmanager.h"
+#include "vigine/core/threading/threadmanagerconfig.h"
 
 #include <gtest/gtest.h>
 
@@ -124,7 +124,7 @@ class PipelineBuilderSmoke : public ::testing::Test
 
     void SetUp() override
     {
-        _tm = vigine::threading::createThreadManager({});
+        _tm = vigine::core::threading::createThreadManager({});
 
         vigine::messaging::BusConfig cfg;
         cfg.threading    = vigine::messaging::ThreadingPolicy::InlineOnly;
@@ -158,7 +158,7 @@ class PipelineBuilderSmoke : public ::testing::Test
         return createPipelineBuilder(*_bus, *_tm, *_channelFactory);
     }
 
-    std::unique_ptr<vigine::threading::IThreadManager>     _tm;
+    std::unique_ptr<vigine::core::threading::IThreadManager>     _tm;
     std::unique_ptr<vigine::messaging::IMessageBus>        _bus;
     std::unique_ptr<vigine::channelfactory::IChannelFactory> _channelFactory;
 };

--- a/test/reactivestream/smoke_test.cpp
+++ b/test/reactivestream/smoke_test.cpp
@@ -8,9 +8,9 @@
 #include "vigine/reactivestream/ireactivesubscriber.h"
 #include "vigine/reactivestream/ireactivesubscription.h"
 #include "vigine/result.h"
-#include "vigine/threading/factory.h"
-#include "vigine/threading/ithreadmanager.h"
-#include "vigine/threading/threadmanagerconfig.h"
+#include "vigine/core/threading/factory.h"
+#include "vigine/core/threading/ithreadmanager.h"
+#include "vigine/core/threading/threadmanagerconfig.h"
 
 #include <gtest/gtest.h>
 
@@ -144,7 +144,7 @@ class ReactiveStreamSmoke : public ::testing::Test
   protected:
     void SetUp() override
     {
-        _tm = vigine::threading::createThreadManager({});
+        _tm = vigine::core::threading::createThreadManager({});
 
         BusConfig cfg;
         cfg.threading    = ThreadingPolicy::InlineOnly;
@@ -171,7 +171,7 @@ class ReactiveStreamSmoke : public ::testing::Test
         }
     }
 
-    std::unique_ptr<vigine::threading::IThreadManager> _tm;
+    std::unique_ptr<vigine::core::threading::IThreadManager> _tm;
     std::unique_ptr<IMessageBus>                        _bus;
     std::unique_ptr<DefaultReactiveStream>              _stream;
 };

--- a/test/requestbus/smoke_test.cpp
+++ b/test/requestbus/smoke_test.cpp
@@ -13,9 +13,9 @@
 #include "vigine/requestbus/irequestbus.h"
 #include "vigine/requestbus/requestconfig.h"
 #include "vigine/result.h"
-#include "vigine/threading/factory.h"
-#include "vigine/threading/ithreadmanager.h"
-#include "vigine/threading/threadmanagerconfig.h"
+#include "vigine/core/threading/factory.h"
+#include "vigine/core/threading/ithreadmanager.h"
+#include "vigine/core/threading/threadmanagerconfig.h"
 #include "vigine/topicbus/topicid.h"
 
 #include <gtest/gtest.h>
@@ -81,7 +81,7 @@ class RequestBusSmoke : public ::testing::Test
   protected:
     void SetUp() override
     {
-        _tm = vigine::threading::createThreadManager({});
+        _tm = vigine::core::threading::createThreadManager({});
 
         BusConfig cfg;
         cfg.threading    = ThreadingPolicy::InlineOnly;
@@ -107,7 +107,7 @@ class RequestBusSmoke : public ::testing::Test
         }
     }
 
-    std::unique_ptr<vigine::threading::IThreadManager> _tm;
+    std::unique_ptr<vigine::core::threading::IThreadManager> _tm;
     std::unique_ptr<IMessageBus>                       _bus;
     std::unique_ptr<IRequestBus>                       _rb;
 };

--- a/test/service/smoke_test.cpp
+++ b/test/service/smoke_test.cpp
@@ -66,7 +66,7 @@ class ThrowingContext final : public vigine::IContext
         throw std::runtime_error{"smoke ThrowingContext: taskFlow called"};
     }
 
-    [[nodiscard]] vigine::threading::IThreadManager &threadManager() override
+    [[nodiscard]] vigine::core::threading::IThreadManager &threadManager() override
     {
         throw std::runtime_error{"smoke ThrowingContext: threadManager called"};
     }

--- a/test/threading/sync_smoke_test.cpp
+++ b/test/threading/sync_smoke_test.cpp
@@ -14,13 +14,13 @@
 // ---------------------------------------------------------------------------
 
 #include "vigine/result.h"
-#include "vigine/threading/factory.h"
-#include "vigine/threading/ibarrier.h"
-#include "vigine/threading/imessagechannel.h"
-#include "vigine/threading/imutex.h"
-#include "vigine/threading/isemaphore.h"
-#include "vigine/threading/ithreadmanager.h"
-#include "vigine/threading/threadmanagerconfig.h"
+#include "vigine/core/threading/factory.h"
+#include "vigine/core/threading/ibarrier.h"
+#include "vigine/core/threading/imessagechannel.h"
+#include "vigine/core/threading/imutex.h"
+#include "vigine/core/threading/isemaphore.h"
+#include "vigine/core/threading/ithreadmanager.h"
+#include "vigine/core/threading/threadmanagerconfig.h"
 
 #include <gtest/gtest.h>
 
@@ -30,14 +30,14 @@
 #include <thread>
 
 using vigine::Result;
-using vigine::threading::createThreadManager;
-using vigine::threading::IBarrier;
-using vigine::threading::IMessageChannel;
-using vigine::threading::IMutex;
-using vigine::threading::ISemaphore;
-using vigine::threading::IThreadManager;
-using vigine::threading::Message;
-using vigine::threading::ThreadManagerConfig;
+using vigine::core::threading::createThreadManager;
+using vigine::core::threading::IBarrier;
+using vigine::core::threading::IMessageChannel;
+using vigine::core::threading::IMutex;
+using vigine::core::threading::ISemaphore;
+using vigine::core::threading::IThreadManager;
+using vigine::core::threading::Message;
+using vigine::core::threading::ThreadManagerConfig;
 
 namespace
 {

--- a/test/threading/threadmanager_smoke_test.cpp
+++ b/test/threading/threadmanager_smoke_test.cpp
@@ -27,13 +27,13 @@
 // ---------------------------------------------------------------------------
 
 #include "vigine/result.h"
-#include "vigine/threading/factory.h"
-#include "vigine/threading/irunnable.h"
-#include "vigine/threading/itaskhandle.h"
-#include "vigine/threading/ithreadmanager.h"
-#include "vigine/threading/namedthreadid.h"
-#include "vigine/threading/threadaffinity.h"
-#include "vigine/threading/threadmanagerconfig.h"
+#include "vigine/core/threading/factory.h"
+#include "vigine/core/threading/irunnable.h"
+#include "vigine/core/threading/itaskhandle.h"
+#include "vigine/core/threading/ithreadmanager.h"
+#include "vigine/core/threading/namedthreadid.h"
+#include "vigine/core/threading/threadaffinity.h"
+#include "vigine/core/threading/threadmanagerconfig.h"
 
 #include <gtest/gtest.h>
 
@@ -43,13 +43,13 @@
 #include <thread>
 
 using vigine::Result;
-using vigine::threading::createThreadManager;
-using vigine::threading::IRunnable;
-using vigine::threading::ITaskHandle;
-using vigine::threading::IThreadManager;
-using vigine::threading::NamedThreadId;
-using vigine::threading::ThreadAffinity;
-using vigine::threading::ThreadManagerConfig;
+using vigine::core::threading::createThreadManager;
+using vigine::core::threading::IRunnable;
+using vigine::core::threading::ITaskHandle;
+using vigine::core::threading::IThreadManager;
+using vigine::core::threading::NamedThreadId;
+using vigine::core::threading::ThreadAffinity;
+using vigine::core::threading::ThreadManagerConfig;
 
 namespace
 {

--- a/test/topicbus/smoke_test.cpp
+++ b/test/topicbus/smoke_test.cpp
@@ -10,9 +10,9 @@
 #include "vigine/messaging/routemode.h"
 #include "vigine/payload/payloadtypeid.h"
 #include "vigine/result.h"
-#include "vigine/threading/factory.h"
-#include "vigine/threading/ithreadmanager.h"
-#include "vigine/threading/threadmanagerconfig.h"
+#include "vigine/core/threading/factory.h"
+#include "vigine/core/threading/ithreadmanager.h"
+#include "vigine/core/threading/threadmanagerconfig.h"
 #include "vigine/topicbus/defaulttopicbus.h"
 #include "vigine/topicbus/itopicbus.h"
 #include "vigine/topicbus/topicid.h"
@@ -99,7 +99,7 @@ class TopicBusSmoke : public ::testing::Test
   protected:
     void SetUp() override
     {
-        _tm = vigine::threading::createThreadManager({});
+        _tm = vigine::core::threading::createThreadManager({});
 
         BusConfig cfg;
         cfg.threading    = ThreadingPolicy::InlineOnly;
@@ -125,7 +125,7 @@ class TopicBusSmoke : public ::testing::Test
         }
     }
 
-    std::unique_ptr<vigine::threading::IThreadManager> _tm;
+    std::unique_ptr<vigine::core::threading::IThreadManager> _tm;
     std::unique_ptr<IMessageBus>                       _bus;
     std::unique_ptr<ITopicBus>                         _topic;
 };


### PR DESCRIPTION
Moves the threading substrate under the kernel layer, so every
low-level primitive (mutex, semaphore, barrier, message channel,
runnable, task handle, and the thread manager itself) now lives
under `<vigine/core/threading/...>` instead of `<vigine/threading/...>`.
The namespace follows the same path: what used to be
`vigine::threading` is now `vigine::core::threading`.

At the same time the default concrete implementation drops its
`Default` prefix — `DefaultThreadManager` is now just `ThreadManager`,
matching the naming used for other core types in the engine. That
class stays internal (callers reach it through the factory, which
still returns a `std::unique_ptr<IThreadManager>`).

Roughly 90 call sites across the engine, tests, and the example app
have been updated to use the new paths and namespace. The sync
primitive implementation headers (`DefaultMutex`, `DefaultBarrier`,
etc.) continue to live in `src/core/threading/` with their old
names — renaming those is left as a follow-up since they are
strictly internal.

All 191 tests pass locally.

Closes #218
