### PR TITLE
Consolidate platform CMake into cmake/platform/ + api/platform interfaces (#293)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ list(APPEND CMAKE_MODULE_PATH
 # cmake/platform/<platform>/config.cmake fragment. Each fragment
 # defines three callbacks consumed below: vigine_platform_setup_global,
 # vigine_platform_collect_sources, and vigine_platform_apply_target.
-include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/platform/platform.cmake)
+include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/platform/platform.cmake")
 vigine_platform_setup_global()
 
 # Build FreeType from external submodule.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,30 +37,6 @@ if(MSVC)
     add_compile_options(/FS /utf-8)
 endif()
 
-if(WIN32)
-    # Windows 10+ baseline. Pins every Win32 API surface to the
-    # Windows 10 RTM (NTDDI_WIN10, value 0x0A000000); an older API
-    # accidentally used elsewhere would fail to compile here. Bump
-    # `_WIN32_WINNT` + `NTDDI_VERSION` together when a newer feature
-    # set is needed (e.g. NTDDI_WIN10_VB = 0x0A000008 for 1903+).
-    #
-    # WIN32_LEAN_AND_MEAN is intentionally NOT in this directory-scoped
-    # block: bundled FreeType (`add_subdirectory(... EXCLUDE_FROM_ALL)`)
-    # would otherwise inherit it on its command line and re-define it
-    # internally, producing C4005 macro-redefinition warnings. The
-    # macro is instead pushed onto the `vigine` target only via
-    # `target_compile_definitions(... PRIVATE)` below; the windowed
-    # example applies its own copy in `example/window/CMakeLists.txt`,
-    # and the test executables do not pull `<windows.h>` transitively
-    # so they need no definition.
-    add_compile_definitions(
-        VK_USE_PLATFORM_WIN32_KHR
-        _WIN32_WINNT=0x0A00
-        NTDDI_VERSION=0x0A000000
-        NOMINMAX
-    )
-endif()
-
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
@@ -68,19 +44,20 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 set(SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
-# Set the CMake module path to include shared and platform-specific modules
+# Set the CMake module path to include shared modules. The
+# platform-specific module path is appended by the dispatcher's
+# vigine_platform_setup_global() call below.
 list(APPEND CMAKE_MODULE_PATH
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules
 )
 
-if(APPLE)
-    list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/platform/macos)
-elseif(WIN32)
-    list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/platform/windows)
-elseif(UNIX)
-    list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/platform/linux)
-endif()
+# Platform dispatcher (R-PlatformPortability). Loads exactly one
+# cmake/platform/<platform>/config.cmake fragment. Each fragment
+# defines three callbacks consumed below: vigine_platform_setup_global,
+# vigine_platform_collect_sources, and vigine_platform_apply_target.
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/platform/platform.cmake)
+vigine_platform_setup_global()
 
 # Build FreeType from external submodule.
 # Keep optional compression/shaping deps disabled for a predictable local build.
@@ -111,14 +88,9 @@ find_package(VulkanHpp REQUIRED)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
-# libxcb is required on Linux for XCB window backend + VK_KHR_xcb_surface.
-if(UNIX AND NOT APPLE)
-    find_package(PkgConfig REQUIRED)
-    pkg_check_modules(XCB REQUIRED xcb)
-    if(NOT XCB_FOUND)
-        message(FATAL_ERROR "libxcb not found. Install libxcb-dev (Ubuntu) or libxcb-devel (Fedora).")
-    endif()
-endif()
+# libxcb / XCB discovery is handled by the Linux platform fragment
+# (cmake/platform/linux/config.cmake) loaded via the platform
+# dispatcher above. Other platforms have no XCB dependency.
 
 # Experimental subsystems are gated behind a single opt-in flag so the
 # default build keeps the public surface small. Postgres is the first
@@ -348,18 +320,15 @@ set(SOURCES
     ${SRC_DIR}/messaging/routing/broadcast.cpp
 )
 
-# Add platform-specific surface factory.
+# Add the platform-agnostic SurfaceFactory header. The platform-
+# specific concrete (Win32 / Metal / XCB) is appended via the
+# dispatcher's vigine_platform_collect_sources(HEADER_PLATFORM
+# SOURCES_PLATFORM) call below.
+#
 # The SurfaceFactory abstract base lives in src/ecs/render/ (private)
 # because it is a Vulkan-typed extension point used only by VulkanDevice
 # -- not part of the public, Vulkan-SDK-free engine API.
 list(APPEND SOURCES ${SRC_DIR}/ecs/render/surfacefactory.h)
