### PR TITLE
Add IConnectionToken::cancel() for API symmetry with ISubscriptionToken (#251)

### DIFF
--- a/include/vigine/messaging/connectiontoken.h
+++ b/include/vigine/messaging/connectiontoken.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <memory>
 
 #include "vigine/messaging/connectionid.h"
@@ -72,11 +73,12 @@ class ConnectionToken final : public IConnectionToken
      *        @c lifecycleMutex so every still-in-flight dispatch on
      *        this slot drains before this destructor returns.
      *
-     * The destructor is the exact mirror of
-     * @ref AbstractMessageBus::SubscriptionToken::cancel: lock the
-     * weak_ptr to the control block, call @c unregisterTarget on a
-     * live block (the block itself drives the cancel barrier through
-     * the slot's @c lifecycleMutex), and finally — defensively —
+     * Delegates to @ref cancel so the RAII teardown path and the
+     * explicit-cancel path share one body. The destructor is the exact
+     * mirror of @ref AbstractMessageBus::SubscriptionToken::cancel:
+     * lock the weak_ptr to the control block, call @c unregisterTarget
+     * on a live block (the block itself drives the cancel barrier
+     * through the slot's @c lifecycleMutex), and finally — defensively —
      * acquire the same @c lifecycleMutex exclusively from the token
      * side and trip @c cancelled. The defensive step covers the path
      * where the bus died first (weak_ptr.lock() returns null) and the
@@ -91,13 +93,29 @@ class ConnectionToken final : public IConnectionToken
     ~ConnectionToken() override;
 
     /**
-     * @brief Returns @c true when both the control block is reachable
-     *        and @ref IBusControlBlock::isAlive reports @c true.
+     * @brief Explicitly releases the slot ahead of destruction.
      *
-     * Cheap: one @c weak_ptr::lock plus one atomic load. The return
-     * value is a momentary snapshot; callers racing with
-     * @ref IBusControlBlock::markDead may observe the bus transitioning
-     * to dead between the @c active check and a subsequent dispatch.
+     * Runs the same unregister-then-barrier sequence as the
+     * destructor. Idempotent across repeated calls via the
+     * @c _cancelled atomic exchange; the second caller short-circuits
+     * before touching the control block or the @c lifecycleMutex so a
+     * repeat is wait-free. Blocks on the slot's @c lifecycleMutex when
+     * a dispatch is in flight, matching the dtor-blocks contract the
+     * @ref IConnectionToken header documents.
+     */
+    void cancel() override;
+
+    /**
+     * @brief Returns @c true when the id is valid, the token has not
+     *        been cancelled, the control block is reachable, and
+     *        @ref IBusControlBlock::isAlive reports @c true.
+     *
+     * Cheap: one valid-id check, one atomic load on @c _cancelled,
+     * one @c weak_ptr::lock, one atomic load on the bus alive flag.
+     * The return value is a momentary snapshot; callers racing with
+     * @ref IBusControlBlock::markDead or a concurrent @ref cancel may
+     * observe the transition between the check and any follow-up
+     * operation.
      */
     [[nodiscard]] bool active() const noexcept override;
 
@@ -122,6 +140,13 @@ class ConnectionToken final : public IConnectionToken
     // sets `_slotState->cancelled` to drain every concurrent
     // onMessage; mirrors the SubscriptionToken cancel path.
     std::shared_ptr<SlotState>      _slotState;
+    // Idempotency flag for `cancel`. The first caller (explicit or
+    // the destructor) wins the compare_exchange and runs the full
+    // unregister-plus-barrier sequence; later callers short-circuit
+    // before touching either the control block or the lifecycle
+    // mutex. Mirrors the same role `_cancelled` plays inside
+    // `AbstractMessageBus::SubscriptionToken`.
+    std::atomic<bool>               _cancelled{false};
 };
 
 } // namespace vigine::messaging

--- a/include/vigine/messaging/iconnectiontoken.h
+++ b/include/vigine/messaging/iconnectiontoken.h
@@ -28,13 +28,42 @@ class IConnectionToken
     virtual ~IConnectionToken() = default;
 
     /**
+     * @brief Tears the connection slot down immediately.
+     *
+     * One-shot release of the connection: asks the underlying bus
+     * control block to retire the registry slot and trips the
+     * cancellation flag on the shared @ref SlotState so every
+     * still-in-flight dispatch on this slot drains before @ref cancel
+     * returns.
+     *
+     * Idempotent: a second call is a no-op, and calling @ref cancel
+     * after the destructor has already run (on a concrete
+     * @ref ConnectionToken that already unregistered itself) is
+     * structurally impossible because the token is gone -- but a
+     * repeated @ref cancel on a still-live token is safely a no-op.
+     *
+     * Blocks if a dispatch is in flight on this slot: @ref cancel
+     * acquires the slot's @c lifecycleMutex exclusively, which waits
+     * for every shared-holder (every concurrent @c onMessage) to
+     * release. This is the same dtor-blocks contract the destructor
+     * honours; explicit @ref cancel and RAII teardown share the same
+     * barrier.
+     *
+     * Mirrors @ref ISubscriptionToken::cancel for API symmetry: a
+     * caller that needs to drop a target's connection earlier than
+     * the owning target's destructor may do so without destroying the
+     * token storage.
+     */
+    virtual void cancel() = 0;
+
+    /**
      * @brief Returns @c true when the subscription slot is still live.
      *
      * A token becomes inactive when the underlying bus is marked dead
      * (either through @ref IBusControlBlock::markDead or the bus being
-     * destroyed) or when the token's slot has been explicitly
-     * unregistered. Once @ref active returns @c false, it never returns
-     * @c true again.
+     * destroyed), when the token's slot has been explicitly
+     * unregistered, or after @ref cancel has been called. Once
+     * @ref active returns @c false, it never returns @c true again.
      */
     [[nodiscard]] virtual bool active() const noexcept = 0;
 

--- a/src/messaging/connectiontoken.cpp
+++ b/src/messaging/connectiontoken.cpp
@@ -18,44 +18,78 @@ ConnectionToken::ConnectionToken(std::weak_ptr<IBusControlBlock> control,
 
 ConnectionToken::~ConnectionToken()
 {
-    // Step 1: ask the control block to retire the registry slot. On a
-    // live bus the block also drains every dispatch in flight on this
-    // slot by acquiring `_slotState->lifecycleMutex` exclusively
-    // before flipping `cancelled`. On a dead bus the weak_ptr.lock()
-    // returns null and the registry has already been reclaimed en
-    // masse — the cancel barrier below still has work to do for any
-    // dispatch snapshot still holding a copy of the same SlotState.
-    if (auto ctrl = _control.lock())
+    // Delegate to cancel() so the explicit-cancel and RAII teardown
+    // paths share one body. cancel() is idempotent via the
+    // _cancelled atomic, so a user who already called cancel() pays
+    // only the short-circuit check here; users who never called
+    // cancel() run the full unregister-plus-barrier sequence exactly
+    // once from inside the destructor. Mirrors the same delegation
+    // pattern SubscriptionToken::~SubscriptionToken uses today.
+    cancel();
+}
+
+void ConnectionToken::cancel()
+{
+    // Idempotency gate: the first caller flips false->true and runs
+    // the full tear-down; any later caller sees true and short-
+    // circuits before touching either the control block or the
+    // slot's lifecycleMutex. acq_rel ordering pairs cleanly with the
+    // acquire-load a future active()-style reader would need.
+    bool expected = false;
+    if (!_cancelled.compare_exchange_strong(expected, true, std::memory_order_acq_rel))
     {
-        ctrl->unregisterTarget(_id);
+        return;
     }
 
-    // Step 2: defensive cancel barrier from the token side. Mirror of
-    // `SubscriptionToken::cancel`. Even when step 1 ran the same
-    // logic inside `unregisterTarget`, repeating it here costs only an
-    // already-uncontended lock acquisition and covers the bus-died-
-    // first path, where step 1 was a no-op but a racing dispatch may
-    // still be sitting on a snapshot copy of `_slotState`. The
-    // `unique_lock` on the shared_mutex blocks until every concurrent
-    // shared holder (every in-flight `onMessage`) has released, which
-    // is the dtor-blocks contract that the IConnectionToken header
-    // documents.
+    // Step 1: defensive cancel barrier from the token side. Mirror of
+    // `AbstractMessageBus::SubscriptionToken::cancel`. Acquired FIRST
+    // so we block concurrent dispatch before the registry slot is
+    // retired; on a dead bus (weak_ptr expired, registry reclaimed
+    // en masse) step 2 becomes a no-op and this is the only barrier
+    // that drains any dispatch snapshot still holding a copy of the
+    // same SlotState. The `unique_lock` on the shared_mutex blocks
+    // until every concurrent shared holder (every in-flight
+    // `onMessage`) has released, which is the dtor-blocks contract
+    // that the IConnectionToken header documents.
     if (_slotState)
     {
         std::unique_lock<std::shared_mutex> lock{_slotState->lifecycleMutex};
         _slotState->cancelled = true;
     }
+
+    // Step 2: ask the control block to retire the registry slot. On
+    // a live bus the block also runs the same exclusive-lock-flip-
+    // cancelled sequence internally; the redundant second flip costs
+    // only an uncontended lock acquisition and keeps the
+    // unregisterTarget contract self-sufficient when callers reach
+    // it through paths other than this token. On a dead bus the
+    // weak_ptr.lock() returns null and the registry has already been
+    // reclaimed — nothing to do in this branch.
+    if (auto ctrl = _control.lock())
+    {
+        ctrl->unregisterTarget(_id);
+    }
 }
 
 bool ConnectionToken::active() const noexcept
 {
-    // An inert token (subscribe returned early on invalid input or on
-    // shutdown) carries a default-constructed ConnectionId whose
-    // generation is the zero sentinel. Such a token must report
-    // active == false even when the bus is still alive, otherwise a
-    // caller guarding an unsubscribe with `if (token.active())` would
-    // happily call unsubscribe on an id the bus never handed out.
+    // An inert token (registerTarget returned early on invalid input
+    // or on shutdown) carries a default-constructed ConnectionId
+    // whose generation is the zero sentinel. Such a token must
+    // report active == false even when the bus is still alive,
+    // otherwise a caller guarding an unregister with
+    // `if (token.active())` would happily call unregister on an id
+    // the bus never handed out.
     if (!_id.valid())
+    {
+        return false;
+    }
+    // An explicitly cancelled token is no longer active even if the
+    // bus is still running. Mirrors the same check
+    // `AbstractMessageBus::SubscriptionToken::active` runs on its
+    // own `_cancelled` flag, so the two RAII tokens report a
+    // consistent view of live/dead through `active()`.
+    if (_cancelled.load(std::memory_order_acquire))
     {
         return false;
     }

--- a/test/messaging/smoke_test.cpp
+++ b/test/messaging/smoke_test.cpp
@@ -1,6 +1,9 @@
 #include "vigine/messaging/busconfig.h"
 #include "vigine/messaging/busid.h"
+#include "vigine/messaging/connectionid.h"
+#include "vigine/messaging/connectiontoken.h"
 #include "vigine/messaging/factory.h"
+#include "vigine/messaging/ibuscontrolblock.h"
 #include "vigine/messaging/imessage.h"
 #include "vigine/messaging/imessagebus.h"
 #include "vigine/messaging/imessagepayload.h"
@@ -9,6 +12,7 @@
 #include "vigine/messaging/messagefilter.h"
 #include "vigine/messaging/messagekind.h"
 #include "vigine/messaging/routemode.h"
+#include "vigine/messaging/subscriptionslot.h"
 #include "vigine/messaging/systemmessagebus.h"
 #include "vigine/payload/payloadtypeid.h"
 #include "vigine/result.h"
@@ -517,6 +521,157 @@ TEST_F(MessagingSmoke, TokenCancelBlocksUntilInFlightDispatchDrains)
     }
 
     dispatcher.join();
+}
+
+// ---------------------------------------------------------------------------
+// Case 10 -- ConnectionToken::cancel() is idempotent and flips active() false.
+//
+// Pins the API-symmetry contract L-B2 adds alongside
+// ISubscriptionToken::cancel():
+//
+//   1. active() reports true while the slot is live.
+//   2. The first cancel() unregisters the slot AND trips the shared
+//      SlotState's `cancelled` flag (the registry observes the loss).
+//   3. active() reports false after cancel().
+//   4. A second cancel() is a structural no-op -- the control block
+//      sees exactly one unregisterTarget call across both invocations.
+//
+// Uses an in-test fake IBusControlBlock so the assertion is local: the
+// ConnectionToken is constructed directly and observed directly,
+// without routing through the full AbstractMessageBus register path
+// (which hides the token inside AbstractMessageTarget's private
+// _connections vector).
+// ---------------------------------------------------------------------------
+
+/// @brief Minimal IBusControlBlock that counts unregisterTarget calls
+///        and tracks whether the last unregister saw its slot live.
+///
+/// Everything else is either a pass-through or a no-op; the test only
+/// cares about unregister bookkeeping plus the two contracts the block
+/// must honour for ConnectionToken to behave correctly: @ref isAlive
+/// returns true until @ref markDead runs, and @ref allocateSlot hands
+/// back a valid id paired with a fresh SlotState. Subscription-side
+/// methods are stubbed because ConnectionToken never reaches them.
+class FakeBusControlBlock final : public IBusControlBlock,
+                                  public std::enable_shared_from_this<FakeBusControlBlock>
+{
+  public:
+    [[nodiscard]] bool isAlive() const noexcept override
+    {
+        return _alive.load(std::memory_order_acquire);
+    }
+
+    void markDead() noexcept override
+    {
+        _alive.store(false, std::memory_order_release);
+    }
+
+    [[nodiscard]] SlotAllocation
+        allocateSlot(AbstractMessageTarget * /*target*/) override
+    {
+        if (!_alive.load(std::memory_order_acquire))
+        {
+            return SlotAllocation{};
+        }
+        auto state = std::make_shared<SlotState>();
+        _lastState = state;
+        return SlotAllocation{
+            ConnectionId{_nextIndex++, _nextGeneration++},
+            std::move(state),
+        };
+    }
+
+    void unregisterTarget(ConnectionId id) noexcept override
+    {
+        if (!id.valid())
+        {
+            return;
+        }
+        _unregisterCalls.fetch_add(1, std::memory_order_acq_rel);
+        _lastUnregisteredId = id;
+    }
+
+    [[nodiscard]] std::uint64_t registerSubscription(
+        ISubscriber * /*subscriber*/,
+        MessageFilter /*filter*/,
+        std::shared_ptr<SlotState> /*slotState*/) override
+    {
+        return 0;
+    }
+
+    void unregisterSubscription(std::uint64_t /*serial*/) noexcept override {}
+
+    [[nodiscard]] std::vector<SubscriptionSlot> snapshotSubscriptions() const override
+    {
+        return {};
+    }
+
+    [[nodiscard]] std::uint32_t unregisterCalls() const noexcept
+    {
+        return _unregisterCalls.load(std::memory_order_acquire);
+    }
+
+    [[nodiscard]] ConnectionId lastUnregisteredId() const noexcept
+    {
+        return _lastUnregisteredId;
+    }
+
+    [[nodiscard]] std::shared_ptr<SlotState> lastState() const noexcept
+    {
+        return _lastState;
+    }
+
+  private:
+    std::atomic<bool>           _alive{true};
+    std::atomic<std::uint32_t>  _unregisterCalls{0};
+    std::uint32_t               _nextIndex{1};
+    std::uint32_t               _nextGeneration{1};
+    ConnectionId                _lastUnregisteredId{};
+    std::shared_ptr<SlotState>  _lastState;
+};
+
+TEST_F(MessagingSmoke, ConnectionTokenCancelIsIdempotent)
+{
+    auto block       = std::make_shared<FakeBusControlBlock>();
+    auto allocation  = block->allocateSlot(nullptr);
+    ASSERT_TRUE(allocation.id.valid());
+    ASSERT_NE(allocation.state, nullptr);
+
+    ConnectionToken token{
+        std::weak_ptr<IBusControlBlock>(block),
+        allocation.id,
+        allocation.state,
+    };
+
+    // Preconditions: the fresh token is live, no unregister yet.
+    EXPECT_TRUE(token.active());
+    EXPECT_EQ(block->unregisterCalls(), 0u);
+    EXPECT_FALSE(allocation.state->cancelled);
+
+    // First cancel: runs the full unregister-plus-barrier sequence.
+    token.cancel();
+
+    EXPECT_FALSE(token.active())
+        << "active() must report false after the first cancel()";
+    EXPECT_EQ(block->unregisterCalls(), 1u)
+        << "first cancel() must drive exactly one unregisterTarget";
+    EXPECT_EQ(block->lastUnregisteredId(), allocation.id)
+        << "unregisterTarget must be called with the token's own id";
+    EXPECT_TRUE(allocation.state->cancelled)
+        << "the shared SlotState's cancelled flag must be true after cancel()";
+
+    // Second cancel: idempotent no-op. The control block must not see
+    // a second unregisterTarget and the state must stay cancelled.
+    token.cancel();
+
+    EXPECT_FALSE(token.active());
+    EXPECT_EQ(block->unregisterCalls(), 1u)
+        << "second cancel() must not drive another unregisterTarget";
+    EXPECT_TRUE(allocation.state->cancelled);
+
+    // A third cancel: same invariants as the second.
+    token.cancel();
+    EXPECT_EQ(block->unregisterCalls(), 1u);
 }
 
 } // namespace


