### PR TITLE
Wire ConnectionToken cancel barrier through SlotState (#244)

### DIFF
--- a/include/vigine/messaging/connectiontoken.h
+++ b/include/vigine/messaging/connectiontoken.h
@@ -1,13 +1,10 @@
 #pragma once
 
-#include <atomic>
-#include <condition_variable>
-#include <cstdint>
 #include <memory>
-#include <mutex>
 
 #include "vigine/messaging/connectionid.h"
 #include "vigine/messaging/iconnectiontoken.h"
+#include "vigine/messaging/subscriptionslot.h"
 
 namespace vigine::messaging
 {
@@ -19,18 +16,21 @@ class IBusControlBlock;
  * @ref ConnectionToken is the only shipped implementation of
  * @ref IConnectionToken. It carries a @c std::weak_ptr to the bus's
  * @ref IBusControlBlock so that it tolerates the bus being destroyed
- * first, plus the @ref ConnectionId that addresses its slot inside that
- * block. The destructor enforces the strong-unsubscribe barrier: the
- * slot is unregistered from the bus, and the destructor then waits until
- * every in-flight @c onMessage call that targets this token has
- * returned. That wait-until-drained step is what keeps the subscriber's
- * lifetime strictly longer than any dispatch that could still be running
- * against it.
+ * first, the @ref ConnectionId that addresses its slot inside that
+ * block, and a @c std::shared_ptr to the slot's @ref SlotState so the
+ * cancel barrier can run without reaching back into the registry. The
+ * destructor enforces the strong-unsubscribe barrier in two
+ * cooperating steps: it asks the control block to unregister the slot
+ * (which captures the same @ref SlotState and acquires
+ * @c lifecycleMutex exclusively, draining every concurrent
+ * @c onMessage), and it then trips @c cancelled to a steady-state
+ * @c true so that any snapshot copy of the slot still in flight
+ * observes the flag and skips @c onMessage. That sequence is what
+ * keeps the target's lifetime strictly longer than any dispatch that
+ * could still be running against it.
  *
  * A token is non-copyable and non-movable: the RAII contract ties one
- * token to one slot for its entire lifetime. The @c _inFlight counter
- * and condition variable are private plumbing driven by the bus during
- * dispatch; callers never touch them directly.
+ * token to one slot for its entire lifetime.
  *
  * Thread-safety: construction, @ref active, and destruction are safe to
  * call from any thread. The destructor is permitted to block until
@@ -48,18 +48,42 @@ class ConnectionToken final : public IConnectionToken
   public:
     /**
      * @brief Builds a token bound to the slot addressed by @p id inside
-     *        the control block reachable through @p control.
+     *        the control block reachable through @p control, sharing
+     *        @p slotState with the registry and the dispatch path.
      *
      * The @c std::weak_ptr lets the token tolerate the bus being
      * destroyed before the target. @p id is stored as-is; invalid ids
      * (generation zero) produce a token whose @ref active always
-     * reports @c false.
+     * reports @c false. @p slotState is the @c shared_ptr returned by
+     * @ref IBusControlBlock::allocateSlot inside @ref SlotAllocation;
+     * it MUST refer to the same live object that the registry slot
+     * holds. Passing an empty @c shared_ptr produces a token whose
+     * destructor still runs @c unregisterTarget but skips the cancel
+     * barrier — matching the inert-token shape that callers see when
+     * allocation failed.
      */
-    ConnectionToken(std::weak_ptr<IBusControlBlock> control, ConnectionId id) noexcept;
+    ConnectionToken(std::weak_ptr<IBusControlBlock> control,
+                    ConnectionId                   id,
+                    std::shared_ptr<SlotState>     slotState) noexcept;
 
     /**
      * @brief Unregisters the slot (if the bus is still alive) and then
-     *        waits for every in-flight dispatch on this slot to drain.
+     *        flips @c slotState->cancelled under the exclusive
+     *        @c lifecycleMutex so every still-in-flight dispatch on
+     *        this slot drains before this destructor returns.
+     *
+     * The destructor is the exact mirror of
+     * @ref AbstractMessageBus::SubscriptionToken::cancel: lock the
+     * weak_ptr to the control block, call @c unregisterTarget on a
+     * live block (the block itself drives the cancel barrier through
+     * the slot's @c lifecycleMutex), and finally — defensively —
+     * acquire the same @c lifecycleMutex exclusively from the token
+     * side and trip @c cancelled. The defensive step covers the path
+     * where the bus died first (weak_ptr.lock() returns null) and the
+     * registry was reclaimed en masse: the token still owns its share
+     * of the @ref SlotState and any racing dispatch holding a snapshot
+     * of the same state still observes @c cancelled before it enters
+     * the dispatch shared region.
      *
      * See the class-level note on reentrancy: destroying a token from
      * inside its own dispatch causes a self-deadlock.
@@ -85,23 +109,6 @@ class ConnectionToken final : public IConnectionToken
      */
     [[nodiscard]] ConnectionId id() const noexcept { return _id; }
 
-    /**
-     * @brief Records that a dispatch targeting this slot is about to
-     *        start. Called by the bus on the dispatch hot path.
-     *
-     * The paired @ref endDispatch must run on exactly one thread per
-     * @ref beginDispatch. Both are wait-free.
-     */
-    void beginDispatch() noexcept;
-
-    /**
-     * @brief Records that the matching dispatch has returned.
-     *
-     * When the in-flight counter transitions from @c 1 to @c 0, the
-     * destructor waiter (if any) is notified.
-     */
-    void endDispatch() noexcept;
-
     ConnectionToken(const ConnectionToken &)            = delete;
     ConnectionToken &operator=(const ConnectionToken &) = delete;
     ConnectionToken(ConnectionToken &&)                 = delete;
@@ -110,9 +117,11 @@ class ConnectionToken final : public IConnectionToken
   private:
     std::weak_ptr<IBusControlBlock> _control;
     ConnectionId                    _id;
-    std::atomic<std::uint32_t>      _inFlight{0};
-    mutable std::mutex              _waitMutex;
-    std::condition_variable_any     _waitCv;
+    // Shared with the registry slot and every dispatch snapshot. The
+    // destructor acquires `_slotState->lifecycleMutex` exclusively and
+    // sets `_slotState->cancelled` to drain every concurrent
+    // onMessage; mirrors the SubscriptionToken cancel path.
+    std::shared_ptr<SlotState>      _slotState;
 };
 
 } // namespace vigine::messaging