-if(WIN32)
-    list(APPEND SOURCES ${SRC_DIR}/ecs/render/platform/win32surfacefactory.cpp)
-elseif(APPLE)
-    list(APPEND SOURCES ${SRC_DIR}/ecs/render/platform/metalsurfacefactory.cpp)
-elseif(UNIX)
-    list(APPEND SOURCES ${SRC_DIR}/platform/linux/vulkan_surface_xcb.cpp)
-endif()
 
 # Add source files
 set(HEADER_SERVICE
@@ -498,22 +467,10 @@ set(SOURCES_EVENTSCHEDULER
     ${SRC_DIR}/eventscheduler/itimersource_default.cpp
 )
 
-if(WIN32)
-    list(APPEND SOURCES_EVENTSCHEDULER
-        ${SRC_DIR}/eventscheduler/iossignalsource_win.h
-        ${SRC_DIR}/eventscheduler/iossignalsource_win.cpp
-    )
-elseif(APPLE)
-    list(APPEND SOURCES_EVENTSCHEDULER
-        ${SRC_DIR}/eventscheduler/iossignalsource_macos.h
-        ${SRC_DIR}/eventscheduler/iossignalsource_macos.mm
-    )
-elseif(UNIX)
-    list(APPEND SOURCES_EVENTSCHEDULER
-        ${SRC_DIR}/platform/linux/iossignalsource_posix.h
-        ${SRC_DIR}/platform/linux/iossignalsource_posix.cpp
-    )
-endif()
+# Platform-specific OS-signal source (iossignalsource_*.{h,cpp,mm}) is
+# appended onto SOURCES_PLATFORM via the dispatcher callback below.
+# Keeping it on a single platform list (instead of per-facade) is the
+# R-PlatformPortability shape: each platform has ONE collection point.
 
 # Topic-bus facade (R.3.3.1.3 / plan_17) -- public surface.
 set(HEADER_TOPICBUS
@@ -694,35 +651,13 @@ set(SOURCES_PLATFORM
     ${SRC_DIR}/ecs/platform/windoweventdispatcher.cpp
 )
 
-if(WIN32)
-    list(APPEND HEADER_PLATFORM
-        ${SRC_DIR}/ecs/platform/winapicomponent.h
-    )
-
-    list(APPEND SOURCES_PLATFORM
-        ${SRC_DIR}/ecs/platform/winapicomponent.cpp
-    )
-endif()
-
-if(APPLE)
-    list(APPEND HEADER_PLATFORM
-        ${SRC_DIR}/ecs/platform/cocoawindowcomponent.h
-    )
-
-    list(APPEND SOURCES_PLATFORM
-        ${SRC_DIR}/ecs/platform/cocoawindowcomponent.mm
-    )
-endif()
-
-if(UNIX AND NOT APPLE)
-    list(APPEND HEADER_PLATFORM
-        ${SRC_DIR}/platform/linux/xcbwindowbackend.h
-    )
-
-    list(APPEND SOURCES_PLATFORM
-        ${SRC_DIR}/platform/linux/xcbwindowbackend.cpp
-    )
-endif()
+# Append every platform-specific source / header onto the shared
+# HEADER_PLATFORM / SOURCES_PLATFORM lists. The active platform's
+# fragment (cmake/platform/<X>/config.cmake) decides which surface
+# factory, OS-signal source, and window backend get pulled in. The
+# fragment was loaded by the platform dispatcher near the top of this
+# file.
+vigine_platform_collect_sources(HEADER_PLATFORM SOURCES_PLATFORM)
 
 # add vulkan
 # Add a library
@@ -782,12 +717,14 @@ add_library(${PROJECT_NAME}
 # other vendored dependencies are not affected.
 vigine_apply_compile_options(${PROJECT_NAME})
 
-# WIN32_LEAN_AND_MEAN trims <windows.h>. Scoped to vigine so the bundled
-# FreeType build (which defines the macro internally for its own TUs)
-# does not see it on its compile line and emit C4005 redefinition.
-if(WIN32)
-    target_compile_definitions(${PROJECT_NAME} PRIVATE WIN32_LEAN_AND_MEAN)
-endif()
+# Apply target-scoped platform configuration (compile definitions,
+# include directories, link libraries). On Windows this pushes
+# WIN32_LEAN_AND_MEAN PRIVATE so the bundled FreeType build does not
+# see the macro on its compile line and emit C4005 redefinition. On
+# macOS this links Cocoa / QuartzCore / Metal frameworks. On Linux
+# this pulls in the XCB include path + library discovered by the
+# fragment's setup_global() call.
+vigine_platform_apply_target(${PROJECT_NAME})
 
 # Apply sanitizer flags when VIGINE_SANITIZER is set. Guarded by the same
 # condition used at include-time above so the helper is only called when the
@@ -832,26 +769,9 @@ target_link_libraries(${PROJECT_NAME}
     freetype
 )
 
-if(APPLE)
-    target_link_libraries(${PROJECT_NAME}
-        PRIVATE
-        "-framework Cocoa"
-        "-framework QuartzCore"
-        "-framework Metal"
-    )
-endif()
-
-if(UNIX AND NOT APPLE)
-    target_include_directories(${PROJECT_NAME}
-        PRIVATE
-        ${XCB_INCLUDE_DIRS}
-    )
-
-    target_link_libraries(${PROJECT_NAME}
-        PRIVATE
-        ${XCB_LIBRARIES}
-    )
-endif()
+# Platform-specific framework / include / link wiring lives in
+# cmake/platform/<X>/config.cmake and is applied via
+# vigine_platform_apply_target() above.
 
 # Install the library and headers
 install(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/build/lib)

--- a/cmake/platform/linux/config.cmake
+++ b/cmake/platform/linux/config.cmake
@@ -20,8 +20,11 @@ function(vigine_platform_setup_global)
     set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE)
 
     # libxcb is required for the XCB window backend + VK_KHR_xcb_surface.
+    # The pkg_check_modules() call below intentionally omits REQUIRED
+    # so the manual XCB_FOUND check can emit a hint pointing the
+    # developer at the right system package.
     find_package(PkgConfig REQUIRED)
-    pkg_check_modules(XCB REQUIRED xcb)
+    pkg_check_modules(XCB xcb)
     if(NOT XCB_FOUND)
         message(FATAL_ERROR "libxcb not found. Install libxcb-dev (Ubuntu) or libxcb-devel (Fedora).")
     endif()

--- a/cmake/platform/linux/config.cmake
+++ b/cmake/platform/linux/config.cmake
@@ -1,0 +1,76 @@
+# Linux platform fragment (R-PlatformPortability)
+#
+# Consolidates every Linux-specific block previously scattered through
+# the root CMakeLists.txt. Loaded by cmake/platform/platform.cmake when
+# CMAKE_SYSTEM_NAME == "Linux".
+
+# Cache results of find_package / pkg_check_modules between callbacks
+# so vigine_platform_apply_target can pick up the include / link
+# values that vigine_platform_setup_global discovered.
+set(VIGINE_LINUX_XCB_INCLUDE_DIRS "" CACHE INTERNAL "Linux XCB include dirs")
+set(VIGINE_LINUX_XCB_LIBRARIES "" CACHE INTERNAL "Linux XCB libraries")
+
+# vigine_platform_setup_global
+#
+# Directory-scope state that must land before vigine is added: module
+# path for find_*.cmake helpers, and an XCB discovery so missing
+# system headers fail at configure rather than compile.
+function(vigine_platform_setup_global)
+    list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+    set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE)
+
+    # libxcb is required for the XCB window backend + VK_KHR_xcb_surface.
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(XCB REQUIRED xcb)
+    if(NOT XCB_FOUND)
+        message(FATAL_ERROR "libxcb not found. Install libxcb-dev (Ubuntu) or libxcb-devel (Fedora).")
+    endif()
+
+    # Cache for vigine_platform_apply_target to pick up.
+    set(VIGINE_LINUX_XCB_INCLUDE_DIRS "${XCB_INCLUDE_DIRS}" CACHE INTERNAL "Linux XCB include dirs" FORCE)
+    set(VIGINE_LINUX_XCB_LIBRARIES "${XCB_LIBRARIES}" CACHE INTERNAL "Linux XCB libraries" FORCE)
+endfunction()
+
+# vigine_platform_collect_sources
+#
+# Append Linux-specific source paths onto the caller-named lists. The
+# Vulkan XCB surface factory + the POSIX OS-signal source + the XCB
+# window backend live here.
+function(vigine_platform_collect_sources headers_var sources_var)
+    set(_headers "${${headers_var}}")
+    set(_sources "${${sources_var}}")
+
+    list(APPEND _sources
+        "${SRC_DIR}/platform/linux/vulkan_surface_xcb.cpp"
+        "${SRC_DIR}/platform/linux/iossignalsource_posix.h"
+        "${SRC_DIR}/platform/linux/iossignalsource_posix.cpp"
+    )
+
+    list(APPEND _headers
+        "${SRC_DIR}/platform/linux/xcbwindowbackend.h"
+    )
+
+    list(APPEND _sources
+        "${SRC_DIR}/platform/linux/xcbwindowbackend.cpp"
+    )
+
+    set(${headers_var} "${_headers}" PARENT_SCOPE)
+    set(${sources_var} "${_sources}" PARENT_SCOPE)
+endfunction()
+
+# vigine_platform_apply_target
+#
+# Target-scoped Linux configuration applied to `target` after
+# add_library() has created it. Pulls in the XCB include path + link
+# library that pkg_check_modules discovered above.
+function(vigine_platform_apply_target target)
+    target_include_directories(${target}
+        PRIVATE
+        ${VIGINE_LINUX_XCB_INCLUDE_DIRS}
+    )
+
+    target_link_libraries(${target}
+        PRIVATE
+        ${VIGINE_LINUX_XCB_LIBRARIES}
+    )
+endfunction()

--- a/cmake/platform/macos/config.cmake
+++ b/cmake/platform/macos/config.cmake
@@ -1,0 +1,55 @@
+# macOS platform fragment (R-PlatformPortability)
+#
+# Consolidates every macOS-specific block previously scattered through
+# the root CMakeLists.txt. Loaded by cmake/platform/platform.cmake when
+# CMAKE_SYSTEM_NAME == "Darwin".
+
+# vigine_platform_setup_global
+#
+# Directory-scope state that must land before vigine is added.
+function(vigine_platform_setup_global)
+    list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+    set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE)
+endfunction()
+
+# vigine_platform_collect_sources
+#
+# Append macOS-specific source paths onto the caller-named lists. The
+# Metal-backed Vulkan surface factory + the macOS OS-signal source
+# (Objective-C++ .mm) + the Cocoa window component live here.
+function(vigine_platform_collect_sources headers_var sources_var)
+    set(_headers "${${headers_var}}")
+    set(_sources "${${sources_var}}")
+
+    list(APPEND _sources
+        "${SRC_DIR}/ecs/render/platform/metalsurfacefactory.cpp"
+        "${SRC_DIR}/eventscheduler/iossignalsource_macos.h"
+        "${SRC_DIR}/eventscheduler/iossignalsource_macos.mm"
+    )
+
+    list(APPEND _headers
+        "${SRC_DIR}/ecs/platform/cocoawindowcomponent.h"
+    )
+
+    list(APPEND _sources
+        "${SRC_DIR}/ecs/platform/cocoawindowcomponent.mm"
+    )
+
+    set(${headers_var} "${_headers}" PARENT_SCOPE)
+    set(${sources_var} "${_sources}" PARENT_SCOPE)
+endfunction()
+
+# vigine_platform_apply_target
+#
+# Target-scoped macOS configuration applied to `target` after
+# add_library() has created it. Links the Cocoa / QuartzCore / Metal
+# frameworks consumed by the Cocoa window backend and the Metal
+# surface factory.
+function(vigine_platform_apply_target target)
+    target_link_libraries(${target}
+        PRIVATE
+        "-framework Cocoa"
+        "-framework QuartzCore"
+        "-framework Metal"
+    )
+endfunction()

