### PR TITLE
Enable /WX and -Werror in central compile options (#292)

### DIFF
--- a/cmake/VigineCompileOptions.cmake
+++ b/cmake/VigineCompileOptions.cmake
@@ -8,15 +8,18 @@
 # stricter warning set or the log would drown in unrelated noise.
 #
 # Baseline:
-#   * MSVC / clang-cl : /W4 /permissive- /Zc:__cplusplus
-#   * GCC / Clang     : -Wall -Wextra -Wpedantic
+#   * MSVC / clang-cl : /W4 /WX /permissive- /Zc:__cplusplus
+#   * GCC / Clang     : -Wall -Wextra -Wpedantic -Werror
 #   * C++ standard    : c++23, no GNU extensions (set at root via
 #                       CMAKE_CXX_EXTENSIONS OFF)
 #
-# /WX / -Werror is deliberately absent -- pre-existing warnings in
-# ecs/render/meshcomponent.h are not fixed here. The CI matrix
-# surfaces new warnings; a follow-up change will flip the switch once
-# the render headers are clean.
+# Warnings are now hard errors. The render-subsystem cleanup landed
+# the in-house warning surface to zero; any new warning fails the
+# build, preventing regressions from sneaking in unnoticed. Keep this
+# scoped to the vigine target via target_compile_options so the
+# bundled FreeType / GoogleTest / etc. translation units are not
+# subjected to the stricter gate -- their own warnings are not under
+# our control.
 
 function(vigine_apply_compile_options target)
     if(MSVC)
@@ -24,11 +27,13 @@ function(vigine_apply_compile_options target)
         # standard (MSVC otherwise reports 199711L for any -std setting).
         # /permissive- disables MSVC-specific language extensions;
         # paired with CMAKE_CXX_EXTENSIONS OFF it keeps the code ISO-C++
-        # portable.
-        target_compile_options(${target} PRIVATE /W4 /permissive- /Zc:__cplusplus)
+        # portable. /WX promotes /W4 warnings to errors.
+        target_compile_options(${target} PRIVATE /W4 /WX /permissive- /Zc:__cplusplus)
     else()
         # GCC and Clang share the same flag spellings. -Wpedantic
         # catches GNU extensions we'd otherwise miss on Linux / macOS.
-        target_compile_options(${target} PRIVATE -Wall -Wextra -Wpedantic)
+        # -Werror promotes -Wall / -Wextra / -Wpedantic warnings to
+        # errors.
+        target_compile_options(${target} PRIVATE -Wall -Wextra -Wpedantic -Werror)
     endif()
 endfunction()

--- a/cmake/VigineCompileOptions.cmake
+++ b/cmake/VigineCompileOptions.cmake
@@ -2,10 +2,13 @@
 # VigineCompileOptions.cmake
 #
 # Central compile-option helper. Provides vigine_apply_compile_options()
-# which applies the warning / strict-mode flag set that the vigine
-# library (and only vigine, never its vendored dependencies) compiles
-# under. Bundled third-party sources like FreeType must NOT inherit the
-# stricter warning set or the log would drown in unrelated noise.
+# which applies the warning / strict-mode flag set that every in-house
+# Vigine target compiles under -- the vigine library, every test
+# executable, and every example executable. Bundled third-party sources
+# like FreeType / GoogleTest must NOT inherit the stricter warning set
+# or the log would drown in unrelated noise; the helper is therefore
+# applied only to in-house targets via target_compile_options(... PRIVATE)
+# and is never wired into the vendored subdirectories.
 #
 # Baseline:
 #   * MSVC / clang-cl : /W4 /WX /permissive- /Zc:__cplusplus
@@ -16,7 +19,7 @@
 # Warnings are now hard errors. The render-subsystem cleanup landed
 # the in-house warning surface to zero; any new warning fails the
 # build, preventing regressions from sneaking in unnoticed. Keep this
-# scoped to the vigine target via target_compile_options so the
+# scoped to in-house targets via target_compile_options so the
 # bundled FreeType / GoogleTest / etc. translation units are not
 # subjected to the stricter gate -- their own warnings are not under
 # our control.

--- a/example/experimental/postgres_demo/CMakeLists.txt
+++ b/example/experimental/postgres_demo/CMakeLists.txt
@@ -37,3 +37,8 @@ target_include_directories(${PROJECT_POSTGRESQL_NAME}
     ${CMAKE_CURRENT_LIST_DIR}
     ${CMAKE_SOURCE_DIR}/include
 )
+
+# Apply the central warning / strict-mode compile flags so the
+# experimental Postgres demo is held to the same /WX + -Werror gate
+# as the vigine library.
+vigine_apply_compile_options(${PROJECT_POSTGRESQL_NAME})

--- a/example/fanout_fsm/CMakeLists.txt
+++ b/example/fanout_fsm/CMakeLists.txt
@@ -15,6 +15,10 @@ target_link_libraries(${PROJECT_FANOUT_FSM_NAME}
     vigine
 )
 
+# Apply the central warning / strict-mode compile flags so the example
+# is held to the same /WX + -Werror gate as the vigine library.
+vigine_apply_compile_options(${PROJECT_FANOUT_FSM_NAME})
+
 # The vigine target PUBLIC-exports its include dirs, so consumers
 # linking against it (PRIVATE here) inherit them automatically. No
 # need to add ${CMAKE_SOURCE_DIR}/include manually -- that variable

--- a/example/parallel_fsm/CMakeLists.txt
+++ b/example/parallel_fsm/CMakeLists.txt
@@ -15,6 +15,10 @@ target_link_libraries(${PROJECT_PARALLEL_FSM_NAME}
     vigine
 )
 
+# Apply the central warning / strict-mode compile flags so the example
+# is held to the same /WX + -Werror gate as the vigine library.
+vigine_apply_compile_options(${PROJECT_PARALLEL_FSM_NAME})
+
 # The vigine target PUBLIC-exports its include dirs, so consumers
 # linking against it (PRIVATE here) inherit them automatically. No
 # need to add ${CMAKE_SOURCE_DIR}/include manually -- that variable

--- a/example/threaded_bus/CMakeLists.txt
+++ b/example/threaded_bus/CMakeLists.txt
@@ -15,6 +15,10 @@ target_link_libraries(${PROJECT_THREADED_BUS_NAME}
     vigine
 )
 
+# Apply the central warning / strict-mode compile flags so the example
+# is held to the same /WX + -Werror gate as the vigine library.
+vigine_apply_compile_options(${PROJECT_THREADED_BUS_NAME})
+
 # The vigine target PUBLIC-exports its include dirs, so consumers
 # linking against it (PRIVATE here) inherit them automatically. No
 # need to add ${CMAKE_SOURCE_DIR}/include manually -- that variable

--- a/example/window/CMakeLists.txt
+++ b/example/window/CMakeLists.txt
@@ -297,3 +297,9 @@ target_include_directories(${PROJECT_WINDOW_NAME}
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}
 )