--- a/include/vigine/messaging/ibuscontrolblock.h
+++ b/include/vigine/messaging/ibuscontrolblock.h
@@ -14,6 +14,31 @@ class AbstractMessageTarget;
 class ISubscriber;
 
 /**
+ * @brief Outcome of a successful @ref IBusControlBlock::allocateSlot
+ *        call.
+ *
+ * Carries both the freshly-issued @ref ConnectionId AND the shared
+ * @ref SlotState that pairs with the connection slot. The state lives
+ * behind a @c std::shared_ptr so the same object survives every value
+ * copy of the slot (the dispatch path takes value snapshots, see
+ * @ref SubscriptionSlot) and so the @ref ConnectionToken handed back
+ * to the caller can keep its own owning reference to the lifecycle
+ * mutex and cancellation flag without reaching back into the registry.
+ *
+ * On failure (bus already dead, registry exhausted, @c nullptr target)
+ * implementations return a default-constructed @ref SlotAllocation
+ * whose @c id has the zero-generation sentinel and whose @c state is
+ * empty. Callers detect failure by checking @c id.valid().
+ */
+struct SlotAllocation
+{
+    /// Generational id addressing the new registry entry.
+    ConnectionId               id{};
+    /// Shared per-slot state. Empty when allocation failed.
+    std::shared_ptr<SlotState> state{};
+};
+
+/**
  * @brief Pure-virtual shared-heap state owned jointly by a message bus
  *        and the connection tokens it hands out.
  *
@@ -44,10 +69,12 @@ class ISubscriber;
  *     remaining weak tokens to be destroyed cleanly. It is always
  *     allocated on the heap and only reached through a shared/weak
  *     pointer pair.
- *   - @ref allocateSlot records a raw, non-owning pointer to the target.
- *     The caller (the bus) must guarantee that the target outlives the
- *     corresponding token or that the token's destructor runs before the
- *     target is freed -- which is the invariant provided by
+ *   - @ref allocateSlot records a raw, non-owning pointer to the target
+ *     and creates a fresh @ref SlotState shared between the registry,
+ *     the dispatch path, and the @ref ConnectionToken. The caller (the
+ *     bus) must guarantee that the target outlives the corresponding
+ *     token or that the token's destructor runs before the target is
+ *     freed -- which is the invariant provided by
  *     @ref AbstractMessageTarget owning its tokens.
  *
  * Thread-safety: every entry point is safe to call from any thread.
@@ -79,28 +106,35 @@ class IBusControlBlock
 
     /**
      * @brief Allocates a new registry slot for @p target and returns its
-     *        generational id.
+     *        generational id paired with the slot's @ref SlotState.
      *
-     * The returned @ref ConnectionId always has a non-zero @c generation
-     * when allocation succeeded. When the bus is already dead or when
-     * the registry is exhausted, implementations return a default-
-     * constructed sentinel (@c generation == 0) so that call sites can
-     * detect the failure without needing a separate @ref Result.
-     *
-     * Passing @c nullptr is a programming error; implementations return
-     * the sentinel id and do not insert anything into the registry.
+     * The returned @ref SlotAllocation::id always has a non-zero
+     * @c generation when allocation succeeded, and @c state holds a
+     * non-empty @c std::shared_ptr to a fresh @ref SlotState that the
+     * registry, the dispatch path, and the resulting
+     * @ref ConnectionToken all share. When the bus is already dead, the
+     * registry is exhausted, or @p target is @c nullptr, implementations
+     * return a default-constructed @ref SlotAllocation (the @c id
+     * sentinel has @c generation == 0 and @c state is empty) so that
+     * call sites can detect the failure without needing a separate
+     * @ref Result.
      */