### PR DESCRIPTION
`ISubscriptionToken` already lets a caller drop a subscription before the token's destructor runs; `IConnectionToken` did not. The asymmetry meant a target had to drop the whole token storage just to retire one of its bus connections — which gets awkward as soon as a target wants to keep its other connections alive.

This PR closes that gap by adding a pure-virtual `cancel()` to `IConnectionToken` and an idempotent implementation on `ConnectionToken`. The behaviour mirrors `ISubscriptionToken::cancel()` exactly: a `compare_exchange`-gated body runs the unregister-plus-barrier sequence at most once, the slot's `lifecycleMutex` is acquired exclusively first so any in-flight `onMessage` drains before `cancel()` returns, and `active()` flips to `false` afterwards. The destructor now delegates to `cancel()`, the same way `SubscriptionToken::~SubscriptionToken` already does, so the explicit-cancel path and the RAII-teardown path share one body.

A new `MessagingSmoke.ConnectionTokenCancelIsIdempotent` test pins the contract: after the first `cancel()` the slot reports `active() == false` and the control block has seen exactly one `unregisterTarget` call; a second and third `cancel()` add no further unregister calls and leave the slot's `cancelled` flag set. The test uses an in-suite `FakeBusControlBlock` so it can construct a `ConnectionToken` directly and assert on the unregister bookkeeping — the public bus API hides connection tokens inside `AbstractMessageTarget`'s private connection vector, which makes a direct observation through the bus unattractive.

`ctest` reports 192/192 (was 191).

Closes #251
