### PR TITLE
Stub three new examples behind opt-in CMake options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,15 @@ endif()
 option(ENABLE_EXAMPLE "Build example projects" ON)
 option(ENABLE_UNITTEST "Enable tests" OFF)
 
+# Per-example opt-in switches for the new examples landing under the
+# v0.1.0 readiness umbrella. Default OFF; the matching subdirectory
+# stubs hold only a placeholder until a follow-up PR replaces them
+# with real sources, so flipping these ON today is a safe no-op
+# guarded by EXISTS in example/CMakeLists.txt.
+option(BUILD_EXAMPLE_THREADED_BUS "Build the threaded_bus example" OFF)
+option(BUILD_EXAMPLE_PARALLEL_FSM "Build the parallel_fsm example" OFF)
+option(BUILD_EXAMPLE_FANOUT_FSM "Build the fanout_fsm example" OFF)
+
 if(ENABLE_UNITTEST AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/CMakeLists.txt")
     # enable_testing() must be called from the top-level CMakeLists.txt so
     # that ctest picks up tests registered with gtest_discover_tests in the

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -16,3 +16,20 @@ if(BUILD_EXAMPLE_WINDOW)
     add_subdirectory(window)
 endif()
 
+# New examples landing under the v0.1.0 readiness umbrella. Each
+# stub directory currently holds only a placeholder file, so the
+# `EXISTS` guard makes today's configure step a clean no-op even
+# when the matching option is flipped ON. A follow-up PR replaces
+# each stub with a real CMakeLists.txt + sources.
+if(BUILD_EXAMPLE_THREADED_BUS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/threaded_bus/CMakeLists.txt")
+    add_subdirectory(threaded_bus)
+endif()
+
+if(BUILD_EXAMPLE_PARALLEL_FSM AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/parallel_fsm/CMakeLists.txt")
+    add_subdirectory(parallel_fsm)
+endif()
+
+if(BUILD_EXAMPLE_FANOUT_FSM AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/fanout_fsm/CMakeLists.txt")
+    add_subdirectory(fanout_fsm)
+endif()
+

--- a/example/fanout_fsm/.gitkeep
+++ b/example/fanout_fsm/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder. The fanout_fsm example replaces this stub in a follow-up PR (#197 readiness).

--- a/example/parallel_fsm/.gitkeep
+++ b/example/parallel_fsm/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder. The parallel_fsm example replaces this stub in a follow-up PR (#197 readiness).

--- a/example/threaded_bus/.gitkeep
+++ b/example/threaded_bus/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder. The threaded_bus example replaces this stub in a follow-up PR (#197 readiness).


### PR DESCRIPTION
Three new examples (`threaded_bus`, `parallel_fsm`, `fanout_fsm`) are
landing in follow-up PRs and need somewhere to plug into the CMake
tree. This change wires the build switches and reserves the
directories so the next PR can drop in real sources without touching
the wiring again.

What ships
- Three new top-level options near `ENABLE_EXAMPLE` in
  `CMakeLists.txt`: `BUILD_EXAMPLE_THREADED_BUS`,
  `BUILD_EXAMPLE_PARALLEL_FSM`, `BUILD_EXAMPLE_FANOUT_FSM`. All
  default OFF, matching the pattern used by `BUILD_EXAMPLE_WINDOW`
  and `BUILD_EXAMPLE_POSTGRESQL`.
- Three guarded `add_subdirectory` blocks in `example/CMakeLists.txt`.
  Each fires only when its option is ON **and** the corresponding
  subdirectory carries a `CMakeLists.txt`. The `EXISTS` guard is the
  reason flipping any option ON today is a clean no-op.
- Three placeholder directories — `example/threaded_bus`,
  `example/parallel_fsm`, `example/fanout_fsm` — each holding a
  single `.gitkeep` file so the directory survives in the tree
  without committing real code.

What does not change
- The default `cmake --preset windows-debug` configure / build /
  ctest run is untouched (191/191 tests pass with both the existing
  and the new options OFF).
- The `BUILD_EXAMPLE_WINDOW` and `BUILD_EXAMPLE_POSTGRESQL`
  branches keep their original behaviour.
- No source files outside `example/{threaded_bus,parallel_fsm,fanout_fsm}/`
  were touched; the engine library is bit-for-bit unchanged.

Verification
- `cmake --preset windows-debug -DENABLE_UNITTEST=ON` configures
  cleanly; `cmake --build build` produces 261 targets; `ctest` runs
  191/191 green.
- `cmake --preset windows-debug -DENABLE_UNITTEST=ON
  -DBUILD_EXAMPLE_THREADED_BUS=ON -DBUILD_EXAMPLE_PARALLEL_FSM=ON
  -DBUILD_EXAMPLE_FANOUT_FSM=ON` also configures + builds + tests
  cleanly; the `EXISTS` guard skips `add_subdirectory` for the
  stub-only directories.

Closes #245