-    [[nodiscard]] virtual ConnectionId
+    [[nodiscard]] virtual SlotAllocation
         allocateSlot(AbstractMessageTarget *target) = 0;
 
     /**
-     * @brief Removes the registry entry addressed by @p id.
+     * @brief Removes the registry entry addressed by @p id and drains
+     *        every dispatch still in flight on that slot.
      *
      * Idempotent: unregistering a stale id or an id from a dead bus is a
      * no-op. After this call returns, no future dispatch on this bus
-     * reaches the slot addressed by @p id; in-flight dispatches on that
-     * slot are serialised separately by the token (see
-     * @ref ConnectionToken).
+     * reaches the slot addressed by @p id; on a live bus the slot's
+     * @ref SlotState is driven through the exclusive @c lifecycleMutex
+     * so every still-in-flight dispatch drains before this call
+     * returns. Snapshot copies that have not yet entered the dispatch
+     * shared region observe the @c cancelled flag and skip
+     * @c onMessage. This is the exact mirror of
+     * @ref unregisterSubscription on the subscriber side.
      */
     virtual void unregisterTarget(ConnectionId id) noexcept = 0;
 

--- a/include/vigine/messaging/iconnectiontoken.h
+++ b/include/vigine/messaging/iconnectiontoken.h
@@ -11,7 +11,8 @@ namespace vigine::messaging
  * only semantic contract is that @ref active reports whether the backing
  * bus and slot are still live; the concrete RAII token
  * (@ref ConnectionToken) adds destructor-driven unregistration, weak
