### PR TITLE
Flip markDead before drainQueue in IMessageBus shutdown (#228)

### DIFF
--- a/src/messaging/abstractmessagebus.cpp
+++ b/src/messaging/abstractmessagebus.cpp
@@ -389,11 +389,15 @@ Result AbstractMessageBus::shutdown()
     }
     _queueCv.notify_all();
 
-    // Drain the remaining queue. Workers that are still running will
-    // pick up the shutdown flag on their next loop iteration and exit.
-    drainQueue(true);
-
-    // Mark the control block dead. This does three things:
+    // Mark the control block dead BEFORE draining the queue. This closes
+    // a dead-bus visibility race window: if drain ran first, a concurrent
+    // token cancel path could observe `_control->isAlive() == true`
+    // between the drain completing and markDead firing, and proceed down
+    // a soon-to-be-dead path. By flipping the alive bit first we make the
+    // dead-bus state visible before any in-flight dispatch / cancel /
+    // token path observes the drain.
+    //
+    // markDead does three things:
     //   1. Every outstanding ConnectionToken destructor becomes a safe
     //      no-op (unchanged behaviour).
     //   2. Every outstanding SubscriptionToken destructor becomes a
@@ -416,6 +420,13 @@ Result AbstractMessageBus::shutdown()
     {
         _control->markDead();
     }
+
+    // Drain the remaining queue. Workers that are still running will
+    // pick up the shutdown flag on their next loop iteration and exit.
+    // Any in-flight dispatch the drain waits on now sees the bus as
+    // already-dead via the control block, so cancel/token paths racing
+    // with the drain take their no-op branch instead of the live path.
+    drainQueue(true);
 
     return Result{};
 }


### PR DESCRIPTION
## Summary

`AbstractMessageBus::shutdown()` previously: set `_shutdown` -> drain queue -> call `_control->markDead()`. Between drain completion and markDead, a concurrent token cancel path could observe `_control->isAlive() == true` and proceed down a soon-to-be-dead path.

This change reorders to: set `_shutdown` -> notify CV -> `markDead()` -> drain queue. The dead-bus state is now visible before any in-flight dispatch / cancel / token path observes the drain, closing the visibility race window.

Only `src/messaging/abstractmessagebus.cpp` is touched (one function). The `_shutdown` flag still flips first, so `post()` after shutdown continues to error out, and the existing idempotency guard / null-control guard are unchanged.

## Test plan

- [x] `cmake --build build --config Debug` -> green (221/221 build targets)
- [x] `ctest --test-dir build --output-on-failure` -> 191/191 pass
- [x] `MessagingRoundTrip.ShutdownRejectsSubsequentPost` -> pass (post-shutdown error guard intact)
- [x] `MessagingSmoke.TokenCancelBlocksUntilInFlightDispatchDrains` -> pass (dtor-blocks contract intact)

Closes #228. Part of #197.