--- a/cmake/platform/platform.cmake
+++ b/cmake/platform/platform.cmake
@@ -1,0 +1,53 @@
+# Platform dispatcher (R-PlatformPortability)
+#
+# Single entry point for selecting platform-specific CMake fragments.
+# The root CMakeLists.txt includes this file once, early, before
+# defining any compile options that depend on the target OS. The
+# dispatcher resolves ${CMAKE_SYSTEM_NAME} (or honors a user-supplied
+# ${VIGINE_PLATFORM}) and includes EXACTLY ONE
+# cmake/platform/<platform>/config.cmake fragment.
+#
+# Adding a new platform requires only:
+#   1. cmake/platform/<platform>/config.cmake (this dispatcher needs no edit)
+#   2. src/impl/platform/<platform>/ concretes
+#   3. a CI workflow snippet
+#
+# The fragment is expected to define three callbacks consumed by the
+# root CMakeLists.txt:
+#
+#   vigine_platform_setup_global()
+#       Runs immediately. Adjust CMAKE_MODULE_PATH, declare
+#       directory-scope compile definitions, find packages whose
+#       absence is fatal on this platform, etc.
+#
+#   vigine_platform_collect_sources(<headers_list_var> <sources_list_var>)
+#       Append platform-specific header / source paths onto the named
+#       lists. Used to compose the SOURCES_PLATFORM / HEADER_PLATFORM
+#       sets and the platform-specific surface factory + os-signal
+#       source pulled into the vigine target.
+#
+#   vigine_platform_apply_target(<target>)
+#       Apply target-scoped compile definitions, include directories,
+#       and link libraries to the named target (typically `vigine`).
+#       Called after add_library() has produced the target.
+
+if(NOT DEFINED VIGINE_PLATFORM OR VIGINE_PLATFORM STREQUAL "")
+    string(TOLOWER "${CMAKE_SYSTEM_NAME}" _vigine_platform_lower)
+    if(_vigine_platform_lower STREQUAL "darwin")
+        set(VIGINE_PLATFORM "macos")
+    else()
+        set(VIGINE_PLATFORM "${_vigine_platform_lower}")
+    endif()
+endif()
+
+set(_vigine_platform_dir "${CMAKE_CURRENT_LIST_DIR}/${VIGINE_PLATFORM}")
+if(NOT EXISTS "${_vigine_platform_dir}/config.cmake")
+    message(FATAL_ERROR
+        "Unsupported platform: '${CMAKE_SYSTEM_NAME}' (resolved to "
+        "VIGINE_PLATFORM='${VIGINE_PLATFORM}'). No fragment found at "
+        "${_vigine_platform_dir}/config.cmake. Add a new "
+        "cmake/platform/${VIGINE_PLATFORM}/config.cmake to support this platform."
+    )
+endif()
+
+include("${_vigine_platform_dir}/config.cmake")

