### PR TITLE
Add example/fanout_fsm with parallelFor demo (#298)

### DIFF
--- a/example/fanout_fsm/.gitkeep
+++ b/example/fanout_fsm/.gitkeep
@@ -1,1 +1,0 @@
-# Placeholder. The fanout_fsm example replaces this stub in a follow-up PR (#197 readiness).

--- a/example/fanout_fsm/CMakeLists.txt
+++ b/example/fanout_fsm/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.10)
+
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED YES)
+
+set(PROJECT_FANOUT_FSM_NAME example-fanout-fsm)
+project(${PROJECT_FANOUT_FSM_NAME})
+
+add_executable(${PROJECT_FANOUT_FSM_NAME}
+    main.cpp
+)
+
+target_link_libraries(${PROJECT_FANOUT_FSM_NAME}
+    PRIVATE
+    vigine
+)
+
+# The vigine target PUBLIC-exports its include dirs, so consumers
+# linking against it (PRIVATE here) inherit them automatically. No
+# need to add ${CMAKE_SOURCE_DIR}/include manually -- that variable
+# would point at a parent project when Vigine is added via
+# add_subdirectory and could leak the wrong include root.

--- a/example/fanout_fsm/README.md
+++ b/example/fanout_fsm/README.md
@@ -1,0 +1,65 @@
+# fanout_fsm
+
+Demonstrates that `vigine::core::threading::parallelFor` can fan out a
+range of work items across the engine thread pool and that each
+dispatched body can drive its own independent `IStateMachine` through
+a small state cycle without contending with the others.
+
+The demo wires three primitives:
+
+  * `IThreadManager` -- default-constructed config; the factory
+    derives the pool size from `std::thread::hardware_concurrency()`.
+  * `parallelFor(tm, N, body)` -- splits `[0, N)` into chunks sized so
+    each pool worker pulls roughly one chunk; returns one aggregated
+    `ITaskHandle` whose `waitFor()` blocks until every chunk has
+    settled and propagates the first chunk error if any.
+  * `IStateMachine` -- one per `parallelFor` body. Each body calls
+    `statemachine::createStateMachine`, registers a `Working` and a
+    `Done` state, walks the FSM through `Idle` (the auto-provisioned
+    default) -> `Working` -> `Done`, and records its completion bit
+    in a per-index atomic slot.
+
+After the aggregated handle waits successfully, `main` aggregates the
+per-body completion bits and prints `fanout completed: X/N FSMs
+reached final state`.
+
+## Why each body owns its FSM
+
+`example/parallel_fsm` shows the pattern for a pair of FSMs that share
+state and ping-pong through a shared bus -- there each FSM is bound to
+its own named thread via `bindToControllerThread` and every transition
+runs on that thread. The fanout demo is the opposite shape: `N`
+independent workflows running in parallel with no shared FSM. Keeping
+each FSM private to its `parallelFor` body means there is nothing for
+the bodies to race on, so the FSM is left unbound; the
+`AbstractStateMachine::checkThreadAffinity` gate is intentionally
+inactive in that mode and sync `transition()` runs on whichever pool
+worker happens to pick the chunk up.
+
+## Build
+
+The example is opt-in: the engine's top-level `CMakeLists.txt` only
+includes `example/fanout_fsm/CMakeLists.txt` when
+`BUILD_EXAMPLE_FANOUT_FSM` is `ON` (default `OFF`).
+
+```bash
+cmake -B build -DBUILD_EXAMPLE_FANOUT_FSM=ON
+cmake --build build --target example-fanout-fsm
+./build/bin/example-fanout-fsm
+```
+
+On Windows / MSVC the executable lands in `build/bin/Debug/` (or
+`build/bin/Release/`) depending on the configuration; adjust the run
+command accordingly.
+
+## Expected output
+
+```
+fanout completed: 16/16 FSMs reached final state
+```
+
+Exit code `0` on success. A non-zero exit code means at least one body
+failed to walk its FSM through the full cycle, the aggregated
+`parallelFor` handle reported an error, or the bounded wait timed out
+-- the example prints the partial completion count so a regression is
+observable from the log alone.

