### PR TITLE
Add IEngineToken + AbstractEngineToken interfaces + StateInvalidatedPayload (#220)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -599,6 +599,15 @@ set(SOURCES_ENGINE
     ${SRC_DIR}/engine/factory.cpp
 )
 
+# Engine-token scaffolding (#220) -- pure interface + thin abstract
+# base only. No concrete EngineToken, no factory, no FSM invalidation
+# hook; those land in follow-up issues under the #197 umbrella.
+set(HEADER_ENGINE_TOKEN
+    ${INCLUDE_DIR}/vigine/api/engine/iengine_token.h
+    ${INCLUDE_DIR}/vigine/api/engine/abstractengine_token.h
+    ${INCLUDE_DIR}/vigine/api/messaging/payload/stateinvalidatedpayload.h
+)
+
 # Add source files
 if(ENABLE_POSTGRESQL)
     set(HEADER_POSTGRESQL
@@ -711,6 +720,7 @@ add_library(${PROJECT_NAME}
     ${SOURCES_PIPELINEBUILDER}
     ${HEADER_ENGINE}
     ${SOURCES_ENGINE}
+    ${HEADER_ENGINE_TOKEN}
     ${HEADER_POSTGRESQL}
     ${SOURCES_POSTGRESQL}
     ${SOURCES_POSTGRESQL_EXTRA}

--- a/include/vigine/api/engine/abstractengine_token.h
+++ b/include/vigine/api/engine/abstractengine_token.h
@@ -1,0 +1,137 @@
+#pragma once
+
+/**
+ * @file abstractengine_token.h
+ * @brief Thin stateful base for @ref vigine::engine::IEngineToken that
+ *        owns the bound-state handle and the alive flag.
+ *
+ * @ref vigine::engine::AbstractEngineToken is the @c Abstract tier of
+ * the token recipe: it carries the minimal state every concrete
+ * @c EngineToken implementation shares (@c boundState, @c alive) and
+ * implements the two introspection accessors on top of that state.
+ * Every other accessor -- gated and ungated alike -- stays pure
+ * virtual; the concrete @c EngineToken (shipping in a follow-up
+ * issue) delegates them to the root @ref vigine::IContext and closes
+ * the inheritance chain.
+ *
+ * Encapsulation: data members are strictly private (INV-12). Derived
+ * classes that need to transition the alive flag go through the
+ * protected @ref markExpired setter; they never mutate the atomic
+ * directly.
+ */
+
+#include <atomic>
+
+#include "vigine/api/engine/iengine_token.h"
+#include "vigine/statemachine/stateid.h"
+
+namespace vigine::engine
+{
+
+/**
+ * @brief Stateful abstract base for every concrete @c EngineToken.
+ *
+ * The class stores the two pieces of state every token needs:
+ *   - @ref _boundState: the @ref vigine::statemachine::StateId the
+ *     token was issued against. Immutable for the token's lifetime.
+ *   - @ref _alive: an atomic flag flipped by the state machine's
+ *     invalidation hook when the bound state transitions away.
+ *
+ * Naming uses the @c Abstract prefix per INV-10 because the class
+ * implements @ref IEngineToken::boundState and
+ * @ref IEngineToken::isAlive -- it carries both state and
+ * non-pure-virtual bodies.
+ *
+ * Lifetime and thread-safety:
+ *   - Tokens are constructed by the state machine when a task
+ *     enters a state. The constructor stamps @ref _boundState and
+ *     initialises @ref _alive to @c true.
+ *   - @ref markExpired is called once, from the state machine's
+ *     invalidation hook, when the bound state transitions away.
+ *     A second call is a no-op.
+ *   - @ref isAlive is safe to read from any thread at any time. The
+ *     atomic uses release / acquire semantics so an observed
+ *     @c false return happens-before any side effect the invalidation
+ *     hook publishes.
+ *
+ * Scope: concrete subclasses must implement every accessor except
+ * @ref boundState and @ref isAlive. The concrete @c EngineToken
+ * lands in a follow-up issue together with the @ref vigine::IContext
+ * factory.
+ */
+class AbstractEngineToken : public IEngineToken
+{
+  public:
+    ~AbstractEngineToken() override = default;
+
+    // ------ IEngineToken (implemented) ------
+
+    [[nodiscard]] vigine::statemachine::StateId
+        boundState() const noexcept override;
+
+    [[nodiscard]] bool isAlive() const noexcept override;
+
+    AbstractEngineToken(const AbstractEngineToken &)            = delete;
+    AbstractEngineToken &operator=(const AbstractEngineToken &) = delete;
+    AbstractEngineToken(AbstractEngineToken &&)                 = delete;
+    AbstractEngineToken &operator=(AbstractEngineToken &&)      = delete;
+
+  protected:
+    /**
+     * @brief Stamps @p boundState and arms the alive flag.
+     *
+     * Called by concrete subclasses during their construction. The
+     * subclass is expected to hold a reference to the engine's
+     * @ref vigine::IContext so the gated accessors can delegate
+     * through it; that reference is not part of this base because
+     * the exact wiring (direct reference, shared pointer to a
+     * control block, etc.) belongs to the concrete implementation.
+     */
+    explicit AbstractEngineToken(vigine::statemachine::StateId boundState) noexcept;
+
+    /**
+     * @brief Flips @ref _alive to @c false.
+     *
+     * Idempotent: a second call is a no-op. The transition uses
+     * release semantics so every prior write made by the state
+     * machine's invalidation hook is visible to subsequent
+     * @ref isAlive observers.
+     */
+    void markExpired() noexcept;
+
+  private:
+    vigine::statemachine::StateId _boundState;
+    std::atomic<bool>             _alive{true};
+};
+
+// ---------------------------------------------------------------------------
+// Inline definitions -- kept in-header because the class is a thin
+// stateful base with no out-of-line implementation file in this leaf.
+// A follow-up issue may move the bodies to a .cpp when the concrete
+// EngineToken lands, at which point the CMakeLists SOURCES_ENGINE_TOKEN
+// block takes shape.
+// ---------------------------------------------------------------------------
+
+inline AbstractEngineToken::AbstractEngineToken(
+    vigine::statemachine::StateId boundState) noexcept
+    : _boundState(boundState)
+{
+}
+
+inline vigine::statemachine::StateId
+    AbstractEngineToken::boundState() const noexcept
+{
+    return _boundState;
+}
+
+inline bool AbstractEngineToken::isAlive() const noexcept
+{
+    return _alive.load(std::memory_order_acquire);
+}
+
+inline void AbstractEngineToken::markExpired() noexcept
+{
+    _alive.store(false, std::memory_order_release);
+}
+
+} // namespace vigine::engine

--- a/include/vigine/api/engine/iengine_token.h
+++ b/include/vigine/api/engine/iengine_token.h
@@ -1,0 +1,378 @@
+#pragma once
+
+/**
+ * @file iengine_token.h
+ * @brief State-scoped handle to the engine API used by @c ITask clients.
+ *
+ * The state machine issues an @ref vigine::engine::IEngineToken to every
+ * task that runs inside a given state. The token behaves like
+ * @c std::weak_ptr: it resolves to a live view of the engine API while
+ * the state it was bound to is active, and it reports expired as soon as
+ * the FSM leaves that state. The concrete implementation, the factory on
+ * @ref vigine::IContext, and the FSM-level invalidation hook land in
+ * follow-up issues under the #197 umbrella. This header ships the pure
+ * contract only.
+ *
+ * Separation between gated and ungated accessors:
+ *   - Domain-level accessors (@ref service, @ref system,
+ *     @ref entityManager, @ref components, @ref ecs) carry lifecycle
+ *     uncertainty: the underlying registry slot may recycle between
+ *     ticks, and a stale handle must not fall back to a different
+ *     object. They return an @ref vigine::engine::Result wrapper that
+ *     carries either a live reference or the reason the lookup failed.
+ *   - Infrastructure accessors (@ref threadManager, @ref systemBus,
+ *     @ref signalEmitter, @ref stateMachine) refer to engine-lifetime
+ *     singletons that outlive every state transition. They return the
+ *     underlying reference directly and cannot fail.
+ *
+ * Invariants:
+ *   - INV-10: @c I prefix for this pure-virtual interface (no state,
+ *             no non-virtual method bodies).
+ *   - INV-12: no data members on this pure interface; the stateful
+ *             base @ref vigine::engine::AbstractEngineToken carries
+ *             @c boundState and @c alive.
+ *
+ * INV-1 deviation -- explicit, scoped exemption:
+ *   The @ref vigine::engine::Result wrapper is a tiny value template
+ *   used exclusively as the return type of the gated accessors. It
+ *   exists so a single return site can convey "live reference or
+ *   reason-for-failure" without collapsing onto a nullable pointer
+ *   and without minting a bespoke enum per accessor. Callers never
+ *   name the template on anything other than the gated-accessor
+ *   return types; no method on the interface itself takes a template
+ *   parameter. This deviation is sanctioned by the #220 scope note;
+ *   the rest of the token surface remains non-template, non-templated,
+ *   and INV-1-conforming.
+ */
+
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <type_traits>
+
+#include "vigine/messaging/isubscriptiontoken.h"
+#include "vigine/service/serviceid.h"
+#include "vigine/statemachine/stateid.h"
+
+// Forward declarations for the references the gated and ungated
+// accessors return. Kept as forward declarations so this header does
+// not pull the full wrapper or facade trees into every task's
+// translation unit. The implementation file (shipping in a follow-up
+// issue) includes the real surfaces.
+
+namespace vigine
+{
+// Legacy string-based SystemId lives in the top-level vigine namespace
+// today (see include/vigine/ecs/abstractsystem.h). The token surface
+// accepts it here so the interface compiles against the current tree.
+// When the ECS wrapper follow-up migrates SystemId into
+// vigine::ecs::SystemId, a later leaf updates this signature together
+// with every concrete EngineToken.
+using SystemId = std::string;
+} // namespace vigine
+
+namespace vigine::ecs
+{
+class IECS;
+} // namespace vigine::ecs
+
+namespace vigine::messaging
+{
+class IMessageBus;
+} // namespace vigine::messaging
+
+namespace vigine::service
+{
+class IService;
+} // namespace vigine::service
+
+namespace vigine::signalemitter
+{
+class ISignalEmitter;
+} // namespace vigine::signalemitter
+
+namespace vigine::statemachine
+{
+class IStateMachine;
+} // namespace vigine::statemachine
+
+namespace vigine::threading
+{
+class IThreadManager;
+} // namespace vigine::threading
+
+namespace vigine
+{
+// Forward declarations for types that the gated accessors reference
+// but that do not yet exist in the public tree. Each stub is marked
+// with the follow-up issue that finalises the surface.
+class IEntityManager;          // defined in vigine/ecs/ientitymanager.h today.
+class IComponentManager;       // to be defined under #197 (component-manager wrapper leaf).
+} // namespace vigine
+
+namespace vigine::ecs
+{
+class ISystem;                 // to be defined under #197 (system wrapper leaf).
+} // namespace vigine::ecs
+
+namespace vigine::engine
+{
+
+/**
+ * @brief Thin value wrapper carrying either a live reference of type
+ *        @p T or the reason the lookup failed.
+ *
+ * @ref Result is the return type of every gated accessor on
+ * @ref IEngineToken. It exists so callers can branch on one typed
+ * answer instead of juggling a nullable pointer next to an error code.
+ * The wrapper never owns the referred-to object; ownership stays with
+ * the engine's context aggregator.
+ *
+ * Status values:
+ *   - @ref Code::Ok          -- the reference is live.
+ *   - @ref Code::Expired     -- the token is no longer bound to an
+ *                               active state; callers must drop the
+ *                               token.
+ *   - @ref Code::NotFound    -- the id / slot addressed a recycled or
+ *                               unregistered entry.
+ *   - @ref Code::Unavailable -- the underlying subsystem is still
+ *                               initialising or has already been torn
+ *                               down; callers can retry.
+ *
+ * The template parameter @p T is always instantiated with a reference
+ * type on the IEngineToken API (e.g. @c Result<IService&>). Storing a
+ * raw pointer internally is safe because the referent is owned by the
+ * engine; the wrapper is a read-only snapshot of the lookup outcome.
+ *
+ * Thread-safety: the wrapper is trivially copyable and carries no
+ * synchronisation primitives. Concurrent reads from different threads
+ * are well-defined; mutating the wrapper is not supported after
+ * construction.
+ *
+ * @note Introduced with explicit scope as a return-type utility for
+ *       @ref IEngineToken; see the INV-1 deviation note on the file
+ *       docstring. Not intended to replace @ref vigine::Result on the
+ *       rest of the engine surface.
+ */
+template <typename T>
+class Result
+{
+  public:
+    enum class Code : std::uint8_t
+    {
+        Ok,
+        Expired,
+        NotFound,
+        Unavailable,
+    };
+
+    /**
+     * @brief Constructs an @c Ok result pointing at @p target.
+     *
+     * The reference must remain live for the duration of the
+     * caller's access window. The engine guarantees this by
+     * pinning the referent until the next state transition.
+     */
+    [[nodiscard]] static Result ok(T target) noexcept
+    {
+        using Stored = std::remove_reference_t<T>;
+        return Result{Code::Ok, std::addressof(static_cast<Stored &>(target))};
+    }
+
+    /**
+     * @brief Constructs a failure result carrying the @p code reason.
+     */
+    [[nodiscard]] static Result failure(Code code) noexcept
+    {
+        return Result{code, nullptr};
+    }
+
+    /**
+     * @brief Returns the status code.
+     */
+    [[nodiscard]] Code code() const noexcept { return _code; }
+
+    /**
+     * @brief Returns @c true when @ref code is @c Code::Ok.
+     */
+    [[nodiscard]] bool ok() const noexcept { return _code == Code::Ok; }
+
+    /**
+     * @brief Returns the referred-to object.
+     *
+     * Caller-side pre-condition: @ref ok returns @c true. Calling
+     * this accessor on a failure result is a programming error and
+     * dereferences a null pointer -- the contract is that callers
+     * always branch on @ref ok first.
+     */
+    [[nodiscard]] T value() const noexcept { return *_target; }
+
+  private:
+    using Stored = std::remove_reference_t<T>;
+
+    Result(Code code, Stored *target) noexcept : _code(code), _target(target) {}
+
+    Code     _code;
+    Stored  *_target;
+};
+
+/**
+ * @brief Pure-virtual state-scoped handle to the engine API.
+ *
+ * A token is issued by the state machine when a task enters a state
+ * and is handed to that task through @c ITask::onEnter. While the
+ * state stays active, the token's accessors resolve normally. The
+ * moment the FSM transitions away from the bound state, every live
+ * token binds to the new state is invalidated: gated accessors start
+ * reporting @ref Result::Code::Expired and @ref isAlive flips to
+ * @c false.
+ *
+ * Lifetime:
+ *   - The concrete @c EngineToken object is owned by the state
+ *     machine. The state machine hands tasks a reference, not a
+ *     value; tasks never construct or destroy a token.
+ *   - @ref subscribeExpiration returns an RAII
+ *     @ref vigine::messaging::ISubscriptionToken. Dropping the
+ *     returned token detaches the callback without racing the
+ *     state transition.
+ *
+ * Thread-safety: every accessor is safe to call from any thread. The
+ * gated accessors read @ref isAlive via the token's internal atomic
+ * before delegating to the engine's context aggregator; the delegation
+ * itself is guarded by the context's own locking rules.
+ *
+ * Invariants:
+ *   - INV-10: @c I prefix for this pure-virtual interface (no state,
+ *             no non-virtual method bodies).
+ *   - INV-12: no data members; state lives on
+ *             @ref AbstractEngineToken.
+ */
+class IEngineToken
+{
+  public:
+    virtual ~IEngineToken() = default;
+
+    // ------ Introspection ------
+
+    /**
+     * @brief Returns the state this token was bound to at issue time.
+     *
+     * The value is immutable for the token's lifetime. A task can
+     * compare it against the current active state (via
+     * @ref stateMachine) to decide whether to skip a side effect
+     * that depends on the originating context.
+     */
+    [[nodiscard]] virtual vigine::statemachine::StateId
+        boundState() const noexcept = 0;
+
+    /**
+     * @brief Reports whether the bound state is still active.
+     *
+     * Reads are lock-free. A @c false return guarantees that every
+     * subsequent gated accessor reports
+     * @ref Result::Code::Expired without touching the engine.
+     */
+    [[nodiscard]] virtual bool isAlive() const noexcept = 0;
+
+    // ------ Domain-level accessors (gated) ------
+
+    /**
+     * @brief Resolves the service registered under @p id.
+     *
+     * Reports @ref Result::Code::Expired when the token's bound
+     * state is no longer active, @ref Result::Code::NotFound when
+     * @p id is the invalid sentinel or addresses a recycled slot,
+     * and @ref Result::Code::Ok otherwise.
+     */
+    [[nodiscard]] virtual Result<vigine::service::IService &>
+        service(vigine::service::ServiceId id) = 0;
+
+    /**
+     * @brief Resolves the system registered under @p id.
+     *
+     * The concrete @ref vigine::ecs::ISystem interface lands in a
+     * follow-up issue; the signature already commits to the
+     * eventual surface so call sites do not rewrite when the
+     * follow-up merges.
+     */
+    [[nodiscard]] virtual Result<vigine::ecs::ISystem &>
+        system(vigine::SystemId id) = 0;
+
+    /**
+     * @brief Resolves the engine-wide entity manager.
+     */
+    [[nodiscard]] virtual Result<vigine::IEntityManager &> entityManager() = 0;
+
+    /**
+     * @brief Resolves the engine-wide component manager.
+     *
+     * The concrete @ref vigine::IComponentManager interface lands
+     * in a follow-up issue; the signature already commits to the
+     * eventual surface.
+     */
+    [[nodiscard]] virtual Result<vigine::IComponentManager &> components() = 0;
+
+    /**
+     * @brief Resolves the engine-wide ECS wrapper.
+     */
+    [[nodiscard]] virtual Result<vigine::ecs::IECS &> ecs() = 0;
+
+    // ------ Infrastructure accessors (ungated) ------
+
+    /**
+     * @brief Returns the engine-wide thread manager.
+     *
+     * The thread manager is built in the first step of the context
+     * aggregator's construction chain and outlives every token the
+     * state machine hands out. No gate is needed.
+     */
+    [[nodiscard]] virtual vigine::threading::IThreadManager &
+        threadManager() noexcept = 0;
+
+    /**
+     * @brief Returns the engine-wide system bus.
+     */
+    [[nodiscard]] virtual vigine::messaging::IMessageBus &
+        systemBus() noexcept = 0;
+
+    /**
+     * @brief Returns the engine-wide signal emitter facade.
+     */
+    [[nodiscard]] virtual vigine::signalemitter::ISignalEmitter &
+        signalEmitter() noexcept = 0;
+
+    /**
+     * @brief Returns the engine-wide state machine wrapper.
+     */
+    [[nodiscard]] virtual vigine::statemachine::IStateMachine &
+        stateMachine() noexcept = 0;
+
+    // ------ Expiration notification ------
+
+    /**
+     * @brief Subscribes @p callback to the token's expiration event.
+     *
+     * The engine invokes @p callback exactly once, on a worker
+     * thread picked by the engine's thread manager, when the bound
+     * state transitions away. Dropping the returned subscription
+     * token before expiration detaches the callback cleanly; after
+     * expiration the returned token is inert.
+     *
+     * Returns a null subscription token when @p callback is empty
+     * or when the token is already expired at registration time.
+     */
+    [[nodiscard]] virtual std::unique_ptr<vigine::messaging::ISubscriptionToken>
+        subscribeExpiration(std::function<void()> callback) = 0;
+
+    IEngineToken(const IEngineToken &)            = delete;
+    IEngineToken &operator=(const IEngineToken &) = delete;
+    IEngineToken(IEngineToken &&)                 = delete;
+    IEngineToken &operator=(IEngineToken &&)      = delete;
+
+  protected:
+    IEngineToken() = default;
+};
+
+} // namespace vigine::engine

--- a/include/vigine/api/messaging/payload/stateinvalidatedpayload.h
+++ b/include/vigine/api/messaging/payload/stateinvalidatedpayload.h
@@ -1,0 +1,111 @@
+#pragma once
+
+/**
+ * @file stateinvalidatedpayload.h
+ * @brief Signal payload announcing that a state transition has
+ *        invalidated every @ref vigine::engine::IEngineToken bound to
+ *        the vacated state.
+ *
+ * The state machine emits this payload on the engine-wide signal bus
+ * as part of its transition post-back, immediately after flipping the
+ * alive flag on the tokens that belonged to the vacated state. Tasks
+ * that subscribed to expiration through the signal emitter rather
+ * than through @ref vigine::engine::IEngineToken::subscribeExpiration
+ * observe the payload and perform their own cleanup. The concrete
+ * wiring into @c AbstractStateMachine lands in a follow-up issue; this
+ * header ships the payload contract only.
+ *
+ * Payload discipline follows the
+ * @ref vigine::signalemitter::ISignalPayload contract:
+ *   - Fields are @c const and set at construction time. The bus may
+ *     deliver the same payload pointer to multiple subscribers
+ *     without copying, so observable state never changes after
+ *     publish.
+ *   - @ref typeId returns a stable
+ *     @ref vigine::payload::PayloadTypeId value registered with the
+ *     engine's payload registry at initialisation time.
+ *   - @ref clone returns an independent deep-owned copy for
+ *     non-inline dispatch paths (see @c TaskFlow::signal).
+ */
+
+#include <memory>
+
+#include "vigine/payload/payloadtypeid.h"
+#include "vigine/signalemitter/isignalpayload.h"
+#include "vigine/statemachine/stateid.h"
+
+/**
+ * @brief Payload identifier for @ref vigine::messaging::payload::StateInvalidatedPayload.
+ *
+ * User-range value; registered by the engine's payload registry before
+ * the state machine emits the first invalidation signal. The 0x203xx
+ * block is reserved for state-machine lifecycle payloads so future
+ * additions (e.g. state-entered, state-exited) extend contiguously
+ * without colliding with existing signal-emitter or window-example
+ * payloads.
+ */
+inline constexpr vigine::payload::PayloadTypeId kStateInvalidatedPayloadTypeId{0x20301u};
+
+namespace vigine::messaging::payload
+{
+
+/**
+ * @brief Immutable payload describing the state whose tokens have just
+ *        been invalidated.
+ *
+ * Carries a copy of the @ref vigine::statemachine::StateId the state
+ * machine has just left. Subscribers compare it against their own
+ * bound state (if any) to decide whether the signal applies to them.
+ */
+class StateInvalidatedPayload final : public vigine::signalemitter::ISignalPayload
+{
+  public:
+    /**
+     * @brief Stamps the payload with the @p invalidatedState handle.
+     */
+    explicit StateInvalidatedPayload(
+        vigine::statemachine::StateId invalidatedState) noexcept
+        : _invalidatedState(invalidatedState)
+    {
+    }
+
+    ~StateInvalidatedPayload() override = default;
+
+    // ------ ISignalPayload ------
+
+    [[nodiscard]] vigine::payload::PayloadTypeId typeId() const noexcept override
+    {
+        return kStateInvalidatedPayloadTypeId;
+    }
+
+    [[nodiscard]] std::unique_ptr<vigine::signalemitter::ISignalPayload>
+        clone() const override
+    {
+        return std::make_unique<StateInvalidatedPayload>(_invalidatedState);
+    }
+
+    // ------ Payload accessors ------
+
+    /**
+     * @brief Returns the @ref vigine::statemachine::StateId the FSM
+     *        has just left.
+     *
+     * Stable for the payload's lifetime. Callers compare the value
+     * against their own bound state (e.g. their token's
+     * @c boundState()) and skip the signal when it does not match.
+     */
+    [[nodiscard]] vigine::statemachine::StateId invalidatedState() const noexcept
+    {
+        return _invalidatedState;
+    }
+
+    StateInvalidatedPayload(const StateInvalidatedPayload &)            = delete;
+    StateInvalidatedPayload &operator=(const StateInvalidatedPayload &) = delete;
+    StateInvalidatedPayload(StateInvalidatedPayload &&)                 = delete;
+    StateInvalidatedPayload &operator=(StateInvalidatedPayload &&)      = delete;
+
+  private:
+    const vigine::statemachine::StateId _invalidatedState;
+};
+
+} // namespace vigine::messaging::payload


### PR DESCRIPTION
Lays down the pure contract for the state-scoped handle tasks will receive
from the state machine when they enter a state. The handle resolves to the
engine API while the bound state is active and reports expired as soon as
the FSM transitions away.

What lands here:

- `include/vigine/api/engine/iengine_token.h` -- pure-virtual `IEngineToken`
  with gated accessors for services, systems, the entity manager, the
  component manager, and the ECS (each returning a small `Result<T>`
  wrapper) plus ungated accessors for the engine-lifetime singletons
  (thread manager, system bus, signal emitter, state machine). Also
  introduces `subscribeExpiration` for async expiration notification.
- `include/vigine/api/engine/abstractengine_token.h` -- thin stateful
  base that owns the bound-state handle and the atomic alive flag, and
  implements `boundState()` / `isAlive()`. Every other accessor stays
  pure virtual for the concrete `EngineToken` to close.
- `include/vigine/api/messaging/payload/stateinvalidatedpayload.h` --
  immutable signal payload (user-range id `0x20301u`) carrying the
  vacated `StateId`, for tasks that prefer to subscribe through the
  signal emitter rather than through the token's own expiration hook.

What does not land here (explicitly out of scope):

- No concrete `EngineToken` class.
- No `IContext::makeEngineToken()` factory.
- No wiring into `AbstractStateMachine::processQueuedTransitions`.
- No migration of existing `ITask` classes.

Each of the above is a follow-up issue under the #197 umbrella.

Build and tests stay green: the new headers compile cleanly when included
but nothing in the tree includes them yet, so the library and all 191
existing tests pass unchanged.

Closes #220