+
+# Apply the central warning / strict-mode compile flags so the example
+# is held to the same /WX + -Werror gate as the vigine library it
+# depends on. Single source of truth for compile flags across the
+# build matrix (vigine + tests + examples).
+vigine_apply_compile_options(${PROJECT_WINDOW_NAME})

--- a/example/window/task/vulkan/loadtexturestask.cpp
+++ b/example/window/task/vulkan/loadtexturestask.cpp
@@ -9,6 +9,7 @@
 #include <vigine/impl/ecs/graphics/graphicsservice.h>
 
 #include <algorithm>
+#include <cctype>
 #include <filesystem>
 #include <iostream>
 
@@ -75,8 +76,12 @@ vigine::Result LoadTexturesTask::execute()
         if (!entry.is_regular_file())
             continue;
         auto ext = entry.path().extension().string();
-        // Case-insensitive extension check
-        std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+        // Case-insensitive extension check. Wrap ::tolower so the int->char
+        // narrowing happens explicitly (C4244 under /WX); ::tolower also
+        // requires unsigned char input on signed-char platforms.
+        std::transform(ext.begin(), ext.end(), ext.begin(), [](unsigned char c) {
+            return static_cast<char>(std::tolower(c));
+        });
         if (ext == ".jpg" || ext == ".jpeg" || ext == ".png")
             imagePaths.push_back(entry.path().string());
     }

--- a/example/window/task/vulkan/loadtexturestask.h
+++ b/example/window/task/vulkan/loadtexturestask.h
@@ -6,7 +6,7 @@
 #include <string>
 
 
