### PR TITLE
Migrate ITask to setApi/api/run signature with IEngineToken (#288)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,7 @@ set(HEADER
     ${INCLUDE_DIR}/vigine/impl/statemachine/statemachine.h
     ${INCLUDE_DIR}/vigine/api/statemachine/abstractstate.h
     ${INCLUDE_DIR}/vigine/impl/taskflow/taskflow.h
+    ${INCLUDE_DIR}/vigine/api/taskflow/itask.h
     ${INCLUDE_DIR}/vigine/api/taskflow/abstracttask.h
     ${INCLUDE_DIR}/vigine/abstractservice.h
     ${INCLUDE_DIR}/vigine/context.h

--- a/example/experimental/postgres_demo/task/data/addsomedatatask.cpp
+++ b/example/experimental/postgres_demo/task/data/addsomedatatask.cpp
@@ -25,9 +25,9 @@ void AddSomeDataTask::contextChanged()
 
 // COPILOT_TODO: Або дописати реальний insert-сценарій, або прибрати задачу; зараз вона завершується
 // успішно без жодної дії та без перевірки entity/_dbService.
-vigine::Result AddSomeDataTask::execute()
+vigine::Result AddSomeDataTask::run()
 {
-    std::println("-- AddSomeDataTask::execute()");
+    std::println("-- AddSomeDataTask::run()");
 
     auto *entityManager = context()->entityManager();
     auto *entity        = entityManager->getEntityByAlias("PostgresBDLocal");

--- a/example/experimental/postgres_demo/task/data/addsomedatatask.cpp
+++ b/example/experimental/postgres_demo/task/data/addsomedatatask.cpp
@@ -23,8 +23,9 @@ void AddSomeDataTask::contextChanged()
         context()->service("Database", vigine::Name("TestDB"), vigine::Property::Exist));
 }
 
-// COPILOT_TODO: Або дописати реальний insert-сценарій, або прибрати задачу; зараз вона завершується
-// успішно без жодної дії та без перевірки entity/_dbService.
+// COPILOT_TODO: Either implement a real insert scenario or remove
+// this task; it currently returns Success without doing any work and
+// without validating entity/_dbService.
 vigine::Result AddSomeDataTask::run()
 {
     std::println("-- AddSomeDataTask::run()");

--- a/example/experimental/postgres_demo/task/data/addsomedatatask.h
+++ b/example/experimental/postgres_demo/task/data/addsomedatatask.h
@@ -13,7 +13,7 @@ class AddSomeDataTask : public vigine::AbstractTask
     AddSomeDataTask();
 
     void contextChanged() override;
-    vigine::Result execute() override;
+    [[nodiscard]] vigine::Result run() override;
 
   private:
     vigine::DatabaseService *_dbService{nullptr};

--- a/example/experimental/postgres_demo/task/data/readsomedatatask.cpp
+++ b/example/experimental/postgres_demo/task/data/readsomedatatask.cpp
@@ -25,9 +25,9 @@ void ReadSomeDataTask::contextChanged()
 
 // COPILOT_TODO: Перевіряти entity/_dbService і повертати помилку, якщо DatabaseService::readData()
 // лишається недописаним; зараз сценарій маскує неготовий код як success.
-vigine::Result ReadSomeDataTask::execute()
+vigine::Result ReadSomeDataTask::run()
 {
-    std::println("-- ReadSomeDataTask::execute()");
+    std::println("-- ReadSomeDataTask::run()");
 
     auto *entityManager = context()->entityManager();
     auto *entity        = entityManager->getEntityByAlias("PostgresBDLocal");

--- a/example/experimental/postgres_demo/task/data/readsomedatatask.cpp
+++ b/example/experimental/postgres_demo/task/data/readsomedatatask.cpp
@@ -23,8 +23,9 @@ void ReadSomeDataTask::contextChanged()
         context()->service("Database", vigine::Name("TestDB"), vigine::Property::Exist));
 }
 
