### PR TITLE
Honor explicit unregister in ConnectionToken::active (#258)

### DIFF
--- a/include/vigine/messaging/connectiontoken.h
+++ b/include/vigine/messaging/connectiontoken.h
@@ -124,10 +124,13 @@ class ConnectionToken final : public IConnectionToken
      * holding the token must observe @ref active as @c false even
      * before the bus itself goes dead.
      *
-     * Cheap: one valid-id check, one atomic load on @c _cancelled,
-     * one direct (lock-free) read of @c _slotState->cancelled, one
-     * @c weak_ptr::lock, one atomic load on the bus alive flag. The
-     * return value is a momentary snapshot; callers racing with
+     * Cheap: one valid-id check, one acquire-load on @c _cancelled,
+     * one acquire-load on @c _slotState->cancelled (also
+     * @c std::atomic<bool> — pairs with the release store every
+     * unregister path issues under @c lifecycleMutex), one
+     * @c weak_ptr::lock, one atomic load on the bus alive flag. No
+     * lock acquisitions in the hot path. The return value is a
+     * momentary snapshot; callers racing with
      * @ref IBusControlBlock::markDead, a concurrent @ref cancel, or a
      * sibling unregister path may observe the transition between the
      * check and any follow-up operation.

--- a/include/vigine/messaging/connectiontoken.h
+++ b/include/vigine/messaging/connectiontoken.h
@@ -106,16 +106,31 @@ class ConnectionToken final : public IConnectionToken
     void cancel() override;
 
     /**
-     * @brief Returns @c true when the id is valid, the token has not
-     *        been cancelled, the control block is reachable, and
-     *        @ref IBusControlBlock::isAlive reports @c true.
+     * @brief Returns @c true only when (a) the id is valid, (b) this
+     *        token's own @c _cancelled atomic is still @c false, (c)
+     *        the shared @ref SlotState reports @c cancelled == @c false
+     *        (so a sibling unregister path that flipped the slot
+     *        without going through this token's @ref cancel still
+     *        retires @ref active here), and (d) the control block is
+     *        reachable and @ref IBusControlBlock::isAlive reports
+     *        @c true.
+     *
+     * The middle SlotState check is what makes @ref active honour an
+     * explicit unregister driven from outside the token: the bus may
+     * call @ref IBusControlBlock::unregisterTarget on its own (e.g.
+     * programmatic teardown of a target's slots) which flips
+     * @c slotState->cancelled under @c lifecycleMutex; once that
+     * happens the slot is gone from the registry and any caller still
+     * holding the token must observe @ref active as @c false even
+     * before the bus itself goes dead.
      *
      * Cheap: one valid-id check, one atomic load on @c _cancelled,
-     * one @c weak_ptr::lock, one atomic load on the bus alive flag.
-     * The return value is a momentary snapshot; callers racing with
-     * @ref IBusControlBlock::markDead or a concurrent @ref cancel may
-     * observe the transition between the check and any follow-up
-     * operation.
+     * one direct (lock-free) read of @c _slotState->cancelled, one
+     * @c weak_ptr::lock, one atomic load on the bus alive flag. The
+     * return value is a momentary snapshot; callers racing with
+     * @ref IBusControlBlock::markDead, a concurrent @ref cancel, or a
+     * sibling unregister path may observe the transition between the
+     * check and any follow-up operation.
      */
     [[nodiscard]] bool active() const noexcept override;
 

--- a/include/vigine/messaging/iconnectiontoken.h
+++ b/include/vigine/messaging/iconnectiontoken.h
@@ -59,11 +59,21 @@ class IConnectionToken
     /**
      * @brief Returns @c true when the subscription slot is still live.
      *
-     * A token becomes inactive when the underlying bus is marked dead
-     * (either through @ref IBusControlBlock::markDead or the bus being
-     * destroyed), when the token's slot has been explicitly
-     * unregistered, or after @ref cancel has been called. Once
-     * @ref active returns @c false, it never returns @c true again.
+     * A token becomes inactive when any of the following happen:
+     *  - @ref cancel is called on the token (the same atomic flag
+     *    that drives the unregister-and-barrier sequence is also
+     *    consulted here, so once @ref cancel has run @ref active
+     *    must report @c false);
+     *  - the slot is explicitly unregistered out-of-band (e.g. the
+     *    bus drives @c unregisterTarget on its own and flips the
+     *    shared @ref SlotState's @c cancelled flag without going
+     *    through this token's @ref cancel) — implementations MUST
+     *    consult that flag in addition to their own internal one;
+     *  - the underlying bus is marked dead (either through
+     *    @ref IBusControlBlock::markDead or the bus being destroyed).
+     *
+     * Once @ref active returns @c false it never returns @c true
+     * again.
      */
     [[nodiscard]] virtual bool active() const noexcept = 0;
 

--- a/include/vigine/messaging/subscriptionslot.h
+++ b/include/vigine/messaging/subscriptionslot.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <cstdint>
 #include <memory>
 #include <mutex>
@@ -36,11 +37,11 @@ class ISubscriber;
  *     unsubscribe path (@ref IBusControlBlock::unregisterSubscription)
  *     acquires it in EXCLUSIVE mode, which blocks until every concurrent
  *     shared-holder has returned. Once the exclusive lock is held,
- *     @c cancelled is flipped to @c true so that snapshot copies still
- *     waiting to enter the shared region observe the flag and skip
- *     @c onMessage entirely. That is the use-after-free barrier for a
- *     subscriber whose owner drops the token and then destroys the
- *     subscriber right after the cancel returns.
+ *     @c cancelled is flipped to @c true with a release store so that
+ *     snapshot copies still waiting to enter the shared region observe
+ *     the flag and skip @c onMessage entirely. That is the use-after-
+ *     free barrier for a subscriber whose owner drops the token and
+ *     then destroys the subscriber right after the cancel returns.
  *
  * The struct is non-copyable and non-movable because the contained
  * mutexes are neither. A lifetime share through @c std::shared_ptr is
@@ -53,10 +54,16 @@ struct SlotState
     /// Guards the slot's active lifetime: shared for dispatch, exclusive
     /// for cancellation. See class comment above.
     std::shared_mutex lifecycleMutex;
-    /// Set to @c true under the exclusive @c lifecycleMutex by the
-    /// unsubscribe path. The dispatch path checks it under the shared
-    /// lock and skips @c onMessage when true.
-    bool              cancelled{false};
+    /// Set to @c true with a release store under the exclusive
+    /// @c lifecycleMutex by the unsubscribe path. Two readers exist: the
+    /// dispatch path reads it under the shared @c lifecycleMutex (the
+    /// shared lock already supplies the happens-before pair, the atomic
+    /// type only forbids torn reads / data races); the lock-free
+    /// @c ConnectionToken::active reader takes no lock and relies
+    /// purely on @c memory_order_acquire to see the writer's release.
+    /// The flag is monotonic — once @c true, never @c false again — so
+    /// a relaxed-after-acquire view is still correct.
+    std::atomic<bool> cancelled{false};
 
     SlotState()                             = default;
     ~SlotState()                            = default;

--- a/src/messaging/abstractmessagebus.cpp
+++ b/src/messaging/abstractmessagebus.cpp
@@ -576,7 +576,7 @@ DispatchResult AbstractMessageBus::deliver(const SubscriptionSlot &slot,
     if (state != nullptr)
     {
         lifeLock = std::shared_lock<std::shared_mutex>{state->lifecycleMutex};
-        if (state->cancelled)
+        if (state->cancelled.load(std::memory_order_acquire))
         {
             return DispatchResult::Pass;
         }

--- a/src/messaging/connectiontoken.cpp
+++ b/src/messaging/connectiontoken.cpp
@@ -93,6 +93,24 @@ bool ConnectionToken::active() const noexcept
     {
         return false;
     }
+    // The slot's shared SlotState may also be flipped from outside
+    // this token — for example when the bus drives unregisterTarget
+    // on its own (programmatic teardown) or when a sibling cancel
+    // path on the same SlotState ran without going through this
+    // token's own _cancelled atomic. The flag is a plain bool, and
+    // every writer flips it under an exclusive lock on
+    // lifecycleMutex; a reader that touched it without any lock
+    // would race with that exclusive write. We therefore take a
+    // shared_lock for the read so concurrent readers stay parallel
+    // while writers still get exclusive ownership during the flip.
+    if (_slotState)
+    {
+        std::shared_lock<std::shared_mutex> lock{_slotState->lifecycleMutex};
+        if (_slotState->cancelled)
+        {
+            return false;
+        }
+    }
     auto ctrl = _control.lock();
     return static_cast<bool>(ctrl) && ctrl->isAlive();
 }

--- a/src/messaging/connectiontoken.cpp
+++ b/src/messaging/connectiontoken.cpp
@@ -50,11 +50,14 @@ void ConnectionToken::cancel()
     // same SlotState. The `unique_lock` on the shared_mutex blocks
     // until every concurrent shared holder (every in-flight
     // `onMessage`) has released, which is the dtor-blocks contract
-    // that the IConnectionToken header documents.
+    // that the IConnectionToken header documents. The `cancelled`
+    // store uses release ordering so the lock-free reader in
+    // `active()` (which only does an acquire-load and never takes
+    // this lock) sees the flip on its very next call.
     if (_slotState)
     {
         std::unique_lock<std::shared_mutex> lock{_slotState->lifecycleMutex};
-        _slotState->cancelled = true;
+        _slotState->cancelled.store(true, std::memory_order_release);
     }
 
     // Step 2: ask the control block to retire the registry slot. On
@@ -97,19 +100,22 @@ bool ConnectionToken::active() const noexcept
     // this token — for example when the bus drives unregisterTarget
     // on its own (programmatic teardown) or when a sibling cancel
     // path on the same SlotState ran without going through this
-    // token's own _cancelled atomic. The flag is a plain bool, and
-    // every writer flips it under an exclusive lock on
-    // lifecycleMutex; a reader that touched it without any lock
-    // would race with that exclusive write. We therefore take a
-    // shared_lock for the read so concurrent readers stay parallel
-    // while writers still get exclusive ownership during the flip.
-    if (_slotState)
+    // token's own _cancelled atomic. The flag is `std::atomic<bool>`
+    // and every writer pairs an exclusive `lifecycleMutex` (which
+    // gives it the lifetime barrier for in-flight dispatches) with a
+    // release store on the atomic (which gives it the visibility
+    // pair for lock-free readers). This reader therefore needs only
+    // an acquire load: the flag is monotonic — once it is `true` it
+    // never returns to `false` — so observing it `true` is a
+    // permanent retire signal, and observing it `false` is a
+    // momentary live snapshot consistent with everything else
+    // `active()` returns. Skipping the shared_lock here keeps the
+    // hot path lock-free and removes the unnecessary contention
+    // against concurrent dispatchers that already hold the same
+    // shared_mutex shared.
+    if (_slotState && _slotState->cancelled.load(std::memory_order_acquire))
     {
-        std::shared_lock<std::shared_mutex> lock{_slotState->lifecycleMutex};
-        if (_slotState->cancelled)
-        {
-            return false;
-        }
+        return false;
     }
     auto ctrl = _control.lock();
     return static_cast<bool>(ctrl) && ctrl->isAlive();

--- a/src/messaging/ibuscontrolblock_default.cpp
+++ b/src/messaging/ibuscontrolblock_default.cpp
@@ -148,11 +148,13 @@ void DefaultBusControlBlock::unregisterTarget(ConnectionId id) noexcept
         // dispatch that reached this slot through `lookup` holds it
         // SHARED for the duration of onMessage, so the exclusive
         // acquisition blocks until all of them have returned. Once we
-        // hold the lock we flip `cancelled` so that any later lookup
-        // racing the registry erase observes the flag and returns an
-        // empty guard — matching the subscriber-side flow.
+        // hold the lock we flip `cancelled` with a release store so
+        // that any later lookup racing the registry erase — including
+        // the lock-free `ConnectionToken::active` reader — observes
+        // the flag and returns an empty guard / `false`. Matching the
+        // subscriber-side flow.
         std::unique_lock<std::shared_mutex> ex{state->lifecycleMutex};
-        state->cancelled = true;
+        state->cancelled.store(true, std::memory_order_release);
     }
 }
 
