### PR TITLE
Fix build warnings in render subsystem (#291)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,8 +48,11 @@ if(WIN32)
     # block: bundled FreeType (`add_subdirectory(... EXCLUDE_FROM_ALL)`)
     # would otherwise inherit it on its command line and re-define it
     # internally, producing C4005 macro-redefinition warnings. The
-    # macro is instead pushed onto the `vigine` (and example/test)
-    # targets via `target_compile_definitions(... PRIVATE)` below.
+    # macro is instead pushed onto the `vigine` target only via
+    # `target_compile_definitions(... PRIVATE)` below; the windowed
+    # example applies its own copy in `example/window/CMakeLists.txt`,
+    # and the test executables do not pull `<windows.h>` transitively
+    # so they need no definition.
     add_compile_definitions(
         VK_USE_PLATFORM_WIN32_KHR
         _WIN32_WINNT=0x0A00

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,11 +43,17 @@ if(WIN32)
     # accidentally used elsewhere would fail to compile here. Bump
     # `_WIN32_WINNT` + `NTDDI_VERSION` together when a newer feature
     # set is needed (e.g. NTDDI_WIN10_VB = 0x0A000008 for 1903+).
+    #
+    # WIN32_LEAN_AND_MEAN is intentionally NOT in this directory-scoped
+    # block: bundled FreeType (`add_subdirectory(... EXCLUDE_FROM_ALL)`)
+    # would otherwise inherit it on its command line and re-define it
+    # internally, producing C4005 macro-redefinition warnings. The
+    # macro is instead pushed onto the `vigine` (and example/test)
+    # targets via `target_compile_definitions(... PRIVATE)` below.
     add_compile_definitions(
         VK_USE_PLATFORM_WIN32_KHR
         _WIN32_WINNT=0x0A00
         NTDDI_VERSION=0x0A000000
-        WIN32_LEAN_AND_MEAN
         NOMINMAX
     )
 endif()
@@ -766,6 +772,13 @@ add_library(${PROJECT_NAME}
 # Scoped via target_compile_options inside the helper so FreeType and
 # other vendored dependencies are not affected.
 vigine_apply_compile_options(${PROJECT_NAME})
+
+# WIN32_LEAN_AND_MEAN trims <windows.h>. Scoped to vigine so the bundled
+# FreeType build (which defines the macro internally for its own TUs)
+# does not see it on its compile line and emit C4005 redefinition.
+if(WIN32)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE WIN32_LEAN_AND_MEAN)
+endif()
 
 # Apply sanitizer flags when VIGINE_SANITIZER is set. Guarded by the same
 # condition used at include-time above so the helper is only called when the

--- a/example/window/CMakeLists.txt
+++ b/example/window/CMakeLists.txt
@@ -284,6 +284,13 @@ target_link_libraries(${PROJECT_WINDOW_NAME}
     vigine
 )
 
+# WIN32_LEAN_AND_MEAN trims <windows.h>. Scoped per-target so it stays
+# off the bundled FreeType command line (which redefines the macro
+# internally and would otherwise emit C4005).
+if(WIN32)
+    target_compile_definitions(${PROJECT_WINDOW_NAME} PRIVATE WIN32_LEAN_AND_MEAN)
+endif()
+
 target_include_directories(${PROJECT_WINDOW_NAME}
     PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}

--- a/include/vigine/ecs/render/meshcomponent.h
+++ b/include/vigine/ecs/render/meshcomponent.h
@@ -10,6 +10,8 @@
 #include "vigine/base/macros.h"
 
 #include <glm/glm.hpp>
+#include <cassert>
+#include <limits>
 #include <memory>
 #include <vector>
 
@@ -49,8 +51,16 @@ class MeshComponent
     const std::vector<Vertex> &getVertices() const { return _vertices; }
     const std::vector<uint32_t> &getIndices() const { return _indices; }
 
-    uint32_t getVertexCount() const { return static_cast<uint32_t>(_vertices.size()); }
-    uint32_t getIndexCount() const { return static_cast<uint32_t>(_indices.size()); }
+    uint32_t getVertexCount() const
+    {
+        assert(_vertices.size() <= (std::numeric_limits<uint32_t>::max)());
+        return static_cast<uint32_t>(_vertices.size());
+    }
+    uint32_t getIndexCount() const
+    {
+        assert(_indices.size() <= (std::numeric_limits<uint32_t>::max)());
+        return static_cast<uint32_t>(_indices.size());
+    }
 
     // Procedural geometry in shader (e.g., cube.vert, sphere.vert generate vertices)
     void setProceduralInShader(bool procedural, uint32_t vertexCount = 0)

--- a/include/vigine/ecs/render/meshcomponent.h
+++ b/include/vigine/ecs/render/meshcomponent.h
@@ -49,8 +49,8 @@ class MeshComponent
     const std::vector<Vertex> &getVertices() const { return _vertices; }
     const std::vector<uint32_t> &getIndices() const { return _indices; }
 
-    uint32_t getVertexCount() const { return _vertices.size(); }
-    uint32_t getIndexCount() const { return _indices.size(); }
+    uint32_t getVertexCount() const { return static_cast<uint32_t>(_vertices.size()); }
+    uint32_t getIndexCount() const { return static_cast<uint32_t>(_indices.size()); }
 
     // Procedural geometry in shader (e.g., cube.vert, sphere.vert generate vertices)
     void setProceduralInShader(bool procedural, uint32_t vertexCount = 0)

--- a/src/ecs/render/rendercomponent.cpp
+++ b/src/ecs/render/rendercomponent.cpp
@@ -163,7 +163,8 @@ FontAtlas &cachedAtlas(const std::string &fontPath, uint32_t pixelSize)
     return atlas;
 }
 
-const GlyphInfo &ensureGlyph(FontAtlas &atlas, FT_Face face, uint32_t codepoint, uint32_t pixelSize)
+const GlyphInfo &ensureGlyph(FontAtlas &atlas, FT_Face face, uint32_t codepoint,
+                             [[maybe_unused]] uint32_t pixelSize)
 {
     auto it = atlas.glyphs.find(codepoint);
     if (it != atlas.glyphs.end())

--- a/src/ecs/render/vulkanapi.cpp
+++ b/src/ecs/render/vulkanapi.cpp
@@ -257,7 +257,7 @@ bool VulkanAPI::endFrame()
     return true;
 }
 
-void VulkanAPI::submitDrawCall(const DrawCallDesc &desc)
+void VulkanAPI::submitDrawCall([[maybe_unused]] const DrawCallDesc &desc)
 {
     // Draw call submission logic will be extracted from drawFrame() in future phases
 }
@@ -282,7 +282,7 @@ void VulkanAPI::destroyPipeline(PipelineHandle handle)
         _vulkanPipelineStore->destroyPipeline(handle);
 }
 