-// COPILOT_TODO: Перевіряти entity/_dbService і повертати помилку, якщо DatabaseService::readData()
-// лишається недописаним; зараз сценарій маскує неготовий код як success.
+// COPILOT_TODO: Validate entity/_dbService and return an error while
+// DatabaseService::readData() stays unfinished; the current path masks
+// incomplete code as success.
 vigine::Result ReadSomeDataTask::run()
 {
     std::println("-- ReadSomeDataTask::run()");

--- a/example/experimental/postgres_demo/task/data/readsomedatatask.h
+++ b/example/experimental/postgres_demo/task/data/readsomedatatask.h
@@ -13,7 +13,7 @@ class ReadSomeDataTask : public vigine::AbstractTask
     ReadSomeDataTask();
 
     void contextChanged() override;
-    vigine::Result execute() override;
+    [[nodiscard]] vigine::Result run() override;
 
   private:
     vigine::DatabaseService *_dbService{nullptr};

--- a/example/experimental/postgres_demo/task/data/removesomedatatask.cpp
+++ b/example/experimental/postgres_demo/task/data/removesomedatatask.cpp
@@ -25,9 +25,9 @@ void RemoveSomeDataTask::contextChanged()
 
 // COPILOT_TODO: Перевіряти entity/_dbService і мати шлях повернення помилки з
 // clearTable/queryRequest, інакше збої БД тут залишаться непоміченими.
-vigine::Result RemoveSomeDataTask::execute()
+vigine::Result RemoveSomeDataTask::run()
 {
-    std::println("-- RemoveSomeDataTask::execute()");
+    std::println("-- RemoveSomeDataTask::run()");
 
     auto *entityManager = context()->entityManager();
     auto *entity        = entityManager->getEntityByAlias("PostgresBDLocal");

--- a/example/experimental/postgres_demo/task/data/removesomedatatask.cpp
+++ b/example/experimental/postgres_demo/task/data/removesomedatatask.cpp
@@ -23,8 +23,9 @@ void RemoveSomeDataTask::contextChanged()
         context()->service("Database", vigine::Name("TestDB"), vigine::Property::Exist));
 }
 
-// COPILOT_TODO: Перевіряти entity/_dbService і мати шлях повернення помилки з
-// clearTable/queryRequest, інакше збої БД тут залишаться непоміченими.
+// COPILOT_TODO: Validate entity/_dbService and provide an error-return
+// path from clearTable/queryRequest; otherwise database failures here
+// go unnoticed.
 vigine::Result RemoveSomeDataTask::run()
 {
     std::println("-- RemoveSomeDataTask::run()");

--- a/example/experimental/postgres_demo/task/data/removesomedatatask.h
+++ b/example/experimental/postgres_demo/task/data/removesomedatatask.h
@@ -13,7 +13,7 @@ class RemoveSomeDataTask : public vigine::AbstractTask
     RemoveSomeDataTask();
 
     void contextChanged() override;
-    vigine::Result execute() override;
+    [[nodiscard]] vigine::Result run() override;
 
   private:
     vigine::DatabaseService *_dbService{nullptr};

--- a/example/experimental/postgres_demo/task/db/checkbdshecmetask.cpp
+++ b/example/experimental/postgres_demo/task/db/checkbdshecmetask.cpp
@@ -23,7 +23,7 @@ void CheckBDShecmeTask::contextChanged()
         context()->service("Database", vigine::Name("TestDB"), vigine::Property::Exist));
 }
 
-vigine::Result CheckBDShecmeTask::execute()
+vigine::Result CheckBDShecmeTask::run()
 {
     vigine::Result result;
 

--- a/example/experimental/postgres_demo/task/db/checkbdshecmetask.h
+++ b/example/experimental/postgres_demo/task/db/checkbdshecmetask.h
@@ -13,7 +13,7 @@ class CheckBDShecmeTask : public vigine::AbstractTask
     CheckBDShecmeTask();
 
     void contextChanged() override;
-    vigine::Result execute() override;
+    [[nodiscard]] vigine::Result run() override;
 
   private:
     vigine::DatabaseService *_dbService{nullptr};

--- a/example/experimental/postgres_demo/task/db/initbdtask.cpp
+++ b/example/experimental/postgres_demo/task/db/initbdtask.cpp
@@ -24,7 +24,7 @@ void InitBDTask::contextChanged()
         context()->service("Database", vigine::Name("TestDB"), vigine::Property::New));
 }
 
-vigine::Result InitBDTask::execute()
+vigine::Result InitBDTask::run()
 {
     auto *entityManager       = context()->entityManager();
     vigine::Entity *ent       = entityManager->createEntity();

--- a/example/experimental/postgres_demo/task/db/initbdtask.h
+++ b/example/experimental/postgres_demo/task/db/initbdtask.h
@@ -13,7 +13,7 @@ class InitBDTask : public vigine::AbstractTask
     InitBDTask();
 
     void contextChanged() override;
-    vigine::Result execute() override;
+    [[nodiscard]] vigine::Result run() override;
 
   private:
     vigine::DatabaseService *_dbService{nullptr};

--- a/example/window/task/vulkan/initvulkantask.cpp
+++ b/example/window/task/vulkan/initvulkantask.cpp
@@ -52,7 +52,7 @@ void InitVulkanTask::contextChanged()
     std::cout << "RenderSystem initialized successfully" << std::endl;
 }
 