--- a/cmake/platform/platform.cmake
+++ b/cmake/platform/platform.cmake
@@ -32,12 +32,20 @@
 #       Called after add_library() has produced the target.
 
 if(NOT DEFINED VIGINE_PLATFORM OR VIGINE_PLATFORM STREQUAL "")
-    string(TOLOWER "${CMAKE_SYSTEM_NAME}" _vigine_platform_lower)
-    if(_vigine_platform_lower STREQUAL "darwin")
-        set(VIGINE_PLATFORM "macos")
-    else()
-        set(VIGINE_PLATFORM "${_vigine_platform_lower}")
-    endif()
+    set(VIGINE_PLATFORM "${CMAKE_SYSTEM_NAME}")
+endif()
+
+# Normalise the resolved name regardless of whether it came from the
+# user (-DVIGINE_PLATFORM=Windows) or from CMAKE_SYSTEM_NAME. The
+# fragment lookup below is case-sensitive on POSIX filesystems, so a
+# mixed-case input would fail to resolve cmake/platform/<x>/config.cmake.
+string(TOLOWER "${VIGINE_PLATFORM}" VIGINE_PLATFORM)
+
+# Map well-known aliases onto the canonical fragment-directory names
+# (e.g. CMAKE_SYSTEM_NAME=Darwin -> "macos"). Add new entries here when
+# adopting a new platform.
+if(VIGINE_PLATFORM STREQUAL "darwin")
+    set(VIGINE_PLATFORM "macos")
 endif()
 
 set(_vigine_platform_dir "${CMAKE_CURRENT_LIST_DIR}/${VIGINE_PLATFORM}")

