### PR TITLE
Add TEMPLATE EXEMPTION comments to std::hash specializations (#227)

### DIFF
--- a/include/vigine/payload/payloadtypeid.h
+++ b/include/vigine/payload/payloadtypeid.h
@@ -56,6 +56,7 @@ struct PayloadTypeId
 // hash-container usability; shipping the specialisation here keeps that
 // promise. Keyed off the wrapped uint32_t and delegated to the std::hash
 // for uint32_t so the quality matches the standard library's default.
+// TEMPLATE EXEMPTION: std::hash specialization required for hash-map key support; sanctioned per architecture.md § R-NoTemplates.
 template <>
 struct std::hash<vigine::payload::PayloadTypeId>
 {

--- a/include/vigine/topicbus/topicid.h
+++ b/include/vigine/topicbus/topicid.h
@@ -46,16 +46,12 @@ struct TopicId
 
 } // namespace vigine::topicbus
 
-namespace std
-{
-
+// TEMPLATE EXEMPTION: std::hash specialization required for hash-map key support; sanctioned per architecture.md § R-NoTemplates.
 template <>
-struct hash<vigine::topicbus::TopicId>
+struct std::hash<vigine::topicbus::TopicId>
 {
     [[nodiscard]] std::size_t operator()(vigine::topicbus::TopicId id) const noexcept
     {
         return std::hash<std::uint32_t>{}(id.value);
     }
 };
-
-} // namespace std


### PR DESCRIPTION
The two `std::hash<>` specialisations in public headers (`payloadtypeid.h`, `topicid.h`) are sanctioned for hash-map key support but were lacking the marker comment that the rule scanner relies on to allow them under `R-NoTemplates`. This adds a single-line `// TEMPLATE EXEMPTION:` annotation immediately above each specialisation citing `architecture.md § R-NoTemplates`.

Also normalises `topicid.h` to use the same out-of-namespace `template <> struct std::hash<...>` form as `payloadtypeid.h`, so both files match a single consistent pattern.

Closes #227. Part of #197.

### Verification
- `grep -B 2 "struct std::hash" include/vigine/payload/payloadtypeid.h | grep -c "TEMPLATE EXEMPTION"` → `1`
- `grep -B 2 "struct std::hash" include/vigine/topicbus/topicid.h | grep -c "TEMPLATE EXEMPTION"` → `1`
- `cmake --build build --config Debug --target vigine` → `vigine.lib` produced cleanly