-vigine::Result InitVulkanTask::execute()
+vigine::Result InitVulkanTask::run()
 {
     std::cout << "Initializing Vulkan API..." << std::endl;
 

--- a/example/window/task/vulkan/initvulkantask.h
+++ b/example/window/task/vulkan/initvulkantask.h
@@ -22,7 +22,7 @@ class InitVulkanTask : public vigine::AbstractTask
     InitVulkanTask();
 
     void contextChanged() override;
-    vigine::Result execute() override;
+    [[nodiscard]] vigine::Result run() override;
 
   private:
     vigine::ecs::graphics::RenderSystem *_renderSystem{nullptr};

--- a/example/window/task/vulkan/loadtexturestask.cpp
+++ b/example/window/task/vulkan/loadtexturestask.cpp
@@ -31,7 +31,7 @@ void LoadTexturesTask::contextChanged()
     }
 }
 
-vigine::Result LoadTexturesTask::execute()
+vigine::Result LoadTexturesTask::run()
 {
     if (!_graphicsService)
     {

--- a/example/window/task/vulkan/loadtexturestask.h
+++ b/example/window/task/vulkan/loadtexturestask.h
@@ -25,7 +25,7 @@ class LoadTexturesTask : public vigine::AbstractTask
   public:
     LoadTexturesTask() = default;
 
-    vigine::Result execute() override;
+    [[nodiscard]] vigine::Result run() override;
     void contextChanged() override;
 
   private:

--- a/example/window/task/vulkan/rendercubetask.cpp
+++ b/example/window/task/vulkan/rendercubetask.cpp
@@ -12,7 +12,7 @@ void RenderCubeTask::contextChanged()
     // No specific services needed for cube rendering
 }
 
-vigine::Result RenderCubeTask::execute()
+vigine::Result RenderCubeTask::run()
 {
     // Update cube rotation
     _rotationAngle += 0.05f; // Rotate by 0.05 radians per frame

--- a/example/window/task/vulkan/rendercubetask.h
+++ b/example/window/task/vulkan/rendercubetask.h
@@ -8,7 +8,7 @@ class RenderCubeTask : public vigine::AbstractTask
     RenderCubeTask();
 
     void contextChanged() override;
-    vigine::Result execute() override;
+    [[nodiscard]] vigine::Result run() override;
 
   private:
     float _rotationAngle{0.0f};

--- a/example/window/task/vulkan/setupcubetask.cpp
+++ b/example/window/task/vulkan/setupcubetask.cpp
@@ -31,7 +31,7 @@ void SetupCubeTask::contextChanged()
     }
 }
 
-vigine::Result SetupCubeTask::execute()
+vigine::Result SetupCubeTask::run()
 {
     std::cout << "Setting up cube geometry..." << std::endl;
 

--- a/example/window/task/vulkan/setupcubetask.h
+++ b/example/window/task/vulkan/setupcubetask.h
@@ -18,7 +18,7 @@ class SetupCubeTask : public vigine::AbstractTask
     SetupCubeTask();
 
     void contextChanged() override;
-    vigine::Result execute() override;
+    [[nodiscard]] vigine::Result run() override;
 
   private:
     vigine::ecs::graphics::GraphicsService *_graphicsService{nullptr};

--- a/example/window/task/vulkan/setuphelpergeometrytask.cpp
+++ b/example/window/task/vulkan/setuphelpergeometrytask.cpp
@@ -31,7 +31,7 @@ void SetupHelperGeometryTask::contextChanged()
     }
 }
 
-vigine::Result SetupHelperGeometryTask::execute()
+vigine::Result SetupHelperGeometryTask::run()
 {
     std::cout << "Setting up helper geometry (pyramid, grid, sun)..." << std::endl;
 

--- a/example/window/task/vulkan/setuphelpergeometrytask.h
+++ b/example/window/task/vulkan/setuphelpergeometrytask.h
@@ -18,7 +18,7 @@ class SetupHelperGeometryTask : public vigine::AbstractTask
     SetupHelperGeometryTask();
 
     void contextChanged() override;
-    vigine::Result execute() override;
+    [[nodiscard]] vigine::Result run() override;
 
   private:
     vigine::ecs::graphics::GraphicsService *_graphicsService{nullptr};

--- a/example/window/task/vulkan/setuptextedittask.cpp
+++ b/example/window/task/vulkan/setuptextedittask.cpp
@@ -74,7 +74,7 @@ void SetupTextEditTask::contextChanged()
                             _graphicsService ? _graphicsService->renderSystem() : nullptr);
 }
 
-vigine::Result SetupTextEditTask::execute()
+vigine::Result SetupTextEditTask::run()
 {
     if (!_graphicsService)
         return vigine::Result(vigine::Result::Code::Error, "Graphics service is unavailable");

--- a/example/window/task/vulkan/setuptextedittask.h
+++ b/example/window/task/vulkan/setuptextedittask.h
@@ -32,7 +32,7 @@ class SetupTextEditTask : public vigine::AbstractTask
                                std::shared_ptr<TextEditorSystem> editorSystem);
 
     void contextChanged() override;