--- a/cmake/platform/windows/config.cmake
+++ b/cmake/platform/windows/config.cmake
@@ -1,0 +1,74 @@
+# Windows platform fragment (R-PlatformPortability)
+#
+# Consolidates every Windows-specific block previously scattered
+# through the root CMakeLists.txt. Loaded by cmake/platform/platform.cmake
+# when CMAKE_SYSTEM_NAME == "Windows".
+
+# vigine_platform_setup_global
+#
+# Directory-scope state that must land BEFORE add_library(vigine ...)
+# is invoked: module path entries used by find_package(Vulkan), and
+# Win32 compile definitions that pin the API surface and disable the
+# legacy <windows.h> min/max macros.
+#
+# WIN32_LEAN_AND_MEAN is intentionally NOT pushed at directory scope:
+# bundled FreeType (added via add_subdirectory ... EXCLUDE_FROM_ALL)
+# would otherwise inherit it on its compile line and re-define the
+# macro internally, producing C4005 macro-redefinition warnings.
+# WIN32_LEAN_AND_MEAN is instead applied target-scoped to vigine in
+# vigine_platform_apply_target() below.
+function(vigine_platform_setup_global)
+    list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+    set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE)
+
+    # Windows 10+ baseline. Pins every Win32 API surface to the
+    # Windows 10 RTM (NTDDI_WIN10, value 0x0A000000); an older API
+    # accidentally used elsewhere would fail to compile here. Bump
+    # `_WIN32_WINNT` + `NTDDI_VERSION` together when a newer feature
+    # set is needed (e.g. NTDDI_WIN10_VB = 0x0A000008 for 1903+).
+    add_compile_definitions(
+        VK_USE_PLATFORM_WIN32_KHR
+        _WIN32_WINNT=0x0A00
+        NTDDI_VERSION=0x0A000000
+        NOMINMAX
+    )
+endfunction()
+
+# vigine_platform_collect_sources
+#
+# Append Windows-specific source paths onto the caller-named lists.
+# Two source families live here:
+#   - the Vulkan WIN32_KHR surface factory under src/ecs/render/platform/,
+#   - the OS signal source under src/eventscheduler/,
+#   - the WinAPI window component under src/ecs/platform/.
+function(vigine_platform_collect_sources headers_var sources_var)
+    set(_headers "${${headers_var}}")
+    set(_sources "${${sources_var}}")
+
+    list(APPEND _sources
+        "${SRC_DIR}/ecs/render/platform/win32surfacefactory.cpp"
+        "${SRC_DIR}/eventscheduler/iossignalsource_win.h"
+        "${SRC_DIR}/eventscheduler/iossignalsource_win.cpp"
+    )
+
+    list(APPEND _headers
+        "${SRC_DIR}/ecs/platform/winapicomponent.h"
+    )
+
+    list(APPEND _sources
+        "${SRC_DIR}/ecs/platform/winapicomponent.cpp"
+    )
+
+    set(${headers_var} "${_headers}" PARENT_SCOPE)
+    set(${sources_var} "${_sources}" PARENT_SCOPE)
+endfunction()
+
+# vigine_platform_apply_target
+#
+# Target-scoped Windows configuration applied to `target` after
+# add_library() has created it. WIN32_LEAN_AND_MEAN is scoped here
+# (PRIVATE) so the bundled FreeType build does not see the macro on
+# its own command line and emit C4005 redefinition.
+function(vigine_platform_apply_target target)
+    target_compile_definitions(${target} PRIVATE WIN32_LEAN_AND_MEAN)
+endfunction()

--- a/include/vigine/api/platform/ifilesystem.h
+++ b/include/vigine/api/platform/ifilesystem.h
@@ -17,6 +17,8 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <limits>
+#include <optional>
 #include <string_view>
 
 namespace vigine
@@ -37,8 +39,14 @@ using FileHandle = std::uint64_t;
 /**
  * @brief Sentinel returned when a file operation cannot produce a
  *        valid handle.
+ *
+ * Concretely the all-ones bit pattern: matches Win32's
+ * @c INVALID_HANDLE_VALUE (cast of (HANDLE)-1) and stays distinct
+ * from every legal POSIX file descriptor (0..INT_MAX). Zero is NOT
+ * used because it is a valid POSIX descriptor (stdin) and a valid
+ * value on platforms whose handles are integer-counted from zero.
  */
-inline constexpr FileHandle kInvalidFileHandle = 0;
+inline constexpr FileHandle kInvalidFileHandle = (std::numeric_limits<FileHandle>::max)();
 
 /**
  * @brief Open mode flag set used by @ref IFileSystem::open.
@@ -91,10 +99,18 @@ class IFileSystem
     /**
      * @brief Read up to @p size bytes from the file into @p buffer.
      *
-     * @return Number of bytes actually read. Zero indicates EOF or
-     *         error; SIZE_MAX is reserved for "operation failed".
+     * EOF and read failures are distinct outcomes:
+     *   - engaged optional carrying value > 0: bytes actually read.
+     *   - engaged optional carrying value 0:    end-of-file (no error).
+     *   - empty optional (@c std::nullopt):     read failed (I/O error,
+     *                                           handle invalid, etc.).
+     *
+     * Concrete @ref IFileSystem implementations must distinguish these
+     * three states so callers can act on EOF without conflating it
+     * with a partial-buffer / I/O-failure case.
      */
