### PR TITLE
Add bindToControllerThread and thread-affinity assert to FSM (#253)

### DIFF
--- a/include/vigine/statemachine/abstractstatemachine.h
+++ b/include/vigine/statemachine/abstractstatemachine.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <atomic>
+#include <cassert>
 #include <memory>
+#include <thread>
 
 #include "vigine/result.h"
 #include "vigine/statemachine/istatemachine.h"
@@ -107,6 +109,11 @@ class AbstractStateMachine : public IStateMachine
     [[nodiscard]] RouteMode routeMode() const noexcept override;
     void                    setRouteMode(RouteMode mode) noexcept override;
 
+    // ------ IStateMachine: thread affinity ------
+
+    void                          bindToControllerThread(std::thread::id controllerId) override;
+    [[nodiscard]] std::thread::id controllerThread() const noexcept override;
+
     AbstractStateMachine(const AbstractStateMachine &)            = delete;
     AbstractStateMachine &operator=(const AbstractStateMachine &) = delete;
     AbstractStateMachine(AbstractStateMachine &&)                 = delete;
@@ -141,6 +148,25 @@ class AbstractStateMachine : public IStateMachine
      * @ref transition instead.
      */
     [[nodiscard]] StateId defaultState() const noexcept;
+
+    /**
+     * @brief Debug-only thread-affinity gate for sync mutators.
+     *
+     * Reads the controller binding installed through
+     * @ref bindToControllerThread. When a binding is present and the
+     * current thread is not the controller, the helper fires an
+     * @c assert in Debug builds. Release builds compile the body to a
+     * no-op — the assert is wrapped in @c \#ifndef NDEBUG so the helper
+     * disappears entirely with optimisation on. When no binding has
+     * been installed yet the helper is a no-op too, matching the
+     * "un-bound = assert inactive" contract documented on
+     * @ref bindToControllerThread.
+     *
+     * @c noexcept so it stays safe to call from @c noexcept mutators
+     * if any arrive in the future; today every call-site is a
+     * plain mutator, but the gate must never throw by design.
+     */
+    void checkThreadAffinity() const noexcept;
 
   private:
     /**
@@ -186,6 +212,26 @@ class AbstractStateMachine : public IStateMachine
      * reason as @c _current — a single-byte enum, always lock-free.
      */
     std::atomic<RouteMode> _routeMode{RouteMode::Bubble};
+
+    /**
+     * @brief Controller thread binding (one-shot, default-constructed
+     *        sentinel means @e unbound).
+     *
+     * Installed once through @ref bindToControllerThread via a
+     * compare-exchange on the default-constructed @c std::thread::id
+     * sentinel, so a second bind attempt observes a non-sentinel
+     * expected value and fails — Debug fires the contract assert,
+     * Release keeps the original binding silently. Read back with
+     * acquire semantics so the debug gate in @ref checkThreadAffinity
+     * and the public @ref controllerThread getter both observe the
+     * latest published value.
+     *
+     * Atomic because the binding is installed by the controller
+     * thread but the @ref controllerThread getter is documented as
+     * thread-safe; @c std::atomic<std::thread::id> is lock-free on
+     * every supported target.
+     */
+    std::atomic<std::thread::id> _controllerThreadId{};
 };
 
 } // namespace vigine::statemachine

--- a/include/vigine/statemachine/istatemachine.h
+++ b/include/vigine/statemachine/istatemachine.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <thread>
+
 #include "vigine/result.h"
 #include "vigine/statemachine/routemode.h"
 #include "vigine/statemachine/stateid.h"
@@ -224,6 +226,25 @@ class IStateMachine
      * @ref routeMode calls return the newly selected value.
      */
     virtual void setRouteMode(RouteMode mode) noexcept = 0;
+
+    // ------ Thread affinity ------
+
+    /**
+     * @brief Binds the state machine to its controller thread.
+     *
+     * One-shot. Must be called once before the first sync mutation
+     * (setInitial / transition / addChildState). A second call is
+     * rejected: Debug builds assert; Release silently keeps the original
+     * binding.
+     */
+    virtual void bindToControllerThread(std::thread::id controllerId) = 0;
+
+    /**
+     * @brief Returns the bound controller thread id.
+     *
+     * Default-constructed @c std::thread::id when not yet bound.
+     */
+    [[nodiscard]] virtual std::thread::id controllerThread() const noexcept = 0;
 
     IStateMachine(const IStateMachine &)            = delete;
     IStateMachine &operator=(const IStateMachine &) = delete;