-    vigine::Result execute() override;
+    [[nodiscard]] vigine::Result run() override;
 
   private:
     std::shared_ptr<TextEditState> _state;

--- a/example/window/task/vulkan/setuptexttask.cpp
+++ b/example/window/task/vulkan/setuptexttask.cpp
@@ -56,7 +56,7 @@ void SetupTextTask::contextChanged()
     }
 }
 
-vigine::Result SetupTextTask::execute()
+vigine::Result SetupTextTask::run()
 {
     if (!_graphicsService)
     {

--- a/example/window/task/vulkan/setuptexttask.h
+++ b/example/window/task/vulkan/setuptexttask.h
@@ -18,7 +18,7 @@ class SetupTextTask : public vigine::AbstractTask
     SetupTextTask();
 
     void contextChanged() override;
-    vigine::Result execute() override;
+    [[nodiscard]] vigine::Result run() override;
 
   private:
     vigine::ecs::graphics::GraphicsService *_graphicsService{nullptr};

--- a/example/window/task/vulkan/setuptexturedplanestask.cpp
+++ b/example/window/task/vulkan/setuptexturedplanestask.cpp
@@ -30,7 +30,7 @@ void SetupTexturedPlanesTask::contextChanged()
             context()->service("Graphics", vigine::Name("MainGraphics"), vigine::Property::New));
     }
 }
-vigine::Result SetupTexturedPlanesTask::execute()
+vigine::Result SetupTexturedPlanesTask::run()
 {
     std::cout << "Setting up textured planes..." << std::endl;
 

--- a/example/window/task/vulkan/setuptexturedplanestask.h
+++ b/example/window/task/vulkan/setuptexturedplanestask.h
@@ -19,7 +19,7 @@ class SetupTexturedPlanesTask : public vigine::AbstractTask
   public:
     SetupTexturedPlanesTask() = default;
 
-    vigine::Result execute() override;
+    [[nodiscard]] vigine::Result run() override;
     void contextChanged() override;
 
   private:

--- a/example/window/task/window/initwindowtask.cpp
+++ b/example/window/task/window/initwindowtask.cpp
@@ -28,7 +28,7 @@ void InitWindowTask::createEventHandlers()
     _eventHandlers.push_back(std::make_unique<WindowEventHandler>("MainWindowHandler"));
 }
 
-vigine::Result InitWindowTask::execute()
+vigine::Result InitWindowTask::run()
 {
     if (!_platformService)
         return vigine::Result(vigine::Result::Code::Error, "Platform service is unavailable");

--- a/example/window/task/window/initwindowtask.h
+++ b/example/window/task/window/initwindowtask.h
@@ -22,7 +22,7 @@ class InitWindowTask : public vigine::AbstractTask
     InitWindowTask();
 
     void contextChanged() override;
-    vigine::Result execute() override;
+    [[nodiscard]] vigine::Result run() override;
 
   private:
     vigine::ecs::platform::PlatformService *_platformService{nullptr};

--- a/example/window/task/window/processinputeventtask.cpp
+++ b/example/window/task/window/processinputeventtask.cpp
@@ -19,7 +19,7 @@ ProcessInputEventTask::~ProcessInputEventTask()
     _tokens.clear();
 }
 