@@ -246,12 +248,12 @@ void DefaultBusControlBlock::unregisterSubscription(std::uint64_t serial) noexce
         // Acquire lifecycleMutex EXCLUSIVELY. Every concurrent
         // deliver() holds it SHARED for the duration of onMessage, so
         // the exclusive acquisition blocks until all of them have
-        // returned. Once we hold the lock we flip `cancelled` so that
-        // any snapshot copy still waiting to enter the shared region
-        // will observe the flag and skip onMessage without running
-        // the subscriber.
+        // returned. Once we hold the lock we flip `cancelled` with a
+        // release store so that any snapshot copy still waiting to
+        // enter the shared region will observe the flag and skip
+        // onMessage without running the subscriber.
         std::unique_lock<std::shared_mutex> ex{state->lifecycleMutex};
-        state->cancelled = true;
+        state->cancelled.store(true, std::memory_order_release);
     }
 }
 
@@ -306,7 +308,7 @@ DefaultBusControlBlock::lookup(ConnectionId id) const noexcept
     if (slotState)
     {
         lifecycleLock = std::shared_lock<std::shared_mutex>{slotState->lifecycleMutex};
-        if (slotState->cancelled)
+        if (slotState->cancelled.load(std::memory_order_acquire))
         {
             // The slot was cancelled between the registry probe and
             // the lifecycle acquisition; an empty guard skips

--- a/test/messaging/smoke_test.cpp
+++ b/test/messaging/smoke_test.cpp
@@ -28,6 +28,7 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
+#include <shared_mutex>
 #include <string_view>
 #include <thread>
 #include <utility>
@@ -646,7 +647,7 @@ TEST_F(MessagingSmoke, ConnectionTokenCancelIsIdempotent)
     // Preconditions: the fresh token is live, no unregister yet.
     EXPECT_TRUE(token.active());
     EXPECT_EQ(block->unregisterCalls(), 0u);
-    EXPECT_FALSE(allocation.state->cancelled);
+    EXPECT_FALSE(allocation.state->cancelled.load(std::memory_order_acquire));
 
     // First cancel: runs the full unregister-plus-barrier sequence.
     token.cancel();
@@ -657,7 +658,7 @@ TEST_F(MessagingSmoke, ConnectionTokenCancelIsIdempotent)
         << "first cancel() must drive exactly one unregisterTarget";
     EXPECT_EQ(block->lastUnregisteredId(), allocation.id)
         << "unregisterTarget must be called with the token's own id";
-    EXPECT_TRUE(allocation.state->cancelled)
+    EXPECT_TRUE(allocation.state->cancelled.load(std::memory_order_acquire))
         << "the shared SlotState's cancelled flag must be true after cancel()";
 
     // Second cancel: idempotent no-op. The control block must not see
@@ -667,7 +668,7 @@ TEST_F(MessagingSmoke, ConnectionTokenCancelIsIdempotent)
     EXPECT_FALSE(token.active());
     EXPECT_EQ(block->unregisterCalls(), 1u)
         << "second cancel() must not drive another unregisterTarget";
-    EXPECT_TRUE(allocation.state->cancelled);
+    EXPECT_TRUE(allocation.state->cancelled.load(std::memory_order_acquire));
 
     // A third cancel: same invariants as the second.
     token.cancel();
@@ -675,16 +676,81 @@ TEST_F(MessagingSmoke, ConnectionTokenCancelIsIdempotent)
 }
 
 // ---------------------------------------------------------------------------
-// Case 11 -- ConnectionToken::active() honours an explicit unregister.
+// Case 11 -- ConnectionToken::active() honours an OUT-OF-BAND unregister.
 //
-// Pins the L-B6 contract: once a token has been cancelled (which
-// trips its own atomic _cancelled flag AND, on the way through, the
-// shared SlotState->cancelled flag under lifecycleMutex), active()
-// must report false even though the FakeBusControlBlock is still
-// alive and reachable through the weak_ptr. Without the new
-// _cancelled / _slotState->cancelled short-circuits inside
-// ConnectionToken::active(), the call would still walk all the way
+// Pins the L-B6 contract: once the shared SlotState->cancelled flag
+// has been flipped from outside the token (e.g. the bus driving its
+// own programmatic unregisterTarget without anyone calling cancel()
+// on the token first), active() must report false even though the
+// FakeBusControlBlock is still alive and the token's own _cancelled
+// atomic is still false. This is exactly the path that exercises the
+// new _slotState->cancelled short-circuit inside
+// ConnectionToken::active() — without it, the call would walk
+// straight past the token-side _cancelled check (still false) and
 // down to ctrl->isAlive() and return true.
+//
+// The flip is issued directly on the SlotState shared with the token;
+// we do NOT call token->cancel() here precisely so the token's own
+// _cancelled atomic stays false. The store mirrors what every real
+// writer does (release store under exclusive lifecycleMutex), which
+// is also the synchronisation the new lock-free reader inside
+// active() pairs with via memory_order_acquire.
+// ---------------------------------------------------------------------------
+
+TEST_F(MessagingSmoke, ConnectionTokenActiveHonorsExternalUnregister)
+{
+    auto block      = std::make_shared<FakeBusControlBlock>();
+    auto allocation = block->allocateSlot(nullptr);
+    ASSERT_TRUE(allocation.id.valid());
+    ASSERT_NE(allocation.state, nullptr);
+
+    auto token = std::make_unique<ConnectionToken>(
+        std::weak_ptr<IBusControlBlock>(block),
+        allocation.id,
+        allocation.state);
+
+    // Pre-flip: the bus is alive, the id is valid, neither the token's
+    // own _cancelled atomic nor the shared SlotState's cancelled flag
+    // is set — active() must say true.
+    EXPECT_TRUE(token->active())
+        << "fresh token over a live bus must report active() == true";
+    EXPECT_TRUE(block->isAlive());
+    EXPECT_FALSE(allocation.state->cancelled.load(std::memory_order_acquire));
+
+    // Out-of-band unregister: simulate the bus driving its own
+    // unregisterTarget (or any other path that flips the shared
+    // SlotState without ever going through this token's cancel()).
+    // We DO NOT call token->cancel() — the token's _cancelled atomic
+    // must stay false so the assertion below proves that active()
+    // returned false because of the SlotState short-circuit, not
+    // because of the token-side gate.
+    {
+        std::unique_lock<std::shared_mutex> ex{allocation.state->lifecycleMutex};
+        allocation.state->cancelled.store(true, std::memory_order_release);
+    }
+
+    EXPECT_TRUE(block->isAlive())
+        << "external unregister must not affect the bus's own alive flag";
+    EXPECT_EQ(block->unregisterCalls(), 0u)
+        << "we did not call cancel(); the control block must not have "
+           "seen any unregisterTarget";
+    EXPECT_TRUE(allocation.state->cancelled.load(std::memory_order_acquire))
+        << "external writer must have set the shared SlotState->cancelled "
+           "flag";
+    EXPECT_FALSE(token->active())
+        << "active() must observe the external unregister via the new "
+           "_slotState->cancelled short-circuit and report false";
+}
+
+// ---------------------------------------------------------------------------
+// Case 11b -- ConnectionToken::active() honours its own cancel().
+//
+// Companion to the external-unregister case: covers the path where
+// the user explicitly calls token->cancel() on a still-live bus. The
+// short-circuit that fires here is the token-side _cancelled atomic
+// (the SlotState short-circuit also happens, but the test does not
+// distinguish the two — Case 11 above is what isolates the new
+// SlotState path).
 // ---------------------------------------------------------------------------
 
 TEST_F(MessagingSmoke, ConnectionTokenActiveHonorsCancel)
@@ -699,25 +765,18 @@ TEST_F(MessagingSmoke, ConnectionTokenActiveHonorsCancel)
         allocation.id,
         allocation.state);
 