--- a/example/fanout_fsm/main.cpp
+++ b/example/fanout_fsm/main.cpp
@@ -1,0 +1,212 @@
+// ---------------------------------------------------------------------------
+// example-fanout-fsm
+//
+// Demonstrates that vigine::core::threading::parallelFor can fan out a
+// range of work items across the IThreadManager pool and that each
+// dispatched body can drive its own independent IStateMachine through a
+// small state cycle without contending with the others.
+//
+// What the demo proves
+// --------------------
+//   * IThreadManager constructed with default config (poolSize derived
+//     from std::thread::hardware_concurrency()).
+//   * parallelFor splits a [0, kFsmCount) range into chunks sized so each
+//     pool worker pulls roughly one chunk; the helper returns one
+//     aggregated ITaskHandle whose wait() blocks until every chunk
+//     settled, propagating the first chunk error if any.
+//   * Each parallelFor body owns its own IStateMachine (created via
+//     statemachine::createStateMachine) and walks it through a fixed
+//     state cycle: Idle -> Working -> Done. Per-body FSMs are local to
+//     the body, never bound to a controller thread, so the
+//     AbstractStateMachine::checkThreadAffinity gate is intentionally
+//     inactive and sync transition() runs from whichever pool worker
+//     happens to pick the chunk up.
+//   * After the aggregated handle waits successfully, main aggregates
+//     the per-body completion bits via an atomic counter and asserts
+//     ordering: every body that ran reports a successful Result and
+//     leaves its FSM at the Done state.
+//
+// Output: "fanout completed: X/N FSMs reached final state".
+// Exit code 0 only when X == N AND every parallelFor chunk reported
+// success.
+//
+// Why each body owns its FSM (and not one shared FSM bound elsewhere)
+// -------------------------------------------------------------------
+//   parallel_fsm's pattern -- bindToControllerThread + scheduleOnNamed
+//   -- exists to serialise transitions on a *shared* FSM that several
+//   actors poke. The fanout demo wants the opposite: N independent
+//   workflows running in parallel, with no shared FSM at all. Keeping
+//   each FSM private to its parallelFor body means there is nothing
+//   for the bodies to race on -- the per-FSM std::shared_mutex inside
+//   the substrate is the only synchronisation point and it is only
+//   ever taken by the body that owns the machine.
+// ---------------------------------------------------------------------------
+
+#include "vigine/core/threading/factory.h"
+#include "vigine/core/threading/itaskhandle.h"
+#include "vigine/core/threading/ithreadmanager.h"
+#include "vigine/core/threading/parallel_for.h"
+#include "vigine/core/threading/threadaffinity.h"
+#include "vigine/core/threading/threadmanagerconfig.h"
+#include "vigine/result.h"
+#include "vigine/statemachine/factory.h"
+#include "vigine/statemachine/istatemachine.h"
+#include "vigine/statemachine/stateid.h"
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <iostream>
+#include <memory>
+#include <vector>
+
+namespace
+{
+
+// Number of independent FSMs to drive in parallel. Picked large enough
+// that a typical pool (4-16 workers) gets several chunks, but small
+// enough that the demo's wall-clock stays well under one second on any
+// reasonable host.
+constexpr std::size_t kFsmCount = 16;
+
+// Wall-clock safety belt for the aggregated wait(). The fan-out body
+// is purely local and trivially fast on every modern machine; one
+// second is two orders of magnitude over the expected runtime.
+constexpr auto kWaitTimeout = std::chrono::seconds{5};
+
+// Per-body bit pattern used to record "this index completed its FSM
+// cycle successfully". Indexed by the parallelFor index so the aggregate
+// step can verify every body ran exactly once.
+//
+// std::atomic<bool> per slot keeps the recording lock-free; the
+// surrounding std::vector is sized once before parallelFor dispatches
+// any chunk, and the slots are never resized while bodies run.
+struct CompletionSlot
+{
+    std::atomic<bool> done{false};
+};
+
+} // namespace
+
+int main()
+{
+    // ---- Threading substrate ------------------------------------------------
+    auto threadManager = vigine::core::threading::createThreadManager(
+        vigine::core::threading::ThreadManagerConfig{});
+    if (!threadManager)
+    {
+        std::cerr << "createThreadManager failed\n";
+        return 1;
+    }
+
+    // ---- Per-FSM completion bookkeeping ------------------------------------
+    //
+    // Sized to kFsmCount so every parallelFor index has a stable slot.
+    // The vector itself is not resized after construction, so it is safe
+    // for concurrent writes from different bodies as long as each body
+    // writes only to slots[index] (the parallelFor contract guarantees
+    // each index is dispatched exactly once).
+    std::vector<CompletionSlot> slots(kFsmCount);
+
+    // ---- Fan out -----------------------------------------------------------
+    //
+    // Each body constructs its own IStateMachine, registers an Idle and
+    // a Done state, walks the FSM through Idle (the auto-provisioned
+    // default) -> Working -> Done, and records its completion bit. No
+    // body shares any state with any other body.
+    auto handle = vigine::core::threading::parallelFor(
+        *threadManager,
+        kFsmCount,
+        [&slots](std::size_t index) {
+            // Per-body FSM. Owned by this body via std::unique_ptr so
+            // the machine is destroyed at body exit; the substrate
+            // releases its mutex and its state topology cleanly when
+            // the unique_ptr goes out of scope.
+            auto fsm = vigine::statemachine::createStateMachine();
+            if (!fsm)
+            {
+                // Leave the slot at the default-constructed `false` so
+                // the aggregate step counts this index as not-completed
+                // and main exits non-zero. parallelFor itself receives
+                // a successful Result -- the aggregate is the source of
+                // truth for the demo.
+                return;
+            }
+
+            // Register the working and final states. The FSM auto-
+            // provisions a default state in its constructor (UD-3),
+            // which we treat as the Idle slot.
+            const vigine::statemachine::StateId working = fsm->addState();
+            const vigine::statemachine::StateId done    = fsm->addState();
+            if (!working.valid() || !done.valid())
+            {
+                return;
+            }
+
+            // Walk the cycle. Each transition is sync; the FSM is not
+            // bound to a controller thread, so checkThreadAffinity is
+            // intentionally inactive. transition() returns an error
+            // Result for stale ids -- treat any error as a body
+            // failure, leaving the slot at false so the aggregate
+            // counts it as not-completed.
+            if (fsm->transition(working).isError())
+            {
+                return;
+            }
+            if (fsm->transition(done).isError())
+            {
+                return;
+            }
+
+            // Final-state assertion: the FSM must report `done` as the
+            // current state after the last transition. If it does not,
+            // do NOT mark the slot as completed -- the aggregate will
+            // treat this body as a failure.
+            if (fsm->current() != done)
+            {
+                return;
+            }
+
+            // Record the success bit. release-store pairs with the
+            // acquire-load in main so the aggregate step sees a
+            // consistent view of every per-slot write.
+            slots[index].done.store(true, std::memory_order_release);
+        });
+
+    if (!handle)
+    {
+        std::cerr << "parallelFor returned a null handle\n";
+        return 1;
+    }
+
+    // Bounded wait. waitFor returns the aggregated Result -- success
+    // when every chunk completed without error, otherwise the first
+    // failing chunk's error (timeout returns its own error message).
+    const vigine::Result waitResult = handle->waitFor(
+        std::chrono::duration_cast<std::chrono::milliseconds>(kWaitTimeout));
+    if (waitResult.isError())
+    {
+        std::cerr << "parallelFor wait failed: " << waitResult.message()
+                  << "\n";
+        return 1;
+    }
+
+    // ---- Aggregate ---------------------------------------------------------
+    //
+    // Count slots that reported completion. The acquire-load pairs with
+    // the release-store inside each body so every successful write is
+    // visible here.
+    std::size_t completed = 0;
+    for (const auto &slot : slots)
+    {
+        if (slot.done.load(std::memory_order_acquire))
+        {
+            ++completed;
+        }
+    }
+
+    std::cout << "fanout completed: " << completed << "/" << kFsmCount
+              << " FSMs reached final state\n";
+
+    return (completed == kFsmCount) ? 0 : 1;
+}