-vigine::Result ProcessInputEventTask::execute()
+vigine::Result ProcessInputEventTask::run()
 {
     // The task participates in the flow only to own its subscription
     // tokens and serve as a subscriber target; there is no per-tick work

--- a/example/window/task/window/processinputeventtask.h
+++ b/example/window/task/window/processinputeventtask.h
@@ -34,7 +34,7 @@ class IMessage;
  * future member is added after @c _tokens, the explicit clear still runs
  * first and drains any in-flight @c onMessage before other fields go away.
  *
- * @c execute remains a no-op returning @c Success; the task participates
+ * @c run remains a no-op returning @c Success; the task participates
  * in the flow only to own its subscription tokens and serve as a
  * subscriber target.
  */
@@ -45,7 +45,7 @@ class ProcessInputEventTask final : public vigine::AbstractTask,
     ProcessInputEventTask();
     ~ProcessInputEventTask() override;
 
-    [[nodiscard]] vigine::Result execute() override;
+    [[nodiscard]] vigine::Result run() override;
 
     /**
      * @brief Delivers an incoming message from the bus to the matching

--- a/example/window/task/window/runwindowtask.cpp
+++ b/example/window/task/window/runwindowtask.cpp
@@ -119,7 +119,7 @@ void RunWindowTask::contextChanged()
 
 // COPILOT_TODO: Гарантувати unbindEntity() на всіх ранніх виходах через
 // RAII/guard, інакше PlatformService може залишитися прив'язаним після помилки.
-vigine::Result RunWindowTask::execute()
+vigine::Result RunWindowTask::run()
 {
     if ((!_platformService || !_graphicsService) && context())
         contextChanged();

--- a/example/window/task/window/runwindowtask.cpp
+++ b/example/window/task/window/runwindowtask.cpp
@@ -117,8 +117,9 @@ void RunWindowTask::contextChanged()
         _textEditorSystem->bind(context(), _graphicsService, _renderSystem);
 }
 
-// COPILOT_TODO: Гарантувати unbindEntity() на всіх ранніх виходах через
-// RAII/guard, інакше PlatformService може залишитися прив'язаним після помилки.
+// COPILOT_TODO: Guarantee unbindEntity() on every early exit via an
+// RAII/scope guard; otherwise PlatformService can stay bound to the
+// entity after an error return path.
 vigine::Result RunWindowTask::run()
 {
     if ((!_platformService || !_graphicsService) && context())

--- a/example/window/task/window/runwindowtask.h
+++ b/example/window/task/window/runwindowtask.h
@@ -38,7 +38,7 @@ class RunWindowTask final : public vigine::AbstractTask
     RunWindowTask();
 
     void contextChanged() override;
-    vigine::Result execute() override;
+    [[nodiscard]] vigine::Result run() override;
 
     void onMouseButtonDown(vigine::ecs::platform::MouseButton button, int x, int y);
     void onMouseButtonUp(vigine::ecs::platform::MouseButton button, int x, int y);

--- a/include/vigine/api/taskflow/abstracttask.h
+++ b/include/vigine/api/taskflow/abstracttask.h
@@ -2,10 +2,17 @@
 
 /**
  * @file abstracttask.h
- * @brief Legacy base class for a single unit of work run inside a TaskFlow.
+ * @brief Stateful base class for a single unit of work run inside a
+ *        TaskFlow.
  */
 
+#include "vigine/api/taskflow/itask.h"
 #include "vigine/result.h"
+
+namespace vigine::engine
+{
+class IEngineToken;
+} // namespace vigine::engine
 
 namespace vigine
 {
@@ -13,20 +20,38 @@ namespace vigine
 class Context;
 
 /**
- * @brief Base for task objects executed by TaskFlow / StateMachine.
+ * @brief Stateful @ref ITask base.
  *
- * A task carries a non-owning Context pointer set externally via
- * setContext, runs once when its owning flow schedules it, and returns
- * a Result whose Code drives the next transition. Concrete tasks
- * implement execute() and may override contextChanged() to react to
- * context binding. The Context pointer is held by composition (private
- * member); the previous ContextHolder mixin has been deleted.
+ * @ref AbstractTask wires the task-side half of the
+ * @ref vigine::engine::IEngineToken contract documented in
+ * @c architecture.md § R-StateScope: it stores the non-owning token
+ * pointer bound by the engine via @ref setApi and exposes it through
+ * @ref api. Concrete tasks override @ref run; they reach engine
+ * subsystems through @ref api or through the legacy @ref context
+ * accessor while the umbrella branch is still mid-migration to a
+ * token-only world.
+ *
+ * Composition, not inheritance:
+ *   - The base inherits from @ref ITask only. The previous
+ *     @c ContextHolder mixin has been deleted (issue #283); the
+ *     @c Context* pointer is now held as a private member and
+ *     surfaced through @ref setContext / @ref context /
+ *     @ref contextChanged for tasks that have not yet been migrated
+ *     off direct context access.
+ *
+ * Strict encapsulation: the @c _api token pointer and the
+ * @c _context pointer are both @c private. The @ref setApi and
+ * @ref api overrides are marked @c final so concrete tasks cannot
+ * bypass the binding contract.
  */
-class AbstractTask
+class AbstractTask : public ITask
 {
   public:
-    virtual ~AbstractTask();
-    [[nodiscard]] virtual Result execute() = 0;
+    ~AbstractTask() override;
+
+    void setApi(engine::IEngineToken *api) noexcept override final;
+
+    [[nodiscard]] engine::IEngineToken *api() noexcept override final;
 
     void setContext(Context *context);
 
@@ -37,7 +62,27 @@ class AbstractTask
     virtual void contextChanged();
 
   private:
+    /**
+     * @brief Non-owning context pointer bound externally via
+     *        @ref setContext.
+     *
+     * Held by composition; the previous @c ContextHolder mixin has
+     * been deleted (issue #283). Concrete tasks that have not yet
+     * been migrated off direct context access reach the context via
+     * @ref context.
+     */
     Context *_context{nullptr};
+
+    /**
+     * @brief Non-owning engine token bound by the task flow before
+     *        every @ref run invocation.
+     *
+     * Reset to @c nullptr when the task flow clears the binding
+     * between ticks. The pointer never owns the underlying token; the
+     * task flow (or the state machine that issued the token) keeps
+     * the concrete object alive while it is in scope.
+     */
+    engine::IEngineToken *_api{nullptr};
 };
 
 } // namespace vigine

--- a/include/vigine/api/taskflow/itask.h
+++ b/include/vigine/api/taskflow/itask.h
@@ -8,9 +8,11 @@
  * @ref ITask is the task-side half of the @ref vigine::engine::IEngineToken
  * contract documented in @c architecture.md § R-StateScope. The task
  * flow hands every concrete task a state-scoped @ref IEngineToken via
- * @ref setApi before invoking @ref run; the task reaches engine
- * subsystems exclusively through the bound token instead of caching a
- * raw @ref vigine::IContext pointer.
+ * @ref setApi before invoking @ref run; tasks SHOULD prefer the bound
+ * token for engine access. Legacy @c context()-based access remains
+ * available during the v0.1.0 migration window for tasks still derived
+ * from the @ref vigine::ContextHolder mixin; future versions will
+ * remove the legacy path and require the bound token exclusively.
  *
  * Lifecycle:
  *   - @ref setApi binds a non-owning @ref vigine::engine::IEngineToken

--- a/include/vigine/api/taskflow/itask.h
+++ b/include/vigine/api/taskflow/itask.h
@@ -1,0 +1,130 @@
+#pragma once
+
+/**
+ * @file itask.h
+ * @brief Pure-virtual contract for a single unit of work executed by
+ *        the task flow.
+ *
+ * @ref ITask is the task-side half of the @ref vigine::engine::IEngineToken
+ * contract documented in @c architecture.md § R-StateScope. The task
+ * flow hands every concrete task a state-scoped @ref IEngineToken via
+ * @ref setApi before invoking @ref run; the task reaches engine
+ * subsystems exclusively through the bound token instead of caching a
+ * raw @ref vigine::IContext pointer.
+ *
+ * Lifecycle:
+ *   - @ref setApi binds a non-owning @ref vigine::engine::IEngineToken
+ *     pointer for the upcoming @ref run call. The pointer must remain
+ *     live for the duration of the @ref run invocation; the engine
+ *     guarantees this by issuing the token, calling @ref run
+ *     synchronously inside the bound state's scope, and only then
+ *     letting the token expire.
+ *   - @ref api returns the bound token (or @c nullptr when no token
+ *     has been bound yet). Callers branch on the return value before
+ *     dereferencing.
+ *   - @ref run is the canonical task-facing entry point. The task
+ *     flow calls it once per scheduled tick. The return @ref Result
+ *     drives the result-code-keyed transitions registered on the
+ *     enclosing @ref vigine::TaskFlow.
+ *
+ * Self-destruct contract (architecture.md § R-StateScope, mechanism
+ * step 5): a task whose bound state has been torn down out from under
+ * it sees gated accessors on @ref api return
+ * @ref vigine::engine::Result::Code::Expired. The task MUST cooperate
+ * by returning from @ref run promptly with an error @ref Result rather
+ * than racing the engine through additional gated calls. The engine
+ * does not interrupt or kill running tasks.
+ *
+ * Invariants:
+ *   - INV-10: @c I prefix for this pure-virtual interface (no state,
+ *             no non-virtual method bodies).
+ *   - INV-12: no data members on this pure interface; the stateful
+ *             base @ref vigine::AbstractTask carries the bound
+ *             @ref vigine::engine::IEngineToken pointer.
+ */
+
+#include "vigine/result.h"
+
+namespace vigine::engine
+{
+class IEngineToken;
+} // namespace vigine::engine
+
+namespace vigine
+{
+
+/**
+ * @brief Pure-virtual contract for a unit of work scheduled by the
+ *        task flow.
+ *
+ * Concrete tasks derive from @ref AbstractTask, which implements
+ * @ref setApi and @ref api as @c final and leaves @ref run pure
+ * virtual. The task flow binds a state-scoped
+ * @ref vigine::engine::IEngineToken via @ref setApi before invoking
+ * @ref run.
+ *
+ * Thread-safety: the contract does not pin one. The default
+ * implementation in @ref AbstractTask runs every method on the
+ * thread that drives the task flow's tick (typically the controller
+ * thread). Concrete tasks may dispatch work to other threads via
+ * @ref vigine::engine::IEngineToken::threadManager but must complete
+ * their own @ref run on the calling thread before returning.
+ */
+class ITask
+{
+  public:
+    virtual ~ITask() = default;
+
+    /**
+     * @brief Binds @p api as the engine token for the upcoming
+     *        @ref run invocation.
+     *
+     * The pointer is non-owning. The task must not store it past the
+     * end of @ref run because the token expires when the FSM
+     * transitions away from the bound state. Pass @c nullptr to clear
+     * the binding (e.g. between ticks); subsequent @ref api calls
+     * return @c nullptr until the next @ref setApi.
+     */
+    virtual void setApi(engine::IEngineToken *api) = 0;
+
+    /**
+     * @brief Returns the engine token bound for the current
+     *        @ref run, or @c nullptr when no token has been bound.
+     *
+     * Tasks reach engine subsystems through the returned token's
+     * gated and ungated accessors; see
+     * @ref vigine::engine::IEngineToken for the surface. Callers
+     * inside @ref run dereference without checking when the engine's
+     * dispatch contract guarantees a token was bound; callers from
+     * helpers running outside @ref run (e.g. event handlers) must
+     * branch on null.
+     */
+    [[nodiscard]] virtual engine::IEngineToken *api() = 0;
+
+    /**
+     * @brief Canonical task-facing entry point.
+     *
+     * The task flow invokes @ref run exactly once per scheduled tick
+     * after binding the engine token via @ref setApi. The returned
+     * @ref Result drives the result-code-keyed transitions registered
+     * on the enclosing flow: a transition with a matching
+     * @ref Result::Code fires; otherwise the flow stops.
+     *
+     * Tasks signalling staleness (gated accessor returned
+     * @ref vigine::engine::Result::Code::Expired) should return an
+     * error @ref Result so the flow does not advance. The engine
+     * never interrupts a running @ref run; cooperative exit is the
+     * task's responsibility.
+     */
+    [[nodiscard]] virtual Result run() = 0;
+
+    ITask(const ITask &)            = delete;
+    ITask &operator=(const ITask &) = delete;
+    ITask(ITask &&)                 = delete;
+    ITask &operator=(ITask &&)      = delete;
+
+  protected:
+    ITask() = default;
+};
+
+} // namespace vigine

--- a/src/api/taskflow/abstracttask.cpp
+++ b/src/api/taskflow/abstracttask.cpp
@@ -2,16 +2,31 @@
 
 #include "vigine/context.h"
 
-vigine::AbstractTask::~AbstractTask() {}
+namespace vigine
+{
 
-vigine::AbstractTask::AbstractTask() {}
+AbstractTask::AbstractTask() = default;
 
-void vigine::AbstractTask::setContext(Context *context)
+AbstractTask::~AbstractTask() = default;
+
+void AbstractTask::setApi(engine::IEngineToken *api) noexcept
+{
+    _api = api;
+}
+
+engine::IEngineToken *AbstractTask::api() noexcept
+{
+    return _api;
+}
+
+void AbstractTask::setContext(Context *context)
 {
     _context = context;
     contextChanged();
 }
 
-vigine::Context *vigine::AbstractTask::context() const { return _context; }
+Context *AbstractTask::context() const { return _context; }
 
-void vigine::AbstractTask::contextChanged() {}
+void AbstractTask::contextChanged() {}
+
+} // namespace vigine

--- a/src/impl/taskflow/taskflow.cpp
+++ b/src/impl/taskflow/taskflow.cpp
@@ -1,5 +1,6 @@
 #include <vigine/context.h>
 #include <vigine/api/context/icontext.h>
+#include <vigine/api/engine/iengine_token.h>
 #include <vigine/api/messaging/imessage.h>
 #include <vigine/api/messaging/isubscriber.h>
 #include <vigine/api/messaging/isubscriptiontoken.h>
@@ -8,6 +9,7 @@
 #include <vigine/api/messaging/routemode.h>
 #include <vigine/api/messaging/payload/payloadtypeid.h>
 #include <vigine/api/messaging/isignalemitter.h>
+#include <vigine/api/statemachine/stateid.h>
 #include <vigine/impl/taskflow/taskflow.h>
 #include <vigine/core/threading/irunnable.h>
 #include <vigine/core/threading/ithreadmanager.h>
@@ -449,8 +451,36 @@ void TaskFlow::runCurrentTask() {
   if (!_currTask)
     return;
 
-  // Execute current task and get result
-  auto currStatus = _currTask->execute();
+  // R-StateScope wiring: bind a state-scoped engine token before
+  // invoking the task's run() entry point. The legacy aggregator
+  // returns a null token (see Context::makeEngineToken stub) — that
+  // is fine for tasks that have not yet migrated off the
+  // ContextHolder mixin; their api() accessor reports nullptr and
+  // they fall back to context() as before. New-shape tasks check
+  // api() and reach engine subsystems through the bound token.
+  std::unique_ptr<engine::IEngineToken> token;
+  if (_context != nullptr) {
+    // Pass the invalid-sentinel StateId on the legacy path: the
+    // legacy Context::makeEngineToken ignores the argument and
+    // returns nullptr unconditionally; the new-shape AbstractContext
+    // factory also tolerates the sentinel and threads it into the
+    // concrete token. The IStateMachine::current() lookup that
+    // would normally seed the bound state lands together with the
+    // upcoming TaskFlow rewrite.
+    token = _context->makeEngineToken(vigine::statemachine::StateId{});
+  }
+  _currTask->setApi(token.get());
+
+  // Run the task (canonical R-StateScope entry point). The Result
+  // drives the result-code-keyed transitions registered through
+  // route().
+  auto currStatus = _currTask->run();
+
+  // Clear the binding before the token expires so the task cannot
+  // accidentally reach the dying token from a callback that fires
+  // outside the run() scope.
+  _currTask->setApi(nullptr);
+  token.reset();
 
   // Check possible transitions
   auto transitions = _transitions.find(_currTask);

--- a/src/impl/taskflow/taskflow.cpp
+++ b/src/impl/taskflow/taskflow.cpp
@@ -469,17 +469,35 @@ void TaskFlow::runCurrentTask() {
     // upcoming TaskFlow rewrite.
     token = _context->makeEngineToken(vigine::statemachine::StateId{});
   }
-  _currTask->setApi(token.get());
 
-  // Run the task (canonical R-StateScope entry point). The Result
-  // drives the result-code-keyed transitions registered through
-  // route().
-  auto currStatus = _currTask->run();
+  // RAII scope guard: ensures setApi(nullptr) runs even if run()
+  // throws. The guard's destructor clears the binding before the
+  // owning unique_ptr below releases the token, so the task cannot
+  // observe a dangling IEngineToken* through a stray callback.
+  struct ApiBindingGuard {
+    AbstractTask *task;
+    explicit ApiBindingGuard(AbstractTask *t) : task(t) {}
+    ~ApiBindingGuard() {
+      if (task)
+        task->setApi(nullptr);
+    }
+    ApiBindingGuard(const ApiBindingGuard &)            = delete;
+    ApiBindingGuard &operator=(const ApiBindingGuard &) = delete;
+    ApiBindingGuard(ApiBindingGuard &&)                 = delete;
+    ApiBindingGuard &operator=(ApiBindingGuard &&)      = delete;
+  };
 
-  // Clear the binding before the token expires so the task cannot
-  // accidentally reach the dying token from a callback that fires
-  // outside the run() scope.
-  _currTask->setApi(nullptr);
+  Result currStatus;
+  {
+    _currTask->setApi(token.get());
+    [[maybe_unused]] ApiBindingGuard guard(_currTask);
+
+    // Run the task (canonical R-StateScope entry point). The Result
+    // drives the result-code-keyed transitions registered through
+    // route(). If run() throws, the guard above clears the binding
+    // before stack unwinding releases `token`.
+    currStatus = _currTask->run();
+  }
   token.reset();
 
   // Check possible transitions


### PR DESCRIPTION
## Summary

- Add the pure-virtual `vigine::ITask` interface in
  `include/vigine/api/taskflow/itask.h` with the three R-StateScope
  methods: `setApi(IEngineToken*)`, `api() -> IEngineToken*`, and
  `Result run()`.
- `AbstractTask` now derives from `ITask` and stores the bound token
  through a private non-owning `IEngineToken*`; `setApi` and `api`
  are marked `final`. The `ContextHolder` mixin stays in place so
  tasks that have not yet been migrated off direct context access
  keep compiling.
- `TaskFlow::runCurrentTask` mints a state-scoped token via
  `Context::makeEngineToken` (legacy stub returns `nullptr` today —
  the wiring is in place for the new context aggregator), hands it
  to the task through `setApi`, invokes `run()`, then clears the
  binding and lets the token expire before evaluating result-code
  transitions on the registered edges.
- Migrate every concrete task subclass under `example/window` and
  `example/experimental/postgres_demo` (16 files) by renaming the
  override from `execute()` to `run()` and adding the missing
  `[[nodiscard]]` attribute on the new declarations.

## Test plan

- [x] `cmake --preset windows-debug -DENABLE_UNITTEST=ON
      -DBUILD_EXAMPLE_THREADED_BUS=ON -DBUILD_EXAMPLE_PARALLEL_FSM=ON
      -DBUILD_EXAMPLE_FANOUT_FSM=ON` configures cleanly.
- [x] `cmake --build --preset windows-debug` builds at `/WX` with
      no warnings (277/277 targets including `example-window`,
      `example-parallel-fsm`, `example-threaded-bus`,
      `example-fanout-fsm`).
- [x] `ctest --output-on-failure` reports `100% tests passed,
      0 tests failed out of 205`.
- [x] `example-parallel-fsm.exe`: `exchanges: 100/100`.
- [x] `example-threaded-bus.exe`: `Received: 800 / 800`,
      `Reentry violations: 0`.
- [x] `example-fanout-fsm.exe`: `fanout completed: 16/16 FSMs reached
      final state`.

Closes #288.