-    // Pre-cancel: the bus is alive, the id is valid, and neither the
-    // token's own _cancelled atomic nor the shared SlotState's
-    // cancelled flag has been flipped — active() must say true.
     EXPECT_TRUE(token->active())
         << "fresh token over a live bus must report active() == true";
     EXPECT_TRUE(block->isAlive());
 
-    // Cancel runs the full unregister-plus-barrier sequence. After
-    // it returns, both the token's own _cancelled atomic and the
-    // shared SlotState->cancelled flag are true; the bus itself is
-    // still alive (cancel does not mark the bus dead).
     token->cancel();
 
     EXPECT_TRUE(block->isAlive())
         << "cancel() must not affect the bus's own alive flag";
-    EXPECT_TRUE(allocation.state->cancelled)
+    EXPECT_TRUE(allocation.state->cancelled.load(std::memory_order_acquire))
         << "cancel() must trip the shared SlotState->cancelled flag";
     EXPECT_FALSE(token->active())
-        << "active() must observe the explicit unregister and report false";
+        << "active() must observe the cancel() and report false";
 }
 
 } // namespace

--- a/test/messaging/smoke_test.cpp
+++ b/test/messaging/smoke_test.cpp
@@ -674,4 +674,50 @@ TEST_F(MessagingSmoke, ConnectionTokenCancelIsIdempotent)
     EXPECT_EQ(block->unregisterCalls(), 1u);
 }
 