--- a/src/statemachine/abstractstatemachine.cpp
+++ b/src/statemachine/abstractstatemachine.cpp
@@ -1,6 +1,8 @@
 #include "vigine/statemachine/abstractstatemachine.h"
 
+#include <cassert>
 #include <memory>
+#include <thread>
 
 #include "statemachine/statetopology.h"
 #include "vigine/result.h"
@@ -56,6 +58,7 @@ StateId AbstractStateMachine::defaultState() const noexcept
 
 StateId AbstractStateMachine::addState()
 {
+    checkThreadAffinity();
     return _topology->addState();
 }
 
@@ -70,6 +73,7 @@ bool AbstractStateMachine::hasState(StateId state) const noexcept
 
 Result AbstractStateMachine::addChildState(StateId parent, StateId child)
 {
+    checkThreadAffinity();
     return _topology->addChildEdge(parent, child);
 }
 
@@ -91,6 +95,7 @@ bool AbstractStateMachine::isAncestorOf(StateId ancestor, StateId descendant) co
 
 Result AbstractStateMachine::setInitial(StateId state)
 {
+    checkThreadAffinity();
     if (!_topology->hasState(state))
     {
         return Result(Result::Code::Error, "initial state not registered");
@@ -101,6 +106,7 @@ Result AbstractStateMachine::setInitial(StateId state)
 
 Result AbstractStateMachine::transition(StateId state)
 {
+    checkThreadAffinity();
     if (!_topology->hasState(state))
     {
         return Result(Result::Code::Error, "transition target not registered");
@@ -127,7 +133,61 @@ RouteMode AbstractStateMachine::routeMode() const noexcept
 
 void AbstractStateMachine::setRouteMode(RouteMode mode) noexcept
 {
+    checkThreadAffinity();
     _routeMode = mode;
+}
+
+// ---------------------------------------------------------------------------
+// IStateMachine: thread affinity.
+//
+// bindToControllerThread is a one-shot contract: the first successful call
+// installs the binding, a second call is rejected. Implementing the
+// one-shot with compare_exchange_strong on the default-constructed
+// sentinel lets the bind remain lock-free and also lets the
+// checkThreadAffinity gate observe the published id with acquire
+// semantics without taking a mutex. The contract says Debug asserts on a
+// repeat bind and Release silently keeps the original — that is exactly
+// the behaviour a failing compare_exchange gives us: when the CAS fails
+// Release simply returns, leaving the first-install id untouched.
+// ---------------------------------------------------------------------------
+
+void AbstractStateMachine::bindToControllerThread(std::thread::id controllerId)
+{
+    std::thread::id expected{}; // default-constructed = unbound sentinel
+    if (!_controllerThreadId.compare_exchange_strong(
+            expected,
+            controllerId,
+            std::memory_order_release,
+            std::memory_order_acquire))
+    {
+        assert(false && "AbstractStateMachine::bindToControllerThread called twice");
+    }
+}
+
+std::thread::id AbstractStateMachine::controllerThread() const noexcept
+{
+    return _controllerThreadId.load(std::memory_order_acquire);
+}
+
+// ---------------------------------------------------------------------------
+// checkThreadAffinity: Debug-only gate at the entry of every sync mutator.
+//
+// The unbound case (default-constructed id sentinel) is intentionally a
+// no-op so the 191 existing tests — which never bind — keep passing
+// unchanged. The Release case disappears entirely because the whole
+// body is wrapped in @c \#ifndef NDEBUG.
+// ---------------------------------------------------------------------------
+
+void AbstractStateMachine::checkThreadAffinity() const noexcept
+{
+#ifndef NDEBUG
+    const auto bound = _controllerThreadId.load(std::memory_order_acquire);
+    if (bound != std::thread::id{})
+    {
+        assert(std::this_thread::get_id() == bound
+               && "AbstractStateMachine: sync mutation from non-controller thread");
+    }
+#endif
 }
 
 } // namespace vigine::statemachine


### PR DESCRIPTION
Adds bindToControllerThread / controllerThread to IStateMachine and a Debug-only checkThreadAffinity helper that runs as the first line of every sync mutator on AbstractStateMachine. Release builds compile the assert out. Closes #253. Part of #197.