- * tracking of the control block, and a strong-unsubscribe barrier.
+ * tracking of the control block, and a strong-unsubscribe barrier
+ * driven through the slot's @c lifecycleMutex.
  *
  * Ownership: tokens are owned by their target (typically by
  * @ref AbstractMessageTarget holding them in its @c _connections vector).

--- a/src/messaging/abstractmessagebus.cpp
+++ b/src/messaging/abstractmessagebus.cpp
@@ -159,11 +159,12 @@ Result AbstractMessageBus::registerTarget(AbstractMessageTarget *target)
 
     // Allocate the registry slot first so a failure past this point
     // only needs to roll back the allocation, not a half-built target
-    // connection. allocateSlot returns the sentinel id on failure; we
-    // translate that into an error result without mutating any state on
-    // the target side.
-    const ConnectionId connectionId = _control->allocateSlot(target);
-    if (!connectionId.valid())
+    // connection. `allocateSlot` returns a default-constructed
+    // SlotAllocation on failure (id sentinel + empty SlotState); we
+    // translate that into an error result without mutating any state
+    // on the target side.
+    SlotAllocation allocation = _control->allocateSlot(target);
+    if (!allocation.id.valid())
     {
         return Result{Result::Code::Error, "bus registry exhausted or dead"};
     }
@@ -175,11 +176,13 @@ Result AbstractMessageBus::registerTarget(AbstractMessageTarget *target)
     try
     {
         token = std::make_unique<ConnectionToken>(
-            std::weak_ptr<IBusControlBlock>(_control), connectionId);
+            std::weak_ptr<IBusControlBlock>(_control),
+            allocation.id,
+            allocation.state);
     }
     catch (...)
     {
-        _control->unregisterTarget(connectionId);
+        _control->unregisterTarget(allocation.id);
         throw;
     }
 
@@ -197,7 +200,7 @@ Result AbstractMessageBus::registerTarget(AbstractMessageTarget *target)
         // the argument -- which calls unregisterTarget through the
         // ConnectionToken destructor. Calling unregisterTarget a second
         // time is a documented no-op.
-        _control->unregisterTarget(connectionId);
+        _control->unregisterTarget(allocation.id);
         throw;
     }
 

--- a/src/messaging/connectiontoken.cpp
+++ b/src/messaging/connectiontoken.cpp
@@ -1,5 +1,7 @@
 #include "vigine/messaging/connectiontoken.h"
 
+#include <mutex>
+#include <shared_mutex>
 #include <utility>
 
 #include "vigine/messaging/ibuscontrolblock.h"
