### PR TITLE
Delete scenario_01 LegacyEngineLifecycle test (#285)

### DIFF
--- a/test/contract/scenario_01_engine_lifecycle.cpp
+++ b/test/contract/scenario_01_engine_lifecycle.cpp
@@ -17,7 +17,6 @@
 #include "vigine/statemachine/istatemachine.h"
 #include "vigine/taskflow/itaskflow.h"
 #include "vigine/core/threading/ithreadmanager.h"
-#include "vigine/vigine.h"
 
 #include <gtest/gtest.h>
 
@@ -74,24 +73,6 @@ TEST_F(EngineLifecycle, FreezeTogglesTopologyFlag)
     // Second freeze must be idempotent.
     ctx.freeze();
     EXPECT_TRUE(ctx.isFrozen());
-}
-
-// Legacy vigine::Engine front door: confirms the engine ctor plumbs a
-// real IThreadManager into its Context. Before the wiring change,
-// Context::threadManager threw std::logic_error, which silently broke
-// TaskFlow::signal's non-default-affinity path for every caller that
-// instantiated Engine directly.
-TEST(LegacyEngineLifecycle, ConstructionPlumbsThreadManagerIntoContext)
-{
-    vigine::Engine engine;
-
-    auto &ctx = engine.context();
-    ASSERT_NO_THROW({
-        auto &tm = ctx.threadManager();
-        EXPECT_GE(tm.poolSize(), 1u)
-            << "legacy engine must plumb a thread manager whose pool "
-            << "carries at least one worker";
-    });
 }
 
 } // namespace


### PR DESCRIPTION
Closes #285.

## Summary

Per architect Q-C5: deletes the legacy LegacyEngineLifecycle test block from `test/contract/scenario_01_engine_lifecycle.cpp`. The two surrounding modern `TEST_F(EngineLifecycle, ...)` cases that exercise the same plumbing through `IContext` are preserved.

## Note on legacy concretes

The deletion targets the TEST block, not the legacy concretes themselves. `vigine::Engine` / `vigine::Context` (root-namespace) still exist in `include/vigine/vigine.h` + `src/vigine.cpp` as a deprecated compatibility surface. The modern fixture-based tests cover the same engine-lifetime invariants via `vigine::engine::Engine` / `vigine::context::Context`. Q-C5 architect default decision: delete the test, leave the deprecated surface for a separate follow-up cleanup leaf.

## Tests

- ctest count: 196/196 (was 197 before; deletion of one case)
- Build: 272/272 windows-debug + ENABLE_UNITTEST + both examples
- Demos: parallel-fsm 100/100, threaded-bus 800/800, 0 reentry violations