+// ---------------------------------------------------------------------------
+// Case 11 -- ConnectionToken::active() honours an explicit unregister.
+//
+// Pins the L-B6 contract: once a token has been cancelled (which
+// trips its own atomic _cancelled flag AND, on the way through, the
+// shared SlotState->cancelled flag under lifecycleMutex), active()
+// must report false even though the FakeBusControlBlock is still
+// alive and reachable through the weak_ptr. Without the new
+// _cancelled / _slotState->cancelled short-circuits inside
+// ConnectionToken::active(), the call would still walk all the way
+// down to ctrl->isAlive() and return true.
+// ---------------------------------------------------------------------------
+
+TEST_F(MessagingSmoke, ConnectionTokenActiveHonorsCancel)
+{
+    auto block      = std::make_shared<FakeBusControlBlock>();
+    auto allocation = block->allocateSlot(nullptr);
+    ASSERT_TRUE(allocation.id.valid());
+    ASSERT_NE(allocation.state, nullptr);
+
+    auto token = std::make_unique<ConnectionToken>(
+        std::weak_ptr<IBusControlBlock>(block),
+        allocation.id,
+        allocation.state);
+
+    // Pre-cancel: the bus is alive, the id is valid, and neither the
+    // token's own _cancelled atomic nor the shared SlotState's
+    // cancelled flag has been flipped — active() must say true.
+    EXPECT_TRUE(token->active())
+        << "fresh token over a live bus must report active() == true";
+    EXPECT_TRUE(block->isAlive());
+
+    // Cancel runs the full unregister-plus-barrier sequence. After
+    // it returns, both the token's own _cancelled atomic and the
+    // shared SlotState->cancelled flag are true; the bus itself is
+    // still alive (cancel does not mark the bus dead).
+    token->cancel();
+
+    EXPECT_TRUE(block->isAlive())
+        << "cancel() must not affect the bus's own alive flag";
+    EXPECT_TRUE(allocation.state->cancelled)
+        << "cancel() must trip the shared SlotState->cancelled flag";
+    EXPECT_FALSE(token->active())
+        << "active() must observe the explicit unregister and report false";
+}
+
 } // namespace