-    [[nodiscard]] virtual std::size_t read(FileHandle handle, void *buffer, std::size_t size) = 0;
+    [[nodiscard]] virtual std::optional<std::size_t>
+    read(FileHandle handle, void *buffer, std::size_t size) = 0;
 
     /**
      * @brief Write up to @p size bytes from @p data to the file.

--- a/include/vigine/api/platform/ifilesystem.h
+++ b/include/vigine/api/platform/ifilesystem.h
@@ -1,0 +1,125 @@
+#pragma once
+
+/**
+ * @file ifilesystem.h
+ * @brief Pure-virtual filesystem abstraction (R-PlatformPortability skeleton).
+ *
+ * Pure interface for OS-level file operations. The platform-agnostic
+ * engine consumes file I/O exclusively through @ref IFileSystem; per-
+ * platform concretes live under @c src/impl/platform/<X>/ and ship
+ * the actual Win32 / POSIX / mobile-runtime backends.
+ *
+ * INV-10 compliance: the @c I prefix marks a pure-virtual interface
+ * with no state and no non-virtual method bodies. A future
+ * @c AbstractFileSystem may carry shared helpers; this file is the
+ * thin contract.
+ */
+
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+
+namespace vigine
+{
+namespace platform
+{
+
+/**
+ * @brief Opaque handle returned by @ref IFileSystem::open.
+ *
+ * The concrete value is platform-defined (Win32 HANDLE, POSIX file
+ * descriptor, etc.) and only meaningful inside the matching
+ * @ref IFileSystem implementation. Callers treat it as an opaque
+ * token and pass it back to the same @ref IFileSystem instance.
+ */
+using FileHandle = std::uint64_t;
+
+/**
+ * @brief Sentinel returned when a file operation cannot produce a
+ *        valid handle.
+ */
+inline constexpr FileHandle kInvalidFileHandle = 0;
+
+/**
+ * @brief Open mode flag set used by @ref IFileSystem::open.
+ *
+ * Bit-flag encoding so multiple modes can be combined (e.g.
+ * @c Read | @c Write). Concrete implementations translate the flags
+ * to the matching OS-level constants.
+ */
+enum OpenMode : unsigned int
+{
+    OpenModeRead   = 1u << 0,
+    OpenModeWrite  = 1u << 1,
+    OpenModeAppend = 1u << 2,
+    OpenModeCreate = 1u << 3,
+    OpenModeBinary = 1u << 4,
+};
+
+/**
+ * @brief Pure-virtual root interface for filesystem access.
+ *
+ * The contract is intentionally narrow. Each method maps to one
+ * common OS primitive (open, close, read, write, exists). Higher-
+ * level helpers (path manipulation, recursive walks, etc.) belong on
+ * a future @c AbstractFileSystem helper base, not on this interface.
+ */
+class IFileSystem
+{
+  public:
+    virtual ~IFileSystem() = default;
+
+    /**
+     * @brief Open a file with the given mode flags.
+     *
+     * @param path  UTF-8 file path. The implementation is responsible
+     *              for converting to the platform-native encoding.
+     * @param flags Bit-or of @ref OpenMode values.
+     * @return Opaque handle on success; @ref kInvalidFileHandle on
+     *         failure.
+     */
+    [[nodiscard]] virtual FileHandle open(std::string_view path, unsigned int flags) = 0;
+
+    /**
+     * @brief Close a previously-opened file handle.
+     *
+     * @return true on success; false if the handle was already closed
+     *         or never valid.
+     */
+    virtual bool close(FileHandle handle) = 0;
+
+    /**
+     * @brief Read up to @p size bytes from the file into @p buffer.
+     *
+     * @return Number of bytes actually read. Zero indicates EOF or
+     *         error; SIZE_MAX is reserved for "operation failed".
+     */
+    [[nodiscard]] virtual std::size_t read(FileHandle handle, void *buffer, std::size_t size) = 0;
+
+    /**
+     * @brief Write up to @p size bytes from @p data to the file.
+     *
+     * @return Number of bytes actually written. Less than @p size
+     *         indicates a short write (disk full, pipe closed, etc.).
+     */
+    [[nodiscard]] virtual std::size_t write(FileHandle handle, const void *data, std::size_t size) = 0;
+
+    /**
+     * @brief Check whether a file exists at @p path.
+     *
+     * Does not open the file. Symbolic-link resolution is platform-
+     * defined; concretes may diverge here.
+     */
+    [[nodiscard]] virtual bool exists(std::string_view path) const = 0;
+
+    IFileSystem(const IFileSystem &)            = delete;
+    IFileSystem &operator=(const IFileSystem &) = delete;
+    IFileSystem(IFileSystem &&)                 = delete;
+    IFileSystem &operator=(IFileSystem &&)      = delete;
+
+  protected:
+    IFileSystem() = default;
+};
+
+} // namespace platform
+} // namespace vigine

--- a/include/vigine/api/platform/igraphicsbackend.h
+++ b/include/vigine/api/platform/igraphicsbackend.h
@@ -1,0 +1,92 @@
+#pragma once
+
+/**
+ * @file igraphicsbackend.h
+ * @brief Pure-virtual platform graphics-backend abstraction (R-PlatformPortability skeleton).
+ *
+ * Lower-level platform graphics-context interface. Distinct from
+ * @c include/vigine/ecs/render/graphicsbackend.h
+ * (@c vigine::graphics::GraphicsBackend), which is the ECS rendering-
+ * side abstraction over draw calls / pipelines / buffers / textures.
+ *
+ * Two layers, two responsibilities:
+ *
+ *   - @ref IGraphicsBackend (this file) selects the platform graphics
+ *     API (Vulkan vs Metal vs D3D vs WebGPU) and reports whether the
+ *     selected backend is available on the running host. It is the
+ *     CPU-side platform-graphics-context selector.
+ *   - @c vigine::graphics::GraphicsBackend (ECS side, from #280) is
+ *     the rendering-side draw-call surface used by the ECS render
+ *     system once a backend has been picked.
+ *
+ * TODO(#293): Reconcile with @c include/vigine/ecs/render/graphicsbackend.h
+ * once the platform concretes land in @c src/impl/platform/<X>/. A
+ * follow-up leaf will decide whether one wraps the other, or whether
+ * the platform side feeds metadata into the ECS side.
+ *
+ * INV-10 compliance: the @c I prefix marks a pure-virtual interface
+ * with no state and no non-virtual method bodies.
+ */
+
+#include <cstdint>
+
+namespace vigine
+{
+namespace platform
+{
+
+/**
+ * @brief Identifier for a platform graphics backend.
+ *
+ * The set of values is open-ended; future platforms (Android Vulkan,
+ * iOS Metal, WebGPU) extend it without breaking existing concretes.
+ */
+enum class GraphicsBackendKind : std::uint8_t
+{
+    Unknown = 0,
+    Vulkan,  ///< Desktop Vulkan (Linux, Windows, macOS-via-MoltenVK).
+    Metal,   ///< Native macOS / iOS Metal.
+    D3D12,   ///< Direct3D 12 (Windows-only).
+    WebGPU,  ///< WebGPU (browser / Wasm).
+};
+
+/**
+ * @brief Pure-virtual root interface for platform graphics-backend selection.
+ *
+ * The contract is intentionally narrow: report which backend kind
+ * this concrete implements, and whether it is currently usable on
+ * the running host (driver present, SDK loaded, runtime API version
+ * sufficient, etc.). Higher-level rendering operations live on the
+ * ECS-side @c vigine::graphics::GraphicsBackend interface.
+ */
+class IGraphicsBackend
+{
+  public:
+    virtual ~IGraphicsBackend() = default;
+
+    /**
+     * @brief Identifier for the platform graphics backend that this
+     *        concrete implements.
+     */
+    [[nodiscard]] virtual GraphicsBackendKind kind() const noexcept = 0;
+
+    /**
+     * @brief Whether the backend is available on the running host.
+     *
+     * Returns false when, e.g., a Vulkan ICD is missing, the Metal
+     * device is not present, or a D3D12 feature level is too low.
+     * Concrete implementations are responsible for the runtime probe.
+     */
+    [[nodiscard]] virtual bool isAvailable() const = 0;
+
+    IGraphicsBackend(const IGraphicsBackend &)            = delete;
+    IGraphicsBackend &operator=(const IGraphicsBackend &) = delete;
+    IGraphicsBackend(IGraphicsBackend &&)                 = delete;
+    IGraphicsBackend &operator=(IGraphicsBackend &&)      = delete;
+
+  protected:
+    IGraphicsBackend() = default;
+};
+
+} // namespace platform
+} // namespace vigine