-BufferHandle VulkanAPI::createBuffer(const BufferDesc &desc)
+BufferHandle VulkanAPI::createBuffer([[maybe_unused]] const BufferDesc &desc)
 {
     // Buffer creation logic will be implemented when migrating geometry to components
     BufferHandle handle;
@@ -290,7 +290,8 @@ BufferHandle VulkanAPI::createBuffer(const BufferDesc &desc)
     return handle;
 }
 
-void VulkanAPI::uploadBuffer(BufferHandle handle, const void *data, size_t size)
+void VulkanAPI::uploadBuffer([[maybe_unused]] BufferHandle handle, [[maybe_unused]] const void *data,
+                             [[maybe_unused]] size_t size)
 {
     // Buffer upload logic will be implemented when migrating geometry to components
 }


### PR DESCRIPTION
Closes #291.

## Summary

Drives the MSVC `/W4` warning count from 15 raw instances (8 distinct sites)
to zero across the render subsystem, per the pilot snapshot landed in
`doc/build-warnings-pilot.md`. Build verified clean on MSVC 19.50 in both
Debug and Release configurations; ctest reports 197/197 green;
`example-window.exe` launches and runs.

### Fixes by family

- **C4267 size_t -> uint32_t narrowing (8 raw / 2 sites)** —
  `MeshComponent::getVertexCount()` and `getIndexCount()` now wrap the
  `std::vector::size()` result in `static_cast<uint32_t>(...)`. Vulkan
  command buffers consume these counts as `uint32_t` already; semantics
  unchanged. Folding the cast into the inline accessor collapses all 8
  amplified instances (the header is included by 4 TUs) at once.

- **C4100 unreferenced parameter (6 raw / 4 sites)** —
  `VulkanAPI::submitDrawCall`, `VulkanAPI::createBuffer`,
  `VulkanAPI::uploadBuffer` are stub bodies with parameters reserved
  for future-phase wiring; the `ensureGlyph` helper in
  `rendercomponent.cpp` likewise carries an unused `pixelSize`. All
  four sites now decorate the unused parameter list with
  `[[maybe_unused]]`. Attribute syntax keeps the parameter names visible
  for readers / future implementers and avoids `(void)param;` casts.

- **C4005 macro redefinition (1 raw / 1 site)** —
  `WIN32_LEAN_AND_MEAN` was defined globally via `add_compile_definitions`
  in the top-level `CMakeLists.txt`. The bundled FreeType target redefines
  the macro internally, producing C4005 on its `ftsystem.c`. The macro is
  removed from the global definitions block and instead pushed onto the
  `vigine` and `example-window` targets via
  `target_compile_definitions(... PRIVATE)`. FreeType (added with
  `EXCLUDE_FROM_ALL`) no longer sees the macro on its compile line, the
  warning disappears, and Vigine's TUs still get the lean `<windows.h>`
  treatment.

### Verification (Windows MSVC, VS 18 Insiders v18 / cl 19.50.35722)

- Forced recompile of the six in-scope TUs (`meshcomponent.cpp`,
  `vulkanapi.cpp`, `rendercomponent.cpp`, `rendersystem.cpp`,
  `graphicsservice.cpp`, `external/freetype/.../ftsystem.c`) plus a
  full clean rebuild — **0** `: warning C\d+ :` lines in the entire log.
- Cross-checked Release build (engine library only): **0** warnings.
- `ctest --output-on-failure -j 4` -> **197/197** passed.
- `example-window.exe` launches, renders, and stays alive.

### Out of scope

- `/WX` / `-Werror` flip — that's #292.
- Non-render warnings — none surfaced here, but a follow-up may be needed
  once #292 enables `-Werror` and the CI matrix exercises Linux GCC /
  Linux Clang / macOS Apple Clang. The pilot doc lists the deltas to
  expect (Cocoa branch, XCB branch, etc.).

### Files changed

- `CMakeLists.txt` — drop global `WIN32_LEAN_AND_MEAN`; add target-private push for vigine.
- `example/window/CMakeLists.txt` — target-private `WIN32_LEAN_AND_MEAN` for example-window.
- `include/vigine/ecs/render/meshcomponent.h` — explicit narrowing cast in two accessors.
- `src/ecs/render/rendercomponent.cpp` — `[[maybe_unused]]` on `ensureGlyph(pixelSize)`.
- `src/ecs/render/vulkanapi.cpp` — `[[maybe_unused]]` on three stub method bodies.