### PR DESCRIPTION
`ConnectionToken::active()` now honours an explicit unregister.

Until this change, `active()` could keep reporting `true` even after the
slot had been cancelled by something other than this token's own
`cancel()` — for example when the bus drove `unregisterTarget` on its
own and flipped the shared `SlotState->cancelled` flag without going
through this token. The four-leg check now consults that flag in
addition to the token's `_cancelled` atomic, so a held token reflects
the registry's view of the slot regardless of which path retired it.
The fast path stays branch-cheap (one valid-id check, two atomic-style
loads, one `weak_ptr::lock`, one bus-alive load); the existing
in-flight-dispatch barrier in `cancel()` is unchanged.

Doxygen on both `IConnectionToken::active()` and
`ConnectionToken::active()` now spells out all four conditions under
which the call returns `false`, matching the new body.

Smoke coverage adds `MessagingSmoke.ConnectionTokenActiveHonorsCancel`,
built on the same `FakeBusControlBlock` test double the existing
`ConnectionTokenCancelIsIdempotent` case uses. It pins the contract
end-to-end: pre-cancel `active()` is `true`, post-cancel `active()` is
`false`, the bus stays alive, and the shared `SlotState->cancelled`
flag is observed flipped. ctest now runs 193 cases (was 192), all
green.

Closes #258