--- a/include/vigine/api/platform/iwindowsystem.h
+++ b/include/vigine/api/platform/iwindowsystem.h
@@ -1,0 +1,126 @@
+#pragma once
+
+/**
+ * @file iwindowsystem.h
+ * @brief Pure-virtual platform window-system abstraction (R-PlatformPortability skeleton).
+ *
+ * Engine-side window-system interface. Distinct from
+ * @c api/ecs/platform/iwindoweventhandler.h, which is the ECS-
+ * subscriber side of the same data flow:
+ *
+ *   - @ref IWindowSystem (this file) abstracts the per-platform
+ *     window-system primitive: creating native windows, polling /
+ *     pumping the event queue, querying display metrics. CPU-side,
+ *     pre-ECS.
+ *   - @c IWindowEventHandlerComponent (ECS side) is the consumer
+ *     callback registered against a specific window component once a
+ *     window has been created and bound to an entity.
+ *
+ * TODO(#293): Reconcile with @c api/ecs/platform/iwindoweventhandler.h
+ * once the platform-side concretes (Win32 / Linux XCB / macOS Cocoa)
+ * land in @c src/impl/platform/<X>/. A follow-up leaf will decide
+ * whether one delegates to the other or they merge.
+ *
+ * INV-10 compliance: the @c I prefix marks a pure-virtual interface
+ * with no state and no non-virtual method bodies.
+ */
+
+#include <cstdint>
+#include <string_view>
+
+namespace vigine
+{
+namespace platform
+{
+
+/**
+ * @brief Opaque handle for a native OS window.
+ *
+ * The concrete value is platform-defined (HWND on Win32, xcb_window_t
+ * on Linux, NSWindow* on macOS). Public callers treat it as an opaque
+ * token and pass it back to the same @ref IWindowSystem instance.
+ */
+using NativeWindowHandle = std::uintptr_t;
+
+/**
+ * @brief Sentinel returned when a window cannot be created.
+ */
+inline constexpr NativeWindowHandle kInvalidWindowHandle = 0;
+
+/**
+ * @brief Initial-creation parameters for a platform window.
+ *
+ * Plain-data descriptor. The @c title pointer must remain valid for
+ * the duration of the @ref IWindowSystem::createWindow call; the
+ * implementation is responsible for any persistent copy.
+ */
+struct WindowDesc
+{
+    std::string_view title;
+    int width{0};
+    int height{0};
+    int x{0};
+    int y{0};
+    bool resizable{true};
+    bool visible{true};
+};
+
+/**
+ * @brief Pure-virtual root interface for the platform window system.
+ *
+ * The contract is intentionally narrow: create / destroy windows,
+ * pump the OS event queue, and report whether the system is alive
+ * (i.e. has not received a quit signal). Per-platform concretes
+ * implement these against the OS-level window-system primitive.
+ */
+class IWindowSystem
+{
+  public:
+    virtual ~IWindowSystem() = default;
+
+    /**
+     * @brief Create a native window matching the given descriptor.
+     *
+     * @return Opaque handle on success; @ref kInvalidWindowHandle on
+     *         failure.
+     */
+    [[nodiscard]] virtual NativeWindowHandle createWindow(const WindowDesc &desc) = 0;
+
+    /**
+     * @brief Destroy a previously-created window.
+     *
+     * @return true on success; false if the handle was already
+     *         destroyed or never valid.
+     */
+    virtual bool destroyWindow(NativeWindowHandle handle) = 0;
+
+    /**
+     * @brief Pump pending OS events from the event queue.
+     *
+     * Returns immediately whether or not events were available. The
+     * implementation dispatches each event to the appropriate
+     * subscriber path (e.g.
+     * @c IWindowEventHandlerComponent on the ECS side).
+     */
+    virtual void pollEvents() = 0;
+
+    /**
+     * @brief Whether the window system is still alive.
+     *
+     * Returns false once the OS has signalled application quit (e.g.
+     * the user closed the last window, the system requested a
+     * shutdown).
+     */
+    [[nodiscard]] virtual bool isAlive() const = 0;
+
+    IWindowSystem(const IWindowSystem &)            = delete;
+    IWindowSystem &operator=(const IWindowSystem &) = delete;
+    IWindowSystem(IWindowSystem &&)                 = delete;
+    IWindowSystem &operator=(IWindowSystem &&)      = delete;
+
+  protected:
+    IWindowSystem() = default;
+};
+
+} // namespace platform
+} // namespace vigine