@@ -8,31 +10,41 @@ namespace vigine::messaging
 {
 
 ConnectionToken::ConnectionToken(std::weak_ptr<IBusControlBlock> control,
-                                 ConnectionId                   id) noexcept
-    : _control{std::move(control)}, _id{id}
+                                 ConnectionId                   id,
+                                 std::shared_ptr<SlotState>     slotState) noexcept
+    : _control{std::move(control)}, _id{id}, _slotState{std::move(slotState)}
 {
 }
 
 ConnectionToken::~ConnectionToken()
 {
-    // First, prevent new dispatches on this slot. If the bus is still
-    // alive we ask it to drop our registry entry; if it died first, the
-    // weak lock fails and we fall through to the drain wait.
+    // Step 1: ask the control block to retire the registry slot. On a
+    // live bus the block also drains every dispatch in flight on this
+    // slot by acquiring `_slotState->lifecycleMutex` exclusively
+    // before flipping `cancelled`. On a dead bus the weak_ptr.lock()
+    // returns null and the registry has already been reclaimed en
+    // masse — the cancel barrier below still has work to do for any
+    // dispatch snapshot still holding a copy of the same SlotState.
     if (auto ctrl = _control.lock())
     {
         ctrl->unregisterTarget(_id);
     }
 
-    // Strong-unsubscribe barrier: wait until every dispatch that
-    // observed the slot (before unregisterTarget took effect) has
-    // finished calling AbstractMessageTarget::onMessage. The bus is
-    // responsible for incrementing _inFlight before the call and
-    // decrementing it after the call; endDispatch signals the cv on
-    // the 1 -> 0 transition.
-    std::unique_lock<std::mutex> lock{_waitMutex};
-    _waitCv.wait(lock, [this] {
-        return _inFlight.load(std::memory_order_acquire) == 0;
-    });
+    // Step 2: defensive cancel barrier from the token side. Mirror of
+    // `SubscriptionToken::cancel`. Even when step 1 ran the same
+    // logic inside `unregisterTarget`, repeating it here costs only an
+    // already-uncontended lock acquisition and covers the bus-died-
+    // first path, where step 1 was a no-op but a racing dispatch may
+    // still be sitting on a snapshot copy of `_slotState`. The
+    // `unique_lock` on the shared_mutex blocks until every concurrent
+    // shared holder (every in-flight `onMessage`) has released, which
+    // is the dtor-blocks contract that the IConnectionToken header
+    // documents.
+    if (_slotState)
+    {
+        std::unique_lock<std::shared_mutex> lock{_slotState->lifecycleMutex};
+        _slotState->cancelled = true;
+    }
 }
 
 bool ConnectionToken::active() const noexcept
@@ -49,20 +61,6 @@ bool ConnectionToken::active() const noexcept
     }
     auto ctrl = _control.lock();
     return static_cast<bool>(ctrl) && ctrl->isAlive();
-}
-
-void ConnectionToken::beginDispatch() noexcept
-{
-    _inFlight.fetch_add(1, std::memory_order_acq_rel);
-}
-
-void ConnectionToken::endDispatch() noexcept
-{
-    if (_inFlight.fetch_sub(1, std::memory_order_acq_rel) == 1)
-    {
-        std::lock_guard<std::mutex> lock{_waitMutex};
-        _waitCv.notify_all();
-    }
 }
 
 } // namespace vigine::messaging

--- a/src/messaging/ibuscontrolblock_default.cpp
+++ b/src/messaging/ibuscontrolblock_default.cpp
@@ -29,17 +29,26 @@ void DefaultBusControlBlock::markDead() noexcept
     _alive.store(false, std::memory_order_release);
 }
 
-ConnectionId
+SlotAllocation
 DefaultBusControlBlock::allocateSlot(AbstractMessageTarget *target)
 {
     if (target == nullptr)
     {
-        return ConnectionId{};
+        return SlotAllocation{};
     }
     if (!_alive.load(std::memory_order_acquire))
     {
-        return ConnectionId{};
+        return SlotAllocation{};
     }
+
+    // Build the SlotState before taking the registry lock: SlotState's
+    // mutexes are constructed under no lock, and a `bad_alloc` here
+    // bubbles back to the caller without leaving any registry mutation
+    // behind. The shared_ptr is moved into both the registry slot and
+    // the SlotAllocation, so the registry, the dispatch path, and the
+    // ConnectionToken all share one live SlotState — exactly the same
+    // shape as the subscriber side.
+    auto slotState = std::make_shared<SlotState>();
 
     std::unique_lock<std::shared_mutex> lock{_registryMutex};
 
@@ -47,7 +56,7 @@ DefaultBusControlBlock::allocateSlot(AbstractMessageTarget *target)
     // called markDead between the fast-path read and the lock.
     if (!_alive.load(std::memory_order_acquire))
     {
-        return ConnectionId{};
+        return SlotAllocation{};
     }
 
     // Prefer a recycled index so the registry does not grow
@@ -77,8 +86,8 @@ DefaultBusControlBlock::allocateSlot(AbstractMessageTarget *target)
         }
     }
 