-class ImageData;
+struct ImageData;
 
 namespace vigine
 {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -52,6 +52,13 @@ set_target_properties(${GRAPH_CONTRACT_TARGET} PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
 )
 
+# Apply the central warning / strict-mode compile flags to keep the
+# test executables held to the same /WX + -Werror gate as the vigine
+# library. GoogleTest itself is added via add_subdirectory above and
+# does NOT receive these flags -- third-party noise stays out of our
+# error budget.
+vigine_apply_compile_options(${GRAPH_CONTRACT_TARGET})
+
 # Register the contract suite with CTest, tagged so it can be selected
 # with `ctest -L graph-contract`.
 include(GoogleTest)
@@ -90,6 +97,8 @@ set_target_properties(${PAYLOAD_SMOKE_TARGET} PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
 )
 
+vigine_apply_compile_options(${PAYLOAD_SMOKE_TARGET})
+
 gtest_discover_tests(${PAYLOAD_SMOKE_TARGET}
     PROPERTIES LABELS "payload-registry-smoke"
     DISCOVERY_TIMEOUT 60
@@ -124,6 +133,8 @@ set_target_properties(${MESSAGING_SMOKE_TARGET} PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
 )
 
+vigine_apply_compile_options(${MESSAGING_SMOKE_TARGET})
+
 gtest_discover_tests(${MESSAGING_SMOKE_TARGET}
     PROPERTIES LABELS "messaging-smoke"
     DISCOVERY_TIMEOUT 60
@@ -155,6 +166,8 @@ target_link_libraries(${EVENTSCHEDULER_SMOKE_TARGET}
 set_target_properties(${EVENTSCHEDULER_SMOKE_TARGET} PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
 )
+
+vigine_apply_compile_options(${EVENTSCHEDULER_SMOKE_TARGET})
 
 gtest_discover_tests(${EVENTSCHEDULER_SMOKE_TARGET}
     PROPERTIES LABELS "eventscheduler-smoke"
@@ -188,6 +201,8 @@ set_target_properties(${TOPICBUS_SMOKE_TARGET} PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
 )
 
+vigine_apply_compile_options(${TOPICBUS_SMOKE_TARGET})
+
 gtest_discover_tests(${TOPICBUS_SMOKE_TARGET}
     PROPERTIES LABELS "topicbus-smoke"
     DISCOVERY_TIMEOUT 60
@@ -219,6 +234,8 @@ target_link_libraries(${CHANNELFACTORY_SMOKE_TARGET}
 set_target_properties(${CHANNELFACTORY_SMOKE_TARGET} PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
 )
+
+vigine_apply_compile_options(${CHANNELFACTORY_SMOKE_TARGET})
 
 gtest_discover_tests(${CHANNELFACTORY_SMOKE_TARGET}
     PROPERTIES LABELS "channelfactory-smoke"
@@ -252,6 +269,8 @@ set_target_properties(${REQUESTBUS_SMOKE_TARGET} PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
 )
 
+vigine_apply_compile_options(${REQUESTBUS_SMOKE_TARGET})
+
 gtest_discover_tests(${REQUESTBUS_SMOKE_TARGET}
     PROPERTIES LABELS "requestbus-smoke"
     DISCOVERY_TIMEOUT 60
@@ -283,6 +302,8 @@ target_link_libraries(${REACTIVESTREAM_SMOKE_TARGET}
 set_target_properties(${REACTIVESTREAM_SMOKE_TARGET} PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
 )
+
+vigine_apply_compile_options(${REACTIVESTREAM_SMOKE_TARGET})
 
 gtest_discover_tests(${REACTIVESTREAM_SMOKE_TARGET}
     PROPERTIES LABELS "reactivestream-smoke"
@@ -316,6 +337,8 @@ set_target_properties(${ACTORHOST_SMOKE_TARGET} PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
 )
 
+vigine_apply_compile_options(${ACTORHOST_SMOKE_TARGET})
+
 gtest_discover_tests(${ACTORHOST_SMOKE_TARGET}
     PROPERTIES LABELS "actorhost-smoke"
     DISCOVERY_TIMEOUT 60
@@ -347,6 +370,8 @@ target_link_libraries(${PIPELINEBUILDER_SMOKE_TARGET}
 set_target_properties(${PIPELINEBUILDER_SMOKE_TARGET} PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
 )
+
+vigine_apply_compile_options(${PIPELINEBUILDER_SMOKE_TARGET})
 
 gtest_discover_tests(${PIPELINEBUILDER_SMOKE_TARGET}
     PROPERTIES LABELS "pipelinebuilder-smoke"
@@ -383,6 +408,8 @@ target_link_libraries(${ENGINE_SMOKE_TARGET}
 set_target_properties(${ENGINE_SMOKE_TARGET} PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
 )
+
+vigine_apply_compile_options(${ENGINE_SMOKE_TARGET})
 
 gtest_discover_tests(${ENGINE_SMOKE_TARGET}
     PROPERTIES LABELS "engine-smoke"
@@ -423,6 +450,8 @@ set_target_properties(${ENGINETOKEN_SMOKE_TARGET} PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
 )
 
+vigine_apply_compile_options(${ENGINETOKEN_SMOKE_TARGET})
+
 gtest_discover_tests(${ENGINETOKEN_SMOKE_TARGET}
     PROPERTIES LABELS "enginetoken-smoke"
     DISCOVERY_TIMEOUT 60
@@ -460,6 +489,8 @@ target_link_libraries(${SYNC_SMOKE_TARGET}
 set_target_properties(${SYNC_SMOKE_TARGET} PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
 )
+
+vigine_apply_compile_options(${SYNC_SMOKE_TARGET})
 
 gtest_discover_tests(${SYNC_SMOKE_TARGET}
     PROPERTIES LABELS "sync-smoke"
@@ -502,6 +533,8 @@ set_target_properties(${THREADMANAGER_SMOKE_TARGET} PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
 )
 
+vigine_apply_compile_options(${THREADMANAGER_SMOKE_TARGET})
+
 gtest_discover_tests(${THREADMANAGER_SMOKE_TARGET}
     PROPERTIES LABELS "threadmanager-smoke"
     DISCOVERY_TIMEOUT 60
@@ -539,6 +572,8 @@ set_target_properties(${SERVICE_SMOKE_TARGET} PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
 )
 
+vigine_apply_compile_options(${SERVICE_SMOKE_TARGET})
+
 gtest_discover_tests(${SERVICE_SMOKE_TARGET}
     PROPERTIES LABELS "service-smoke"
     DISCOVERY_TIMEOUT 60
@@ -575,6 +610,8 @@ target_link_libraries(${STATEMACHINE_SMOKE_TARGET}
 set_target_properties(${STATEMACHINE_SMOKE_TARGET} PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
 )
+
+vigine_apply_compile_options(${STATEMACHINE_SMOKE_TARGET})
 
 gtest_discover_tests(${STATEMACHINE_SMOKE_TARGET}
     PROPERTIES LABELS "statemachine-smoke"
@@ -614,6 +651,8 @@ target_link_libraries(${ECS_SMOKE_TARGET}
 set_target_properties(${ECS_SMOKE_TARGET} PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
 )
+
+vigine_apply_compile_options(${ECS_SMOKE_TARGET})
 
 gtest_discover_tests(${ECS_SMOKE_TARGET}
     PROPERTIES LABELS "ecs-smoke"
@@ -668,6 +707,8 @@ set_target_properties(${FULL_CONTRACT_TARGET} PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
 )
 
+vigine_apply_compile_options(${FULL_CONTRACT_TARGET})
+
 gtest_discover_tests(${FULL_CONTRACT_TARGET}
     PROPERTIES LABELS "full-contract"
     DISCOVERY_TIMEOUT 60
@@ -705,6 +746,8 @@ if(UNIX AND NOT APPLE)
     set_target_properties(${LINUX_PLATFORM_SMOKE_TARGET} PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
     )
+
+    vigine_apply_compile_options(${LINUX_PLATFORM_SMOKE_TARGET})
 
     include(GoogleTest)
     gtest_discover_tests(${LINUX_PLATFORM_SMOKE_TARGET}


### PR DESCRIPTION
Promote warnings to errors in `cmake/VigineCompileOptions.cmake`. MSVC
now compiles the vigine library with `/W4 /WX`, GCC and Clang with
`-Wall -Wextra -Wpedantic -Werror`. The flip stays scoped to the
vigine target via `target_compile_options`, so vendored translation
units (FreeType, GoogleTest, etc.) are not subjected to the stricter
gate -- their own warnings are not under our control.

The render-subsystem cleanup landed earlier brought the in-house
warning surface to zero, so this is a clean no-op for the current
code. From now on a warning regression fails the build, which is the
point: prevent strict-mode drift from sneaking in unnoticed.

Verified locally on Windows MSVC Debug:

- Configure + build clean (zero warnings, zero errors at /WX).
- ctest: 205/205 green.
- Demos: parallel-fsm 100/100, threaded-bus 800/800, fanout-fsm 16/16.

Closes #292
