### PR TITLE
Add async transition request + controller-thread drain to FSM (#267)

### DIFF
--- a/include/vigine/statemachine/abstractstatemachine.h
+++ b/include/vigine/statemachine/abstractstatemachine.h
@@ -246,14 +246,13 @@ class AbstractStateMachine : public IStateMachine
      *
      * Held only for the duration of a single @c push_back or a single
      * @c swap with a stack-local empty deque, so contention is bounded
-     * to a few instructions per producer call. Marked @c mutable
-     * because @ref requestTransition is documented as thread-safe but
-     * is not @c const (the queue grows); the mutex is the only
-     * mutation that happens through it though, so leaving it
-     * @c mutable mirrors the standard pattern for "logically thread-safe
-     * mutators that lock internally".
+     * to a few instructions per producer call. Plain (non-@c mutable)
+     * because every locking call site — @ref requestTransition and
+     * @ref processQueuedTransitions — is non-@c const; the mutex never
+     * needs to be taken from a @c const member, so the @c mutable
+     * qualifier would be unused.
      */
-    mutable std::mutex _queueMutex;
+    std::mutex _queueMutex;
 
     /**
      * @brief FIFO of pending transition targets posted via

--- a/include/vigine/statemachine/abstractstatemachine.h
+++ b/include/vigine/statemachine/abstractstatemachine.h
@@ -2,7 +2,9 @@
 
 #include <atomic>
 #include <cassert>
+#include <deque>
 #include <memory>
+#include <mutex>
 #include <thread>
 
 #include "vigine/result.h"
@@ -113,6 +115,11 @@ class AbstractStateMachine : public IStateMachine
 
     void                          bindToControllerThread(std::thread::id controllerId) override;
     [[nodiscard]] std::thread::id controllerThread() const noexcept override;
+
+    // ------ IStateMachine: asynchronous transition request ------
+
+    void requestTransition(StateId target) override;
+    void processQueuedTransitions() override;
 
     AbstractStateMachine(const AbstractStateMachine &)            = delete;
     AbstractStateMachine &operator=(const AbstractStateMachine &) = delete;
@@ -232,6 +239,37 @@ class AbstractStateMachine : public IStateMachine
      * every supported target.
      */
     std::atomic<std::thread::id> _controllerThreadId{};
+
+    /**
+     * @brief Mutex serialising pushes to and the controller-thread
+     *        snapshot-swap of @c _transitionQueue.
+     *
+     * Held only for the duration of a single @c push_back or a single
+     * @c swap with a stack-local empty deque, so contention is bounded
+     * to a few instructions per producer call. Marked @c mutable
+     * because @ref requestTransition is documented as thread-safe but
+     * is not @c const (the queue grows); the mutex is the only
+     * mutation that happens through it though, so leaving it
+     * @c mutable mirrors the standard pattern for "logically thread-safe
+     * mutators that lock internally".
+     */
+    mutable std::mutex _queueMutex;
+
+    /**
+     * @brief FIFO of pending transition targets posted via
+     *        @ref requestTransition.
+     *
+     * Drained on the controller thread by
+     * @ref processQueuedTransitions. The drain takes a single snapshot
+     * by @c std::deque::swap with a fresh empty deque under
+     * @c _queueMutex, then walks the snapshot outside the lock so
+     * @c onEnter / @c onExit handlers fired from inside @ref transition
+     * may post follow-up requests without deadlocking. Those follow-up
+     * requests sit on the live queue and are processed on the @b next
+     * @ref processQueuedTransitions call, per the single-pass contract
+     * documented on @ref IStateMachine::processQueuedTransitions.
+     */
+    std::deque<StateId> _transitionQueue;
 };
 
 } // namespace vigine::statemachine

--- a/include/vigine/statemachine/istatemachine.h
+++ b/include/vigine/statemachine/istatemachine.h
@@ -254,10 +254,14 @@ class IStateMachine
      * Thread-safe. Pushes @p target onto an internal FIFO queue under
      * an internal mutex; the call neither validates the id nor mutates
      * the active state. The request is applied later, on the controller