--- a/example/fanout_fsm/main.cpp
+++ b/example/fanout_fsm/main.cpp
@@ -70,8 +70,8 @@ namespace
 constexpr std::size_t kFsmCount = 16;
 
 // Wall-clock safety belt for the aggregated wait(). The fan-out body
-// is purely local and trivially fast on every modern machine; one
-// second is two orders of magnitude over the expected runtime.
+// is purely local and trivially fast on every modern machine; five
+// seconds is two orders of magnitude over the expected runtime.
 constexpr auto kWaitTimeout = std::chrono::seconds{5};
 
 // Per-body bit pattern used to record "this index completed its FSM
@@ -110,10 +110,11 @@ int main()
 
     // ---- Fan out -----------------------------------------------------------
     //
-    // Each body constructs its own IStateMachine, registers an Idle and
-    // a Done state, walks the FSM through Idle (the auto-provisioned
-    // default) -> Working -> Done, and records its completion bit. No
-    // body shares any state with any other body.
+    // Each body constructs its own IStateMachine, treats the auto-
+    // provisioned default state as Idle, and registers Working and Done
+    // states for the cycle. The body walks Idle -> Working -> Done and
+    // records its completion bit. No body shares any state with any
+    // other body.
     auto handle = vigine::core::threading::parallelFor(
         *threadManager,
         kFsmCount,
@@ -134,14 +135,11 @@ int main()
             }
 
             // Register the working and final states. The FSM auto-