-    _registry.emplace(index, Slot{target, generation});
-    return ConnectionId{index, generation};
+    _registry.emplace(index, Slot{target, generation, slotState});
+    return SlotAllocation{ConnectionId{index, generation}, std::move(slotState)};
 }
 
 void DefaultBusControlBlock::unregisterTarget(ConnectionId id) noexcept
@@ -94,31 +103,57 @@ void DefaultBusControlBlock::unregisterTarget(ConnectionId id) noexcept
         return;
     }
 
-    std::unique_lock<std::shared_mutex> lock{_registryMutex};
-    auto it = _registry.find(id.index);
-    if (it == _registry.end())
+    // Capture the SlotState shared_ptr BEFORE erasing the registry
+    // entry so the lifecycle mutex survives the map removal. Any
+    // dispatch already past the registry lookup owns its own
+    // shared_ptr to the same SlotState; after this capture AND the
+    // erase, the lifecycle mutex below serialises against every such
+    // in-flight onMessage before we return — which is the dtor-blocks
+    // guarantee that the ConnectionToken contract advertises. Mirror
+    // of `unregisterSubscription`.
+    std::shared_ptr<SlotState> state;
     {
-        return;
+        std::unique_lock<std::shared_mutex> lock{_registryMutex};
+        auto it = _registry.find(id.index);
+        if (it == _registry.end())
+        {
+            return;
+        }
+        if (it->second.generation != id.generation)
+        {
+            // The slot was already recycled under a newer generation;
+            // the caller's id is stale and must not touch the live
+            // slot.
+            return;
+        }
+        state = it->second.slotState;
+        // Remember the next generation for this index, erase the slot,
+        // push the index onto the free-list. `allocateSlot` picks it
+        // up on its next call. Previous behaviour left the slot in
+        // place as a null-target tombstone; over long sessions the
+        // registry grew without bound.
+        std::uint32_t nextGen = it->second.generation + 1u;
+        if (nextGen == 0u)
+        {
+            nextGen = 1u;
+        }
+        _nextGenerationByIndex[id.index] = nextGen;
+        _registry.erase(it);
+        _freeIndices.push_back(id.index);
     }
-    if (it->second.generation != id.generation)
+
+    if (state)
     {
-        // The slot was already recycled under a newer generation; the
-        // caller's id is stale and must not touch the live slot.
-        return;
+        // Acquire lifecycleMutex EXCLUSIVELY. Every concurrent
+        // dispatch that reached this slot through `lookup` holds it
+        // SHARED for the duration of onMessage, so the exclusive
+        // acquisition blocks until all of them have returned. Once we
+        // hold the lock we flip `cancelled` so that any later lookup
+        // racing the registry erase observes the flag and returns an
+        // empty guard — matching the subscriber-side flow.
+        std::unique_lock<std::shared_mutex> ex{state->lifecycleMutex};
+        state->cancelled = true;
     }