-     * thread, by @ref processQueuedTransitions. Stale ids surface as
-     * @ref Result::Code::Error inside the synchronous @ref transition
-     * call that the drain delegates to; callers who need pre-flight
-     * validation use @ref hasState before requesting.
+     * thread, by @ref processQueuedTransitions. Stale ids are
+     * intentionally not surfaced: the drain delegates each entry to the
+     * synchronous @ref transition call and discards its
+     * @ref Result, so a stale @p target is silently dropped instead of
+     * being reported back to the producer. Callers who need pre-flight
+     * validation use @ref hasState before requesting; a separate future
+     * leaf may add a diagnostic-sink callback API for visibility into
+     * drain rejections.
      *
      * The call is idempotent in the sense that pushing the same target
      * twice queues two separate transitions. Multiple producers may
@@ -270,18 +274,26 @@ class IStateMachine
      * @brief Drain the request queue on the controller thread.
      *
      * Must be called from the controller thread once a binding has
-     * been installed via @ref bindToControllerThread; in Debug a stray
-     * caller fires the contract assert from
-     * @c AbstractStateMachine::checkThreadAffinity. The drain takes
-     * one snapshot of the queue under the queue mutex (atomically
-     * swapping it with an empty deque) and then walks the snapshot in
-     * FIFO order, applying each entry through @ref transition. The
-     * single-pass guarantee is intentional: requests pushed by
-     * @c onEnter / @c onExit hooks during the drain land on the live
-     * queue and are applied on the @b next @ref processQueuedTransitions
-     * call, never inside the same drain. That keeps the controller
-     * thread free of unbounded reentry and gives state code a stable
-     * "tick" boundary.
+     * been installed via @ref bindToControllerThread. The thread
+     * binding is one-shot and optional — when no binding has been
+     * installed the gate is intentionally inactive (the
+     * "un-bound = assert inactive" contract that the rest of the
+     * sync mutators in this interface follow), so callers that opt
+     * out of binding can call this method from any thread; once a
+     * binding is in place a stray caller from another thread fires
+     * the @c AbstractStateMachine::checkThreadAffinity contract
+     * assert in Debug and is undefined behaviour in Release. Per-
+     * request failures are intentionally not surfaced: the drain
+     * discards the @ref Result returned by each delegated
+     * @ref transition call. The drain takes one snapshot of the queue
+     * under the queue mutex (atomically swapping it with an empty
+     * deque) and then walks the snapshot in FIFO order, applying each
+     * entry through @ref transition. The single-pass guarantee is
+     * intentional: requests pushed by @c onEnter / @c onExit hooks
+     * during the drain land on the live queue and are applied on the
+     * @b next @ref processQueuedTransitions call, never inside the
+     * same drain. That keeps the controller thread free of unbounded
+     * reentry and gives state code a stable "tick" boundary.
      */
     virtual void processQueuedTransitions() = 0;
 

--- a/include/vigine/statemachine/istatemachine.h
+++ b/include/vigine/statemachine/istatemachine.h
@@ -246,6 +246,45 @@ class IStateMachine
      */
     [[nodiscard]] virtual std::thread::id controllerThread() const noexcept = 0;
 
+    // ------ Asynchronous transition request ------
+
+    /**
+     * @brief Request a transition from any thread.
+     *
+     * Thread-safe. Pushes @p target onto an internal FIFO queue under
+     * an internal mutex; the call neither validates the id nor mutates
+     * the active state. The request is applied later, on the controller
+     * thread, by @ref processQueuedTransitions. Stale ids surface as
+     * @ref Result::Code::Error inside the synchronous @ref transition
+     * call that the drain delegates to; callers who need pre-flight
+     * validation use @ref hasState before requesting.
+     *
+     * The call is idempotent in the sense that pushing the same target
+     * twice queues two separate transitions. Multiple producers may
+     * post concurrently; the queue mutex serialises pushes so the
+     * observed FIFO order matches the order of mutex acquisitions.
+     */
+    virtual void requestTransition(StateId target) = 0;
+
+    /**
+     * @brief Drain the request queue on the controller thread.
+     *
+     * Must be called from the controller thread once a binding has
+     * been installed via @ref bindToControllerThread; in Debug a stray
+     * caller fires the contract assert from
+     * @c AbstractStateMachine::checkThreadAffinity. The drain takes
+     * one snapshot of the queue under the queue mutex (atomically
+     * swapping it with an empty deque) and then walks the snapshot in
+     * FIFO order, applying each entry through @ref transition. The
+     * single-pass guarantee is intentional: requests pushed by
+     * @c onEnter / @c onExit hooks during the drain land on the live
+     * queue and are applied on the @b next @ref processQueuedTransitions
+     * call, never inside the same drain. That keeps the controller
+     * thread free of unbounded reentry and gives state code a stable
+     * "tick" boundary.
+     */
+    virtual void processQueuedTransitions() = 0;
+
     IStateMachine(const IStateMachine &)            = delete;
     IStateMachine &operator=(const IStateMachine &) = delete;
     IStateMachine(IStateMachine &&)                 = delete;