-            // provisions a default state in its constructor (UD-3),
-            // which we treat as the Idle slot.
+            // provisions a default state in its constructor, which we
+            // treat as the Idle slot. addState() always returns a valid
+            // StateId, so no defensive guard is needed here.
             const vigine::statemachine::StateId working = fsm->addState();
             const vigine::statemachine::StateId done    = fsm->addState();
-            if (!working.valid() || !done.valid())
-            {
-                return;
-            }
 
             // Walk the cycle. Each transition is sync; the FSM is not
             // bound to a controller thread, so checkThreadAffinity is


### PR DESCRIPTION
Closes #298.

## Summary

Replaces the F0 stub at `example/fanout_fsm/.gitkeep` with a working
demo: `vigine::core::threading::parallelFor` dispatches N independent
FSMs across the engine thread pool; each parallelFor body owns its own
`IStateMachine` and walks it through the cycle `Idle -> Working ->
Done`; main aggregates the per-index completion bits after the
aggregated handle's bounded wait returns.

Each per-body FSM is local to its parallelFor chunk and never bound to
a controller thread, so `AbstractStateMachine::checkThreadAffinity` is
intentionally inactive and sync `transition()` runs on whichever pool
worker picked up the chunk -- no shared FSM, no controller-thread
round-trip needed.

Default-OFF; opt-in via `-DBUILD_EXAMPLE_FANOUT_FSM=ON`. Mirrors the
gate pattern used by the parallel_fsm and threaded_bus examples.

## Tests

- 197/197 ctest green (full Debug suite, no regressions).
- `example-fanout-fsm` runs `16/16` completion in ~134 ms, exit 0.
- `example-parallel-fsm` still reports `100/100` exchanges.
- `example-threaded-bus` still reports `800/800` received with `0`
  reentry violations.
- Default-OFF gate verified: a fresh configure with no
  `BUILD_EXAMPLE_*` flags leaves all three example options at OFF in
  the cache and `example/fanout_fsm/CMakeLists.txt` is not added.