--- a/include/vigine/ecs/platform/iwindoweventhandler.h
+++ b/include/vigine/ecs/platform/iwindoweventhandler.h
@@ -64,6 +64,14 @@ struct TextEvent
  * component. Implementers receive window lifecycle notifications,
  * mouse events (move / wheel / button / enter / leave), and keyboard
  * events (key down / up, character, dead-key).
+ *
+ * @note TODO(#293): The lower-level platform window primitive (window
+ * creation, OS event-queue pumping, native-handle management) lives
+ * on @c vigine::platform::IWindowSystem in
+ * @c include/vigine/api/platform/iwindowsystem.h. This ECS-side
+ * @c IWindowEventHandlerComponent is the consumer callback registered
+ * against a specific window component once the platform side has
+ * created the window. A follow-up leaf will reconcile the two layers.
  */
 class IWindowEventHandlerComponent
 {

--- a/include/vigine/ecs/render/graphicsbackend.h
+++ b/include/vigine/ecs/render/graphicsbackend.h
@@ -18,6 +18,15 @@ namespace graphics
  * Provides a platform-agnostic API for graphics operations.
  * Implementations (e.g., VulkanAPI) handle backend-specific details.
  * This interface supports hot-swapping graphics backends (Vulkan, DirectX, Metal, etc.).
+ *
+ * @note TODO(#293): A separate @c vigine::platform::IGraphicsBackend
+ * lives in @c include/vigine/api/platform/igraphicsbackend.h as the
+ * lower-level platform-graphics-context selector (Vulkan vs Metal vs
+ * D3D vs WebGPU vs availability-probe). This ECS-side
+ * @c vigine::graphics::GraphicsBackend is the rendering surface used
+ * by the ECS render system after a platform backend has been picked.
+ * A follow-up leaf will reconcile the two layers (delegate /
+ * compose / or merge).
  */
 class GraphicsBackend
 {

--- a/src/impl/platform/linux/.gitkeep
+++ b/src/impl/platform/linux/.gitkeep
@@ -1,0 +1,6 @@
+# Linux platform-implementation folder (R-PlatformPortability).
+#
+# Placeholder marker. Concrete classes (vigine::platform::FileSystem,
+# vigine::platform::WindowSystem, vigine::platform::GraphicsBackend)
+# implementing the api/platform/I*.h interfaces land here in follow-
+# up leaves. Compiled only when CMAKE_SYSTEM_NAME == "Linux".

--- a/src/impl/platform/macos/.gitkeep
+++ b/src/impl/platform/macos/.gitkeep
@@ -1,0 +1,6 @@
+# macOS platform-implementation folder (R-PlatformPortability).
+#
+# Placeholder marker. Concrete classes (vigine::platform::FileSystem,
+# vigine::platform::WindowSystem, vigine::platform::GraphicsBackend)
+# implementing the api/platform/I*.h interfaces land here in follow-
+# up leaves. Compiled only when CMAKE_SYSTEM_NAME == "Darwin".

--- a/src/impl/platform/win32/.gitkeep
+++ b/src/impl/platform/win32/.gitkeep
@@ -1,0 +1,6 @@
+# Win32 platform-implementation folder (R-PlatformPortability).
+#
+# Placeholder marker. Concrete classes (vigine::platform::FileSystem,
+# vigine::platform::WindowSystem, vigine::platform::GraphicsBackend)
+# implementing the api/platform/I*.h interfaces land here in follow-
+# up leaves. Compiled only when CMAKE_SYSTEM_NAME == "Windows".


### PR DESCRIPTION
Closes #293.

## Summary

Moves all platform-conditional blocks from root CMakeLists.txt into per-platform fragments under cmake/platform/{windows,linux,macos}/config.cmake. Adds dispatcher cmake/platform/platform.cmake which resolves CMAKE_SYSTEM_NAME (or honors VIGINE_PLATFORM override) and includes exactly one fragment.

Each fragment defines three callbacks consumed by the root: vigine_platform_setup_global (directory-scope state), vigine_platform_collect_sources (appends platform-specific sources/headers onto HEADER_PLATFORM/SOURCES_PLATFORM), and vigine_platform_apply_target (target-scoped compile defs / include dirs / link libs).

Adds api/platform/ pure-virtual skeleton interfaces (IFileSystem, IWindowSystem, IGraphicsBackend) plus src/impl/platform/{win32,linux,macos}/ stubs (.gitkeep markers — concretes land in follow-up leaves).

Adds TODO(#293) reconciliation notes in the existing api/ecs/platform/iwindoweventhandler.h and api/ecs/render/graphicsbackend.h pointing at their lower-level platform counterparts.

## R-PlatformPortability

Adding a new platform is now 3 files: cmake/platform/<X>/config.cmake + src/impl/platform/<X>/ + a CI workflow snippet. Zero engine-core changes — the dispatcher resolves the new fragment automatically as long as CMAKE_SYSTEM_NAME maps to the new directory name.

Root CMakeLists.txt is platform-conditional-block-free: zero if(WIN32) / if(APPLE) / if(UNIX) blocks remain. The MSVC compile-flag block (/FS /utf-8) stayed at root because it is compiler-specific (MSVC vs GCC vs Clang), not platform-specific (Windows vs Linux vs macOS) — engineer judgement call.

## Tests

- ctest: 197/197 passed (windows-debug preset, ENABLE_UNITTEST + BUILD_EXAMPLE_THREADED_BUS + BUILD_EXAMPLE_PARALLEL_FSM).
- example-parallel-fsm: 100/100 exchanges.
- example-threaded-bus: 800/800 received, 0 reentry violations.