### PR TITLE
Add IContext::makeEngineToken factory and Internal scope-bypass accessors (#286)

### DIFF
--- a/include/vigine/api/context/abstractcontext.h
+++ b/include/vigine/api/context/abstractcontext.h
@@ -124,8 +124,10 @@ class AbstractContext : public IContext
     // diagnostics, lifecycle wiring) can reach the underlying
     // resources without going through a state-scoped token. The
     // public surface keeps the gated semantics; the engine reaches
-    // the substrate directly through the @c *Internal trio. This
-    // matches the R-StateScope architecture rule: tasks see a gated
+    // the substrate directly through the @c *Internal pair
+    // (@ref serviceInternal + @ref ecsInternal -- additional
+    // @c *Internal accessors land alongside future scope-bypass needs).
+    // This matches the R-StateScope architecture rule: tasks see a gated
     // view; the engine itself sees a direct view.
     //
     // Naming: the @c *Internal suffix flags the engine-internal scope.
@@ -140,10 +142,14 @@ class AbstractContext : public IContext
      * under @p id without taking the gated detour through an
      * @ref vigine::engine::IEngineToken. Returns the raw shared
      * pointer so callers can branch on null without juggling a
-     * @ref vigine::engine::Result wrapper. Used by
-     * @ref vigine::engine::EngineToken's gated accessor body and by
-     * any future engine-side diagnostics that want to inspect the
-     * service registry without minting a token first.
+     * @ref vigine::engine::Result wrapper. Intended for
+     * @ref vigine::engine::EngineToken-style aggregators when they
+     * need an engine-internal scope-bypass path, plus any engine-side
+     * diagnostics that want to inspect the service registry without
+     * minting a token first. The concrete @ref vigine::engine::EngineToken
+     * landed under #287 calls @ref IContext::service directly; a
+     * follow-up leaf will switch it to consume the @c *Internal accessors
+     * uniformly.
      *
      * The thread-safety contract matches @ref IContext::service: the
      * registry mutex serialises the lookup against concurrent

--- a/include/vigine/api/context/abstractcontext.h
+++ b/include/vigine/api/context/abstractcontext.h
@@ -8,6 +8,7 @@
 
 #include "vigine/api/context/contextconfig.h"
 #include "vigine/api/context/icontext.h"
+#include "vigine/api/engine/iengine_token.h"
 #include "vigine/api/service/iservice.h"
 #include "vigine/api/service/serviceid.h"
 #include "vigine/api/ecs/iecs.h"
@@ -16,6 +17,7 @@
 #include "vigine/messaging/imessagebus.h"
 #include "vigine/result.h"
 #include "vigine/statemachine/istatemachine.h"
+#include "vigine/statemachine/stateid.h"
 #include "vigine/taskflow/itaskflow.h"
 #include "vigine/core/threading/ithreadmanager.h"
 
@@ -108,6 +110,59 @@ class AbstractContext : public IContext
 
     [[nodiscard]] Result
         registerService(std::shared_ptr<service::IService> service) override;
+
+    // ------ IContext: engine-token factory ------
+
+    [[nodiscard]] std::unique_ptr<vigine::engine::IEngineToken>
+        makeEngineToken(vigine::statemachine::StateId boundState) override;
+
+    // ------ Engine-internal scope-bypass accessors -------------------------
+    //
+    // The accessors below mirror the gated domain accessors on
+    // @ref IContext but stay OFF the public @ref IContext interface --
+    // they exist so engine-internal code (the concrete EngineToken,
+    // diagnostics, lifecycle wiring) can reach the underlying
+    // resources without going through a state-scoped token. The
+    // public surface keeps the gated semantics; the engine reaches
+    // the substrate directly through the @c *Internal trio. This
+    // matches the R-StateScope architecture rule: tasks see a gated
+    // view; the engine itself sees a direct view.
+    //
+    // Naming: the @c *Internal suffix flags the engine-internal scope.
+    // Public on @ref AbstractContext (concrete closers consume them
+    // verbatim) but never lifted to @ref IContext.
+    // ----------------------------------------------------------------------
+
+    /**
+     * @brief Engine-internal direct accessor for @ref service.
+     *
+     * Mirrors @ref IContext::service: looks up the service registered
+     * under @p id without taking the gated detour through an
+     * @ref vigine::engine::IEngineToken. Returns the raw shared
+     * pointer so callers can branch on null without juggling a
+     * @ref vigine::engine::Result wrapper. Used by
+     * @ref vigine::engine::EngineToken's gated accessor body and by
+     * any future engine-side diagnostics that want to inspect the
+     * service registry without minting a token first.
+     *
+     * The thread-safety contract matches @ref IContext::service: the
+     * registry mutex serialises the lookup against concurrent
+     * @ref registerService calls.
+     */
+    [[nodiscard]] std::shared_ptr<service::IService>
+        serviceInternal(service::ServiceId id) const;
+
+    /**
+     * @brief Engine-internal direct accessor for @ref ecs.
+     *
+     * Mirrors @ref IContext::ecs and returns the same reference;
+     * exposed under the @c *Internal name so engine-side code paths
+     * that resolve domain accessors uniformly through the
+     * @c *Internal surface (not through the gated token) have a
+     * consistent entry point. The reference stays live for the
+     * lifetime of this @ref AbstractContext.
+     */
+    [[nodiscard]] ecs::IECS &ecsInternal() noexcept;
 
     // ------ IContext: lifecycle ------
 

--- a/include/vigine/api/context/icontext.h
+++ b/include/vigine/api/context/icontext.h
@@ -6,11 +6,17 @@
 #include "vigine/messaging/busid.h"
 #include "vigine/result.h"
 #include "vigine/api/service/serviceid.h"
+#include "vigine/statemachine/stateid.h"
 
 namespace vigine::ecs
 {
 class IECS;
 } // namespace vigine::ecs
+
+namespace vigine::engine
+{
+class IEngineToken;
+} // namespace vigine::engine
 
 namespace vigine::messaging
 {
@@ -56,12 +62,35 @@ namespace vigine
  *   - One service locator (@c service, @c registerService).
  *   - One user-bus factory (@c createMessageBus) and an id-keyed
  *     lookup (@c messageBus).
+ *   - One engine-token factory (@c makeEngineToken) that mints
+ *     @ref vigine::engine::IEngineToken handles bound to a state. The
+ *     token is the state-scoped DI surface tasks receive at
+ *     @c onEnter; see the gating split below.
  *   - A freeze-after-run boundary (@c freeze, @c isFrozen) that blocks
  *     topology mutation once @c Engine::run starts the main loop.
  *     After @ref freeze is called, @c createMessageBus returns
  *     @c nullptr and @c registerService returns
  *     @ref Result::Code::TopologyFrozen. Read-only accessors stay
  *     available.
+ *
+ * Gating split (R-StateScope hybrid policy, mirrored on
+ * @ref vigine::engine::IEngineToken):
+ *   - @b Domain accessors -- @ref service, @ref ecs (and the
+ *     follow-up @c entityManager / @c components / system-by-id
+ *     surfaces). Lookups carry lifecycle uncertainty: a registry
+ *     slot may recycle between ticks, and @ref freeze may have
+ *     dropped a previously-known id since the caller last looked
+ *     it up. The engine-token wrapper exposes these through
+ *     @ref vigine::engine::Result so callers branch on a typed
+ *     reason; the @ref IContext API itself returns the underlying
+ *     handle (@c std::shared_ptr / reference) directly because
+ *     services using @ref IContext during onInit run before any
+ *     state transitions can invalidate them.
+ *   - @b Infrastructure accessors -- @ref threadManager,
+ *     @ref systemBus, @ref stateMachine, @ref taskFlow. These
+ *     resources outlive every state transition (the context owns
+ *     them for the engine's whole lifetime), so they are always
+ *     non-gated and return references directly.
  *
  * Strict construction order (AD-5 C8, encoded by @ref AbstractContext):
  *   1. @ref core::threading::IThreadManager (created first).
@@ -197,6 +226,67 @@ class IContext
      */
     [[nodiscard]] virtual Result
         registerService(std::shared_ptr<service::IService> service) = 0;
+
+    // ------ Engine-token factory ------
+
+    /**
+     * @brief Mints a fresh @ref vigine::engine::IEngineToken bound to
+     *        @p boundState.
+     *
+     * The returned token is the state-scoped DI surface a task receives
+     * during @c onEnter; it forwards calls to this aggregator's domain
+     * accessors (gated, @ref vigine::engine::Result wrapper) and to the
+     * infrastructure accessors (ungated, direct reference) per the
+     * R-StateScope hybrid policy described on the class docstring.
+     *
+     * The token observes the engine's @ref vigine::statemachine::IStateMachine
+     * for invalidation: when the FSM transitions out of @p boundState,
+     * the token's gated accessors start reporting
+     * @ref vigine::engine::Result::Code::Expired and any callback
+     * registered through @c subscribeExpiration fires exactly once. The
+     * ungated accessors keep working until the token is destroyed so
+     * an invalidated task can still drain in-flight scheduling.
+     *
+     * Ownership: the caller owns the returned @c std::unique_ptr.
+     * Tasks typically receive the token by reference through their
+     * wiring path; the state machine keeps the returned unique_ptr
+     * alive for the duration of the bound state.
+     *
+     * Lifetime invariants of the token wiring:
+     *   - The token captures a non-owning reference to this context
+     *     and to its @ref stateMachine. Both must outlive the token;
+     *     the engine's strict construction order guarantees this
+     *     (the context owns the state machine; both are torn down
+     *     after every token has been dropped).
+     *   - When the engine-wide signal-emitter façade has not yet been
+     *     wired through @ref IContext (the wrapper follow-up under the
+     *     #197 umbrella ships separately), the token falls back to a
+     *     file-private @c NullSignalEmitter stub so the ungated
+     *     @c signalEmitter accessor honours its "cannot fail" contract
+     *     even in the unwired configuration. Once the façade lands,
+     *     this factory passes the real wrapper through and the stub
+     *     stays uninstantiated.
+     *
+     * @param boundState State the new token is bound to. The token
+     *        does not validate that @p boundState is registered on
+     *        the FSM; passing an unregistered id yields a token that
+     *        observes the FSM but never matches any transition --
+     *        effectively a permanently-alive handle. Callers that
+     *        want a stricter contract pre-validate the id through
+     *        @ref stateMachine.
+     * @return A live token from the new aggregator
+     *         (@ref vigine::context::AbstractContext path). Token
+     *         construction is allocation-only and any
+     *         @c std::bad_alloc surfaces as an exception per the
+     *         standard library contract. The legacy
+     *         @ref vigine::Context stub (kept compiling for the
+     *         pre-R.4.5 @c Engine front door) carries no live
+     *         @ref vigine::statemachine::IStateMachine and therefore
+     *         returns @c nullptr; new code that needs a live token
+     *         goes through @c vigine::context::createContext.
+     */
+    [[nodiscard]] virtual std::unique_ptr<vigine::engine::IEngineToken>
+        makeEngineToken(vigine::statemachine::StateId boundState) = 0;
 
     // ------ Lifecycle boundary ------
 

--- a/include/vigine/api/context/icontext.h
+++ b/include/vigine/api/context/icontext.h
@@ -234,10 +234,14 @@ class IContext
      *        @p boundState.
      *
      * The returned token is the state-scoped DI surface a task receives
-     * during @c onEnter; it forwards calls to this aggregator's domain
-     * accessors (gated, @ref vigine::engine::Result wrapper) and to the
-     * infrastructure accessors (ungated, direct reference) per the
-     * R-StateScope hybrid policy described on the class docstring.
+     * during @c onEnter. For domain accessors it calls this aggregator's
+     * non-gated accessors (which return @c std::shared_ptr / a raw
+     * reference) and wraps the outcome in a @ref vigine::engine::Result
+     * -- adding the alive-state gate that flips to
+     * @ref vigine::engine::Result::Code::Expired after invalidation. For
+     * infrastructure accessors it forwards directly (ungated, raw
+     * reference) per the R-StateScope hybrid policy described on the
+     * class docstring.
      *
      * The token observes the engine's @ref vigine::statemachine::IStateMachine
      * for invalidation: when the FSM transitions out of @p boundState,

--- a/include/vigine/context.h
+++ b/include/vigine/context.h
@@ -71,6 +71,13 @@ class Context : public IContext
     [[nodiscard]] Result
         registerService(std::shared_ptr<service::IService> service) override;
 
+    // Legacy stub: the pre-R.4.5 Context carries no live state machine
+    // so the engine-token factory cannot produce a usable token. Returns
+    // @c nullptr per the IContext docstring's legacy-stub clause; new
+    // callers go through @c vigine::context::createContext.
+    [[nodiscard]] std::unique_ptr<engine::IEngineToken>
+        makeEngineToken(statemachine::StateId boundState) override;
+
     void              freeze() noexcept override;
     [[nodiscard]] bool isFrozen() const noexcept override;
 

--- a/src/api/context/abstractcontext.cpp
+++ b/src/api/context/abstractcontext.cpp
@@ -1,10 +1,13 @@
 #include "vigine/api/context/abstractcontext.h"
 
+#include <memory>
 #include <mutex>
 #include <utility>
 
+#include "vigine/api/engine/iengine_token.h"
 #include "vigine/api/service/abstractservice.h"
 #include "vigine/impl/ecs/factory.h"
+#include "vigine/impl/engine/enginetoken.h"
 #include "vigine/messaging/factory.h"
 #include "vigine/statemachine/factory.h"
 #include "vigine/taskflow/factory.h"
@@ -224,6 +227,72 @@ Result AbstractContext::registerService(std::shared_ptr<service::IService> servi
     }
     _services.emplace(stamped.index, std::move(service));
     return Result{};
+}
+
+// ---------------------------------------------------------------------
+// Engine-token factory
+// ---------------------------------------------------------------------
+
+std::unique_ptr<vigine::engine::IEngineToken>
+AbstractContext::makeEngineToken(vigine::statemachine::StateId boundState)
+{
+    // Mint a fresh @ref engine::EngineToken bound to @p boundState.
+    // The token captures:
+    //   - this aggregator by reference (so its gated accessors can
+    //     delegate to @ref serviceInternal / @ref ecsInternal etc.),
+    //   - the engine's @ref IStateMachine wrapper (so the token can
+    //     register an invalidation listener via the
+    //     @ref AbstractStateMachine subclass back-end and observe
+    //     transitions out of @p boundState),
+    //   - a @c nullptr signal-emitter pointer because the engine-wide
+    //     @ref ISignalEmitter façade has not yet been wired through
+    //     @ref IContext (the wrapper follow-up under the #197 umbrella
+    //     ships separately, see #283). The @c EngineToken constructor
+    //     handles the null path by allocating a file-private
+    //     @c NullSignalEmitter stub so the ungated @c signalEmitter
+    //     accessor never crashes; once the real façade lands, this
+    //     factory passes the live wrapper through and the stub stays
+    //     uninstantiated.
+    //
+    // The token does NOT inspect this aggregator's freeze flag: a task
+    // can request a fresh token after @ref freeze (e.g. when a state
+    // transition mints one for an onEnter handler) just like every
+    // read-only accessor stays available post-freeze. The freeze
+    // boundary blocks topology mutation; minting a state-scoped DI
+    // handle is not a topology mutation.
+    return std::make_unique<vigine::engine::EngineToken>(
+        boundState, *this, *_stateMachine, /*signalEmitter=*/nullptr);
+}
+
+// ---------------------------------------------------------------------
+// Engine-internal scope-bypass accessors
+// ---------------------------------------------------------------------
+
+std::shared_ptr<service::IService>
+AbstractContext::serviceInternal(service::ServiceId id) const
+{
+    // Engine-internal direct lookup. Mirrors @ref service exactly --
+    // the engine-side scope-bypass surface intentionally shares the
+    // same generational guarantees as the public surface so callers
+    // who switch between gated (token) and ungated (internal) code
+    // paths observe identical results for the same @p id. The
+    // implementation reuses @ref service to avoid drift; the only
+    // reason this is a separate symbol is the R-StateScope split
+    // between the public @ref IContext surface (gated through tokens
+    // in the engine-token wrapper) and the engine-internal direct
+    // surface that exists on @ref AbstractContext but not on
+    // @ref IContext.
+    return service(id);
+}
+
+ecs::IECS &AbstractContext::ecsInternal() noexcept
+{
+    // Engine-internal direct alias for @ref ecs. The underlying
+    // wrapper lives for the aggregator's lifetime (it is owned
+    // through @ref _ecs, the unique_ptr declared in this class) so
+    // returning a reference is safe regardless of any state-machine
+    // transition or freeze event.
+    return *_ecs;
 }
 
 // ---------------------------------------------------------------------

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -1,6 +1,7 @@
 #include "vigine/context.h"
 
 #include "vigine/api/ecs/iecs.h"
+#include "vigine/api/engine/iengine_token.h"
 #include "vigine/impl/ecs/platform/windowsystem.h"
 #if VIGINE_POSTGRESQL
 #include "vigine/experimental/ecs/postgresql/impl/postgresqlsystem.h"
@@ -234,6 +235,20 @@ vigine::Context::registerService(std::shared_ptr<vigine::service::IService> /*se
     return Result{
         Result::Code::Error,
         "legacy vigine::Context does not accept service registrations; use vigine::context::createContext"};
+}
+
+std::unique_ptr<vigine::engine::IEngineToken>
+vigine::Context::makeEngineToken(vigine::statemachine::StateId /*boundState*/)
+{
+    // The legacy aggregator never wired up an IStateMachine, so the
+    // engine-token wiring (back-reference to context + FSM listener
+    // registration) cannot proceed. Return @c nullptr per the
+    // IContext docstring's legacy-stub clause; callers that need a
+    // live token construct a context through
+    // @c vigine::context::createContext, which routes through the
+    // R.4.5 aggregator @ref vigine::context::AbstractContext where
+    // the factory is fully wired.
+    return nullptr;
 }
 
 void vigine::Context::freeze() noexcept

--- a/test/service/smoke_test.cpp
+++ b/test/service/smoke_test.cpp
@@ -15,9 +15,11 @@
 // ---------------------------------------------------------------------------
 
 #include "vigine/api/context/icontext.h"
+#include "vigine/api/engine/iengine_token.h"
 #include "vigine/api/service/factory.h"
 #include "vigine/api/service/iservice.h"
 #include "vigine/result.h"
+#include "vigine/statemachine/stateid.h"
 
 #include <gtest/gtest.h>
 
@@ -81,6 +83,12 @@ class ThrowingContext final : public vigine::IContext
         registerService(std::shared_ptr<vigine::service::IService>) override
     {
         throw std::runtime_error{"smoke ThrowingContext: registerService called"};
+    }
+
+    [[nodiscard]] std::unique_ptr<vigine::engine::IEngineToken>
+        makeEngineToken(vigine::statemachine::StateId) override
+    {
+        throw std::runtime_error{"smoke ThrowingContext: makeEngineToken called"};
     }
 
     void freeze() noexcept override {}


### PR DESCRIPTION
Closes #286.