### PR TITLE
Mark POD aggregates with ENCAP EXEMPT comments (#281)

### DIFF
--- a/include/vigine/api/actorhost/actorid.h
+++ b/include/vigine/api/actorhost/actorid.h
@@ -20,6 +20,7 @@ namespace vigine::actorhost
  *   - INV-10: POD value type; no template parameters (INV-1).
  *   - INV-11: no graph types here.
  */
+// ENCAP EXEMPT: pure value aggregate
 struct ActorId
 {
     std::uint32_t value{0};

--- a/include/vigine/api/context/contextconfig.h
+++ b/include/vigine/api/context/contextconfig.h
@@ -28,6 +28,7 @@ namespace vigine::context
  * caller overrides individual fields before handing the struct to the
  * factory.
  */
+// ENCAP EXEMPT: pure value aggregate
 struct ContextConfig
 {
     /**

--- a/include/vigine/api/engine/engineconfig.h
+++ b/include/vigine/api/engine/engineconfig.h
@@ -57,6 +57,7 @@ enum class RunMode : std::uint8_t
  * @ref IContext::freeze on entry, after which topology mutation is
  * rejected with @ref Result::Code::TopologyFrozen.
  */
+// ENCAP EXEMPT: pure value aggregate
 struct EngineConfig
 {
     /**

--- a/include/vigine/api/requestbus/requestconfig.h
+++ b/include/vigine/api/requestbus/requestconfig.h
@@ -31,6 +31,7 @@ namespace vigine::requestbus
  *   - POD aggregate: trivially constructible, copyable.
  *   - INV-11: no graph types appear in this header.
  */
+// ENCAP EXEMPT: pure value aggregate
 struct RequestConfig
 {
     /// How long @ref IFuture::wait blocks. Default: effectively forever.

--- a/include/vigine/api/service/serviceid.h
+++ b/include/vigine/api/service/serviceid.h
@@ -27,6 +27,7 @@ namespace vigine::service
  * The pair is small (8 bytes), trivially copyable, and safe to pass by
  * value across thread boundaries.
  */
+// ENCAP EXEMPT: pure value aggregate
 struct ServiceId
 {
     std::uint32_t index{0};

--- a/include/vigine/api/topicbus/topicid.h
+++ b/include/vigine/api/topicbus/topicid.h
@@ -22,6 +22,7 @@ namespace vigine::topicbus
  *   - A zero @c value is the sentinel for "invalid / not found".
  *   - INV-11: no graph types appear in this header.
  */
+// ENCAP EXEMPT: pure value aggregate
 struct TopicId
 {
     std::uint32_t value{0};

--- a/include/vigine/core/graph/edgeid.h
+++ b/include/vigine/core/graph/edgeid.h
@@ -11,6 +11,7 @@ namespace vigine::core::graph
  * POD value type with the same layout contract as @ref NodeId. Generation
  * `0` is the invalid sentinel; lookups with a stale identifier fail safely.
  */
+// ENCAP EXEMPT: pure value aggregate
 struct EdgeId
 {
     std::uint32_t index{0};

--- a/include/vigine/core/graph/nodeid.h
+++ b/include/vigine/core/graph/nodeid.h
@@ -17,6 +17,7 @@ namespace vigine::core::graph
  *       constructed @ref NodeId is therefore always invalid and never
  *       returned by @ref IGraph::addNode.
  */
+// ENCAP EXEMPT: pure value aggregate
 struct NodeId
 {
     std::uint32_t index{0};

--- a/include/vigine/core/threading/imessagechannel.h
+++ b/include/vigine/core/threading/imessagechannel.h
@@ -33,6 +33,7 @@ namespace vigine::core::threading
  *   channel->send(std::move(msg), std::chrono::milliseconds::max());
  * @endcode
  */
+// ENCAP EXEMPT: pure value aggregate
 struct Message
 {
     /// Payload-registry key the receiver uses to decode @ref bytes.

--- a/include/vigine/core/threading/imessagechannel.h
+++ b/include/vigine/core/threading/imessagechannel.h
@@ -33,7 +33,7 @@ namespace vigine::core::threading
  *   channel->send(std::move(msg), std::chrono::milliseconds::max());
  * @endcode
  */
-// ENCAP EXEMPT: pure value aggregate
+// ENCAP EXEMPT: move-only carrier with public fields by design
 struct Message
 {
     /// Payload-registry key the receiver uses to decode @ref bytes.

--- a/include/vigine/core/threading/namedthreadid.h
+++ b/include/vigine/core/threading/namedthreadid.h
@@ -19,6 +19,7 @@ namespace vigine::core::threading
  *       default-constructed @ref NamedThreadId is therefore always invalid
  *       and never returned from a successful registration.
  */
+// ENCAP EXEMPT: pure value aggregate
 struct NamedThreadId
 {
     std::uint32_t index{0};

--- a/include/vigine/core/threading/threadmanagerconfig.h
+++ b/include/vigine/core/threading/threadmanagerconfig.h
@@ -19,6 +19,7 @@ namespace vigine::core::threading
  * applies to @ref maxDedicatedThreads; @ref maxNamedThreads defaults to
  * an upper bound the typical engine will never exhaust.
  */
+// ENCAP EXEMPT: pure value aggregate
 struct ThreadManagerConfig
 {
     /**

--- a/include/vigine/eventscheduler/eventconfig.h
+++ b/include/vigine/eventscheduler/eventconfig.h
@@ -39,6 +39,7 @@ namespace vigine::eventscheduler
  * INV-1: no template parameters.
  * INV-11: no graph types in this header.
  */
+// ENCAP EXEMPT: pure value aggregate
 struct EventConfig
 {
     std::chrono::milliseconds         delay{0};

--- a/include/vigine/messaging/busconfig.h
+++ b/include/vigine/messaging/busconfig.h
@@ -71,6 +71,7 @@ enum class BackpressurePolicy : std::uint8_t
  * configured @ref BackpressurePolicy. When @c bounded is @c false the
  * queue grows dynamically and backpressure is effectively disabled.
  */
+// ENCAP EXEMPT: pure value aggregate
 struct QueueCapacity
 {
     std::size_t maxMessages{1024};
@@ -93,6 +94,7 @@ struct QueueCapacity
  * backing storage alive for the lifetime of the bus (typically a
  * string literal).
  */
+// ENCAP EXEMPT: pure value aggregate
 struct BusConfig
 {
     BusId              id{};

--- a/include/vigine/messaging/busid.h
+++ b/include/vigine/messaging/busid.h
@@ -18,6 +18,7 @@ namespace vigine::messaging
  * The struct is trivially copyable and safe to pass by value across
  * thread boundaries; equality is defined on the underlying value.
  */
+// ENCAP EXEMPT: pure value aggregate
 struct BusId
 {
     std::uint32_t value{0};

--- a/include/vigine/messaging/connectionid.h
+++ b/include/vigine/messaging/connectionid.h
@@ -18,6 +18,7 @@ namespace vigine::messaging
  * value across thread boundaries. Control-block implementations issue
  * ids starting at @c generation == 1; zero is reserved for the sentinel.
  */
+// ENCAP EXEMPT: pure value aggregate
 struct ConnectionId
 {
     std::uint32_t index{0};

--- a/include/vigine/messaging/ibuscontrolblock.h
+++ b/include/vigine/messaging/ibuscontrolblock.h
@@ -30,6 +30,7 @@ class ISubscriber;
  * whose @c id has the zero-generation sentinel and whose @c state is
  * empty. Callers detect failure by checking @c id.valid().
  */
+// ENCAP EXEMPT: pure value aggregate
 struct SlotAllocation
 {
     /// Generational id addressing the new registry entry.

--- a/include/vigine/messaging/imessage.h
+++ b/include/vigine/messaging/imessage.h
@@ -20,6 +20,7 @@ class IMessagePayload;
  * request/response matching (for example @c TopicRequest) allocate a
  * fresh non-zero value per pair.
  */
+// ENCAP EXEMPT: pure value aggregate
 struct CorrelationId
 {
     std::uint64_t value{0};

--- a/include/vigine/messaging/messagefilter.h
+++ b/include/vigine/messaging/messagefilter.h
@@ -39,6 +39,7 @@ class AbstractMessageTarget;
  * through its RAII token vector: a target registered with any bus
  * outlives every subscription that references it.
  */
+// ENCAP EXEMPT: pure value aggregate
 struct MessageFilter
 {
     MessageKind                          kind{MessageKind::Signal};

--- a/include/vigine/messaging/subscriptionslot.h
+++ b/include/vigine/messaging/subscriptionslot.h
@@ -47,7 +47,7 @@ class ISubscriber;
  * mutexes are neither. A lifetime share through @c std::shared_ptr is
  * how snapshot copies all point at the same live object.
  */
-// ENCAP EXEMPT: pure value aggregate
+// ENCAP EXEMPT: intentionally non-encapsulated shared mutable state
 struct SlotState
 {
     /// Serialises concurrent @c onMessage calls to the same subscriber.

--- a/include/vigine/messaging/subscriptionslot.h
+++ b/include/vigine/messaging/subscriptionslot.h
@@ -47,6 +47,7 @@ class ISubscriber;
  * mutexes are neither. A lifetime share through @c std::shared_ptr is
  * how snapshot copies all point at the same live object.
  */
+// ENCAP EXEMPT: pure value aggregate
 struct SlotState
 {
     /// Serialises concurrent @c onMessage calls to the same subscriber.
@@ -93,6 +94,7 @@ struct SlotState
  * copies the pointer, the filter, the serial, the active flag, and
  * bumps the @c SlotState ref-count.
  */
+// ENCAP EXEMPT: pure value aggregate
 struct SubscriptionSlot
 {
     ISubscriber               *subscriber{nullptr};

--- a/include/vigine/payload/payloadtypeid.h
+++ b/include/vigine/payload/payloadtypeid.h
@@ -27,6 +27,7 @@ namespace vigine::payload
  * @ref PayloadTypeId keys without requiring each caller to write their
  * own hasher.
  */
+// ENCAP EXEMPT: pure value aggregate
 struct PayloadTypeId
 {
     std::uint32_t value{0};

--- a/include/vigine/statemachine/stateid.h
+++ b/include/vigine/statemachine/stateid.h
@@ -34,6 +34,7 @@ namespace vigine::statemachine
  *       keeping substrate types out of the public header tree is
  *       the whole point of the separate type.
  */
+// ENCAP EXEMPT: pure value aggregate
 struct StateId
 {
     std::uint32_t index{0};

--- a/include/vigine/taskflow/taskid.h
+++ b/include/vigine/taskflow/taskid.h
@@ -33,6 +33,7 @@ namespace vigine::taskflow
  *       keeping substrate types out of the public header tree is
  *       the whole point of the separate type.
  */
+// ENCAP EXEMPT: pure value aggregate
 struct TaskId
 {
     std::uint32_t index{0};


### PR DESCRIPTION
Closes #281.

Pure-comment edit per the strict-encapsulation policy: every public POD aggregate in include/vigine/ now carries a one-line marker right above its declaration so the rule "every class is private-data unless explicitly marked POD" is auditable by grep.

24 markers added across 22 headers. ECS files (include/vigine/ecs/) skipped — they are restructured by the parallel #279 follow-up.

Zero functional change. Verified locally:
- cmake --preset windows-debug -DENABLE_UNITTEST=ON: configure OK
- cmake --build --preset windows-debug: 268/268 targets built
- ctest --test-dir build -C Debug --output-on-failure: 197/197 passed