### PR TITLE
Run ctest in ci.yml with ENABLE_UNITTEST=ON (#295)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,12 @@ jobs:
           cmake -S . -B build
           -DCMAKE_BUILD_TYPE=${{ matrix.config }}
           -DENABLE_POSTGRESQL=OFF
+          -DVIGINE_ENABLE_EXPERIMENTAL=OFF
+          -DENABLE_UNITTEST=ON
 
       - name: Build
         run: cmake --build build --config ${{ matrix.config }}
+
+      - name: Test
+        working-directory: build
+        run: ctest --output-on-failure --build-config ${{ matrix.config }}


### PR DESCRIPTION
Closes #295.

Adds a Test step to the three-OS build matrix in ci.yml so the matrix actually exercises the unit suite. The configure step now passes:

- `-DVIGINE_ENABLE_EXPERIMENTAL=OFF` (explicit, default)
- `-DENABLE_UNITTEST=ON` (turns on `test/CMakeLists.txt`)

After the build step, ctest runs with `--output-on-failure --build-config ${{ matrix.config }}` so multi-config generators (Visual Studio, Xcode) pick the right binary slot for each matrix cell.

Local verification on windows-debug: configure + build + ctest 205/205 passing.

Scope is limited to ci.yml. linux-build.yml is owned by #296.