-    // Remember the next generation for this index, erase the slot,
-    // push the index onto the free-list. `allocateSlot` picks it
-    // up on its next call. Previous behaviour left the slot in
-    // place as a null-target tombstone; over long sessions the
-    // registry grew without bound.
-    std::uint32_t nextGen = it->second.generation + 1u;
-    if (nextGen == 0u)
-    {
-        nextGen = 1u;
-    }
-    _nextGenerationByIndex[id.index] = nextGen;
-    _registry.erase(it);
-    _freeIndices.push_back(id.index);
 }
 
 std::uint64_t DefaultBusControlBlock::registerSubscription(
@@ -246,7 +281,7 @@ DefaultBusControlBlock::lookup(ConnectionId id) const noexcept
     {
         return {};
     }
-    std::shared_lock<std::shared_mutex> lock{_registryMutex};
+    std::shared_lock<std::shared_mutex> registryLock{_registryMutex};
     auto it = _registry.find(id.index);
     if (it == _registry.end())
     {
@@ -256,11 +291,36 @@ DefaultBusControlBlock::lookup(ConnectionId id) const noexcept
     {
         return {};
     }
-    // Hand the lock over to the caller alongside the pointer. The
-    // RAII guard releases the lock when the caller's scope ends,
-    // so a concurrent unregisterTarget cannot retire the slot while
-    // the caller dereferences `target`.
-    return LookupGuard{it->second.target, std::move(lock)};
+
+    AbstractMessageTarget *const     target    = it->second.target;
+    const std::shared_ptr<SlotState> slotState = it->second.slotState;
+
+    // Acquire the slot's lifecycleMutex in SHARED mode AFTER we have
+    // identified the live slot. This pairs with the exclusive lock
+    // taken by `unregisterTarget`: while we hold the shared lock, the
+    // cancel barrier inside `~ConnectionToken` cannot return, so the
+    // target pointer remains live for the duration of the caller's
+    // onMessage call. Mirror of the subscriber dispatch path in
+    // `AbstractMessageBus::deliver`.
+    std::shared_lock<std::shared_mutex> lifecycleLock;
+    if (slotState)
+    {
+        lifecycleLock = std::shared_lock<std::shared_mutex>{slotState->lifecycleMutex};
+        if (slotState->cancelled)
+        {
+            // The slot was cancelled between the registry probe and
+            // the lifecycle acquisition; an empty guard skips
+            // onMessage and prevents use-after-free on a target whose
+            // owner is mid-destruction.
+            return {};
+        }
+    }
+
+    // Hand both locks over to the caller alongside the pointer. The
+    // RAII guard releases them when the caller's scope ends, so neither
+    // a concurrent unregisterTarget nor a concurrent token destructor
+    // can retire the slot while the caller dereferences `target`.
+    return LookupGuard{target, std::move(registryLock), std::move(lifecycleLock)};
 }
 
 } // namespace vigine::messaging

--- a/src/messaging/ibuscontrolblock_default.h
+++ b/src/messaging/ibuscontrolblock_default.h
@@ -43,7 +43,7 @@ class DefaultBusControlBlock final : public IBusControlBlock
     [[nodiscard]] bool isAlive() const noexcept override;
     void               markDead() noexcept override;
 
-    [[nodiscard]] ConnectionId
+    [[nodiscard]] SlotAllocation
         allocateSlot(AbstractMessageTarget *target) override;
     void unregisterTarget(ConnectionId id) noexcept override;
 