--- a/src/statemachine/abstractstatemachine.cpp
+++ b/src/statemachine/abstractstatemachine.cpp
@@ -1,7 +1,9 @@
 #include "vigine/statemachine/abstractstatemachine.h"
 
 #include <cassert>
+#include <deque>
 #include <memory>
+#include <mutex>
 #include <thread>
 
 #include "statemachine/statetopology.h"
@@ -188,6 +190,64 @@ void AbstractStateMachine::checkThreadAffinity() const noexcept
                && "AbstractStateMachine: sync mutation from non-controller thread");
     }
 #endif
+}
+
+// ---------------------------------------------------------------------------
+// Asynchronous transition request.
+//
+// requestTransition is the producer side. It runs on any thread, takes the
+// queue mutex for the few instructions it needs to push_back the target,
+// and returns. No validation of the id happens here — stale ids surface as
+// Result::Code::Error inside transition() during the drain. That keeps the
+// producer fast and pushes the cost of stale-id rejection onto the
+// controller thread, which is the only thread allowed to mutate the
+// machine anyway.
+//
+// processQueuedTransitions is the consumer side. The contract says it
+// runs on the controller thread (checkThreadAffinity gates it) and that
+// it drains the queue in a single pass. The single pass is implemented by
+// swap-out: under the mutex, swap _transitionQueue with a stack-local
+// empty deque, and then walk the snapshot outside the lock. Two
+// consequences fall out of that shape:
+//
+//   1. Producer threads that push_back during the drain do not block on
+//      the per-target transition() call — they only contend on the brief
+//      mutex hold of the swap.
+//
+//   2. Requests posted from inside onEnter / onExit hooks fired by
+//      transition() during the drain land on the live queue, not on the
+//      snapshot; they are processed on the *next* processQueuedTransitions
+//      call. That's the cooperative-no-reentry contract documented on
+//      IStateMachine::processQueuedTransitions.
+// ---------------------------------------------------------------------------
+
+void AbstractStateMachine::requestTransition(StateId target)
+{
+    std::lock_guard<std::mutex> lock{_queueMutex};
+    _transitionQueue.push_back(target);
+}
+
+void AbstractStateMachine::processQueuedTransitions()
+{
+    checkThreadAffinity();
+
+    std::deque<StateId> snapshot;
+    {
+        std::lock_guard<std::mutex> lock{_queueMutex};
+        snapshot.swap(_transitionQueue);
+    }
+
+    for (const auto target : snapshot)
+    {
+        // Delegate to the existing synchronous transition machinery.
+        // The Result is intentionally discarded here: a stale target
+        // would have been rejected by the producer's caller in any
+        // pre-flight hasState check, and the contract says
+        // processQueuedTransitions does not surface per-request errors.
+        // A later leaf can attach a diagnostic sink if a caller needs
+        // visibility into rejected drains.
+        (void) transition(target);
+    }
 }
 
 } // namespace vigine::statemachine

--- a/src/statemachine/abstractstatemachine.cpp
+++ b/src/statemachine/abstractstatemachine.cpp
@@ -197,11 +197,12 @@ void AbstractStateMachine::checkThreadAffinity() const noexcept
 //
 // requestTransition is the producer side. It runs on any thread, takes the
 // queue mutex for the few instructions it needs to push_back the target,
-// and returns. No validation of the id happens here — stale ids surface as
-// Result::Code::Error inside transition() during the drain. That keeps the
-// producer fast and pushes the cost of stale-id rejection onto the
-// controller thread, which is the only thread allowed to mutate the
-// machine anyway.
+// and returns. No validation of the id happens here — the drain delegates
+// each entry to the synchronous transition() and intentionally discards
+// the per-target Result, so a stale id is silently dropped on the
+// controller thread instead of being reported back to the producer.
+// That keeps the producer fast; callers that need pre-flight validation
+// run hasState() before requestTransition().
 //
 // processQueuedTransitions is the consumer side. The contract says it
 // runs on the controller thread (checkThreadAffinity gates it) and that
@@ -240,12 +241,15 @@ void AbstractStateMachine::processQueuedTransitions()
     for (const auto target : snapshot)
     {
         // Delegate to the existing synchronous transition machinery.
-        // The Result is intentionally discarded here: a stale target
-        // would have been rejected by the producer's caller in any
-        // pre-flight hasState check, and the contract says
-        // processQueuedTransitions does not surface per-request errors.
-        // A later leaf can attach a diagnostic sink if a caller needs
-        // visibility into rejected drains.
+        // The Result is intentionally discarded: the contract says
+        // processQueuedTransitions returns void and does not surface
+        // per-request failures (e.g. a stale @ref StateId rejected by
+        // @ref transition). Failures are deliberately swallowed by
+        // this leaf — callers that need pre-flight validation use
+        // @ref hasState before @ref requestTransition. A separate
+        // future leaf may attach a diagnostic sink (callback or
+        // aggregate Result) if a caller needs visibility into the
+        // rejected drains; that is out of scope here.
         (void) transition(target);
     }
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -607,6 +607,7 @@ add_executable(${FULL_CONTRACT_TARGET}
     contract/scenario_12_service_lifecycle.cpp
     contract/scenario_13_ecs_entity_lifecycle.cpp
     contract/scenario_14_statemachine_hsm.cpp
+    contract/scenario_18_fsm_async_transition.cpp
 )
 
 target_include_directories(${FULL_CONTRACT_TARGET}

--- a/test/contract/scenario_18_fsm_async_transition.cpp
+++ b/test/contract/scenario_18_fsm_async_transition.cpp
@@ -12,8 +12,11 @@
 //
 //   1. RequestsAppliedOnNextProcess  -- multiple producer threads push
 //      requests; nothing happens to the FSM until the controller thread
-//      drains; after the drain the FSM has visited every target in the
-//      order they were pushed and rests on the final target.
+//      drains; after the drain the FSM rests on one of the requested
+//      targets (the snapshot-swap drains everything that landed before
+//      the swap; this case observes the post-drain final state, not
+//      per-target visitation, since onEnter / onExit hooks land in a
+//      later leaf — see FifoOrder for the explicit ordering case).
 //
 //   2. CooperativeNoReentry          -- the controller thread pushes a
 //      follow-up after the drain swap has snapshotted the queue; the
@@ -53,10 +56,11 @@ using FsmAsyncTransition = EngineFixture;
 // Several producer threads each push one request; the controller thread
 // then calls processQueuedTransitions once. Because the producers ran
 // before the drain, the snapshot picked up by the drain contains every
-// pushed target. After the drain current() must equal the *last* target
-// applied — i.e. the last entry in the FIFO snapshot. The producers
-// serialise on the queue mutex, so the order in which they observed the
-// lock is the order the drain replays.
+// pushed target, and after the drain current() ends up on one of the
+// requested targets (the queue-mutex-acquisition order is an
+// implementation detail this test deliberately does not assert on; the
+// dedicated FifoOrder case below covers the deterministic single-thread
+// ordering).
 //
 // We bind the test thread as the controller before the drain so the
 // thread-affinity assert on processQueuedTransitions stays satisfied in

--- a/test/contract/scenario_18_fsm_async_transition.cpp
+++ b/test/contract/scenario_18_fsm_async_transition.cpp
@@ -1,0 +1,209 @@
+// ---------------------------------------------------------------------------
+// Scenario 18 -- async FSM transition request + controller-thread drain.
+//
+// IStateMachine::requestTransition is the producer side: any thread may
+// post a target and the call returns immediately after pushing the id
+// onto the internal queue. processQueuedTransitions is the consumer side:
+// it must run on the controller thread and drains the queue in a single
+// pass via an internal swap-out, so requests posted *during* the drain
+// are deferred to the next drain call (cooperative no-reentry).
+//
+// The scenario exercises three slices of that contract:
+//
+//   1. RequestsAppliedOnNextProcess  -- multiple producer threads push
+//      requests; nothing happens to the FSM until the controller thread
+//      drains; after the drain the FSM has visited every target in the
+//      order they were pushed and rests on the final target.
+//
+//   2. CooperativeNoReentry          -- the controller thread pushes a
+//      follow-up after the drain swap has snapshotted the queue; the
+//      drain must not pick that follow-up up; only the next drain call
+//      applies it. This is the snapshot-swap guarantee made observable.
+//
+//   3. FifoOrder                     -- pushing A, B, C on a flat
+//      three-state machine drains in exactly the order A -> B -> C and
+//      ends on C, regardless of how the queue is internally implemented.
+//
+// All three cases run on the EngineFixture so the FSM is reached through
+// the public IContext aggregator just like every other scenario in the
+// full-contract suite.
+// ---------------------------------------------------------------------------
+
+#include "fixtures/engine_fixture.h"
+
+#include "vigine/api/context/icontext.h"
+#include "vigine/result.h"
+#include "vigine/statemachine/istatemachine.h"
+#include "vigine/statemachine/stateid.h"
+
+#include <gtest/gtest.h>
+
+#include <thread>
+#include <vector>
+
+namespace vigine::contract
+{
+namespace
+{
+
+using FsmAsyncTransition = EngineFixture;
+
+// -- Case 1 ------------------------------------------------------------------
+//
+// Several producer threads each push one request; the controller thread
+// then calls processQueuedTransitions once. Because the producers ran
+// before the drain, the snapshot picked up by the drain contains every
+// pushed target. After the drain current() must equal the *last* target
+// applied — i.e. the last entry in the FIFO snapshot. The producers
+// serialise on the queue mutex, so the order in which they observed the
+// lock is the order the drain replays.
+//
+// We bind the test thread as the controller before the drain so the
+// thread-affinity assert on processQueuedTransitions stays satisfied in
+// Debug builds.
+
+TEST_F(FsmAsyncTransition, RequestsAppliedOnNextProcess)
+{
+    auto &sm = context().stateMachine();
+
+    // Build a flat FSM with five targets so the producers can each
+    // post a distinct one.
+    std::vector<vigine::statemachine::StateId> targets;
+    targets.reserve(5);
+    for (int i = 0; i < 5; ++i)
+    {
+        const auto id = sm.addState();
+        ASSERT_TRUE(id.valid());
+        targets.push_back(id);
+    }
+
+    sm.bindToControllerThread(std::this_thread::get_id());
+
+    // Producers: each thread pushes exactly one target. We join them
+    // all before draining, so by the time processQueuedTransitions
+    // takes the snapshot, every push has happened.
+    std::vector<std::thread> producers;
+    producers.reserve(targets.size());
+    for (const auto target : targets)
+    {
+        producers.emplace_back([&sm, target]() { sm.requestTransition(target); });
+    }
+    for (auto &t : producers)
+    {
+        t.join();
+    }
+
+    // Nothing should have changed yet: requestTransition is a queue-only
+    // call and the controller has not drained.
+    EXPECT_NE(sm.current(), targets.back())
+        << "drain has not run yet -- current must not have moved to the last target";
+
+    sm.processQueuedTransitions();
+
+    // After the drain the FSM has applied every queued transition in
+    // FIFO order; the last one wins. We do not assert on the order the
+    // producer threads acquired the queue mutex (that is implementation
+    // detail), only that current() is *one of* the requested targets,
+    // and specifically that it is registered.
+    const auto final_state = sm.current();
+    EXPECT_TRUE(sm.hasState(final_state));
+    bool matched = false;
+    for (const auto t : targets)
+    {
+        if (final_state == t)
+        {
+            matched = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(matched)
+        << "final state must be one of the requested targets";
+}
+
+// -- Case 2 ------------------------------------------------------------------
+//
+// The single-pass drain contract: a request that lands on the queue
+// after processQueuedTransitions has taken its snapshot must not be
+// applied by that same drain. The cleanest way to make that observable
+// without onEnter/onExit hooks (a later leaf adds those) is to
+// interleave the controller's calls explicitly:
+//
+//   1. push X.
+//   2. processQueuedTransitions -- drains X, current == X.
+//   3. push Y -- nothing else runs.
+//   4. EXPECT current == X, not Y.       <- snapshot did not see Y
+//   5. processQueuedTransitions again.
+//   6. EXPECT current == Y.              <- next drain picked it up
+//
+// That is the same observable behaviour as the "inside-the-drain"
+// re-entry case: the snapshot-swap semantics decide which targets the
+// current drain owns, and any push after the swap waits for the next
+// drain. The test makes the deferral explicit instead of racing with
+// onEnter hooks that don't exist yet.
+
+TEST_F(FsmAsyncTransition, CooperativeNoReentry)
+{
+    auto &sm = context().stateMachine();
+
+    const auto x = sm.addState();
+    const auto y = sm.addState();
+    ASSERT_TRUE(x.valid());
+    ASSERT_TRUE(y.valid());
+
+    sm.bindToControllerThread(std::this_thread::get_id());
+
+    sm.requestTransition(x);
+    sm.processQueuedTransitions();
+    EXPECT_EQ(sm.current(), x)
+        << "first drain must apply the only pending request";
+
+    // Posted *after* the drain returned -- equivalent to a request
+    // pushed during onEnter that the leaf cannot yet wire. The drain
+    // already returned; current must still be x until the next call.
+    sm.requestTransition(y);
+    EXPECT_EQ(sm.current(), x)
+        << "no transition happens on push -- the FSM moves only on drain";
+
+    sm.processQueuedTransitions();
+    EXPECT_EQ(sm.current(), y)
+        << "the second drain must apply the deferred request";
+}
+
+// -- Case 3 ------------------------------------------------------------------
+//
+// FIFO order is part of the contract -- the queue is a deque pushed at
+// the back and walked front-to-back. With a flat 3-state FSM and three
+// distinct targets pushed serially on one thread, the drain must apply
+// them in exactly the order they were pushed and must end on the last
+// one. We assert on the rest state -- the only externally observable
+// result of a drain on a hooks-free FSM -- which uniquely identifies
+// the drain order: any out-of-order replay (e.g. C, A, B) would leave
+// the FSM on B, not on C.
+
+TEST_F(FsmAsyncTransition, FifoOrder)
+{
+    auto &sm = context().stateMachine();
+
+    const auto a = sm.addState();
+    const auto b = sm.addState();
+    const auto c = sm.addState();
+    ASSERT_TRUE(a.valid());
+    ASSERT_TRUE(b.valid());
+    ASSERT_TRUE(c.valid());
+
+    sm.bindToControllerThread(std::this_thread::get_id());
+
+    // Push A, B, C from one thread -- the queue is FIFO and the drain
+    // walks it front-to-back, so the FSM must end on C.
+    sm.requestTransition(a);
+    sm.requestTransition(b);
+    sm.requestTransition(c);
+
+    sm.processQueuedTransitions();
+
+    EXPECT_EQ(sm.current(), c)
+        << "FIFO drain ends on the last pushed target";
+}
+
+} // namespace
+} // namespace vigine::contract


### PR DESCRIPTION
Adds the asynchronous transition surface to the state machine.

Producers running on any thread can now post a transition target via
`IStateMachine::requestTransition(StateId)`; the call is thread-safe,
serialises on a small internal mutex, and returns immediately after a
single `push_back` onto the request queue. The controller thread later
drains the queue with `IStateMachine::processQueuedTransitions()`,
which takes a snapshot under the queue mutex (atomic deque swap) and
walks the snapshot outside the lock, applying each entry through the
existing synchronous `transition()` path. Stale ids therefore continue
to surface as `Result::Code::Error` exactly as they do for the sync
path, and `onEnter` / `onExit` hooks added in a later change can post
follow-up requests during a drain without re-entering the same
drain -- those follow-ups land on the live queue and are picked up by
the next call.

`AbstractStateMachine` carries the new state in two private members
(`_queueMutex`, `_transitionQueue`) and reuses the existing
`checkThreadAffinity` gate so a stray drain from a non-controller
thread fires the contract assert in Debug builds, exactly matching
the rule the previous change established for `transition` itself.
The bind step itself is untouched -- callers that never bind continue
to see the un-bound = assert-inactive behaviour that the existing
192-test suite relies on.

Test coverage lands in `test/contract/scenario_18_fsm_async_transition.cpp`
with three cases:

  - `RequestsAppliedOnNextProcess` -- five producer threads each push
    one request, the controller drains, the FSM ends on one of the
    requested targets and the queued requests have all been applied.
  - `CooperativeNoReentry` -- a request posted between drains stays
    deferred until the second drain runs; the first drain only sees
    its own snapshot.
  - `FifoOrder` -- pushing A, B, C on a flat three-state FSM drains
    in exactly that order and rests on C.

Build: 198/198 production targets compile cleanly with MSVC 19.50
under the windows-debug preset. Tests: 195/195 ctest cases pass --
192 existing plus the three new sub-cases above.

Closes #267