@@ -56,13 +56,15 @@ class DefaultBusControlBlock final : public IBusControlBlock
         snapshotSubscriptions() const override;
 
     /**
-     * @brief RAII pair holding the registry's shared lock alongside
-     *        a target pointer.
+     * @brief RAII bundle holding the registry's shared lock plus the
+     *        slot's @c lifecycleMutex shared lock alongside a target
+     *        pointer.
      *
      * Returned by @ref lookup so callers can dereference `target`
-     * without racing a concurrent `unregisterTarget`. The shared
-     * lock releases when the guard goes out of scope. Move-only
-     * (the shared_lock is move-only by construction); copies would
+     * without racing either a concurrent `unregisterTarget` or a
+     * `~ConnectionToken` running the cancel barrier. Both shared locks
+     * release when the guard goes out of scope. Move-only (the
+     * shared_lock members are move-only by construction); copies would
      * accidentally extend the locked region indefinitely.
      *
      * Usage:
@@ -71,33 +73,43 @@ class DefaultBusControlBlock final : public IBusControlBlock
      *       guard.target->onMessage(msg);
      *   }
      *
-     * When the lookup fails (invalid id, stale generation, bus
-     * dead), `guard.target` is `nullptr` and the shared_lock is
-     * not held. Callers only need to null-check `target`.
+     * When the lookup fails (invalid id, stale generation, bus dead,
+     * or the slot already cancelled), `guard.target` is `nullptr` and
+     * neither shared lock is held. Callers only need to null-check
+     * `target`.
+     *
+     * Lock-order with the cancel path is registry(shared) ->
+     * lifecycleMutex(shared); `unregisterTarget` takes
+     * lifecycleMutex(exclusive) AFTER releasing the registry's
+     * exclusive lock and so cannot race with this nesting.
      */
     struct LookupGuard
     {
         AbstractMessageTarget               *target{nullptr};
-        std::shared_lock<std::shared_mutex>  lock{};
+        std::shared_lock<std::shared_mutex>  registryLock{};
+        std::shared_lock<std::shared_mutex>  lifecycleLock{};
     };
 
     /**
      * @brief Returns an RAII guard around the live target pointer
      *        behind @p id, or an empty guard when the slot is stale,
-     *        recycled, or the bus is dead.
+     *        recycled, the bus is dead, or the slot has already been
+     *        cancelled.
      *
-     * The returned guard owns a shared_lock on the registry, so
-     * dereferencing `guard.target` is safe against a concurrent
-     * `unregisterTarget` for the lifetime of the guard. Releasing
-     * the guard releases the lock.
+     * The returned guard owns a shared_lock on the registry AND a
+     * shared_lock on the slot's @c lifecycleMutex, so dereferencing
+     * `guard.target` is safe against a concurrent `unregisterTarget`
+     * AND against a concurrent `~ConnectionToken` driving the cancel
+     * barrier. Releasing the guard releases both locks.
      */
     [[nodiscard]] LookupGuard lookup(ConnectionId id) const noexcept;
 
   private:
     struct Slot
     {
-        AbstractMessageTarget *target{nullptr};
-        std::uint32_t          generation{0};
+        AbstractMessageTarget     *target{nullptr};
+        std::uint32_t              generation{0};
+        std::shared_ptr<SlotState> slotState{};
     };
 
     mutable std::shared_mutex                     _registryMutex;


### PR DESCRIPTION
ConnectionToken used to carry its own in-flight counter and condition
variable to drain dispatch on destruction. The subscriber-side
SubscriptionToken already had a cleaner design built around a shared
SlotState (a shared_mutex-based lifecycle gate plus a cancelled flag),
and after the message-bus refactor that shipped under #195 there is no
longer any reason to keep the two pin points different.

This change wires the connection side onto the same machinery:

- IBusControlBlock::allocateSlot returns a SlotAllocation pair with
  the ConnectionId and a fresh shared_ptr<SlotState>. The DefaultBus
  control block stores the same SlotState pointer in its registry slot.
- ConnectionToken now owns a shared_ptr<SlotState>. Its destructor
  asks the control block to retire the registry entry and then takes
  a unique_lock on the lifecycle mutex from the token side as a
  defensive cancel barrier — exactly the shape SubscriptionToken::cancel
  already uses.
- DefaultBusControlBlock::unregisterTarget mirrors unregisterSubscription:
  capture the SlotState before erasing the registry row, then take an
  exclusive lock on lifecycleMutex to drain every in-flight onMessage
  before flipping cancelled.
- DefaultBusControlBlock::lookup hands callers a LookupGuard that holds
  both the registry shared lock AND a shared lock on the slot's
  lifecycleMutex, plus a cancelled-flag check, so target-side dispatch
  through lookup is now symmetric with the subscriber side already
  living in AbstractMessageBus::deliver.

The dead _inFlight atomic and _waitCv condition variable are gone from
the connection-token plumbing. The Doxygen on IConnectionToken,
ConnectionToken, and IBusControlBlock::allocateSlot is updated to
describe the new shape — including the fact that the cancel barrier
runs through the same lifecycleMutex on both sides.

The two existing pin tests (the inline shutdown contract and the
TokenCancelBlocksUntilInFlightDispatchDrains subscriber-side dtor-blocks
case) keep passing because the subscriber path is untouched. No public
behaviour change for callers — registerTarget still returns Result, the
token contract is unchanged, and the inert-token shape (allocation
failed -> empty SlotState) is preserved.

Closes #244
