### PR TITLE
Add FF-70 + FSM affinity + parallelFor contract tests (#294)

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -685,7 +685,11 @@ add_executable(${FULL_CONTRACT_TARGET}
     contract/scenario_12_service_lifecycle.cpp
     contract/scenario_13_ecs_entity_lifecycle.cpp
     contract/scenario_14_statemachine_hsm.cpp
+    contract/scenario_15_subscriber_serialization.cpp
+    contract/scenario_16_dtor_blocks_in_flight.cpp
+    contract/scenario_17_fsm_thread_affinity.cpp
     contract/scenario_18_fsm_async_transition.cpp
+    contract/scenario_19_parallel_for.cpp
     contract/scenario_21_stale_engine_token.cpp
     contract/scenario_22_token_expiration_callback.cpp
 )

--- a/test/contract/scenario_15_subscriber_serialization.cpp
+++ b/test/contract/scenario_15_subscriber_serialization.cpp
@@ -151,7 +151,16 @@ TEST_F(SubscriberSerialization, ConcurrentPublishersNeverReenterOnMessage)
     // dispatcher actually runs on the post()-caller thread. The fixture
     // stack offers an InlineOnly variant which would not exercise the
     // FF-70 contract (single-threaded by construction).
+    //
+    // Force at least 4 worker threads regardless of the host CPU count.
+    // The factory's default of poolSize == 0 derives the pool from
+    // std::thread::hardware_concurrency(), which can report 1 on a
+    // single-core CI runner; in that case publishers would run serially
+    // and the FF-70 reentry canary would never fire even if the
+    // serialisation invariant were broken (a false-pass risk). Pinning
+    // poolSize to 4 keeps the contract genuinely under test.
     vigine::core::threading::ThreadManagerConfig tmCfg{};
+    tmCfg.poolSize = 4;
     auto tm = vigine::core::threading::createThreadManager(tmCfg);
     ASSERT_NE(tm, nullptr);
 

--- a/test/contract/scenario_15_subscriber_serialization.cpp
+++ b/test/contract/scenario_15_subscriber_serialization.cpp
@@ -1,0 +1,213 @@
+// ---------------------------------------------------------------------------
+// Scenario 15 -- FF-70 per-subscriber onMessage serialisation.
+//
+// IMessageBus guarantees that ISubscriber::onMessage is never invoked
+// concurrently for the SAME subscriber, even when N producer threads
+// drive post() at once on a Shared-policy bus (drain runs on the
+// post()-caller thread, so several drains race for the slot's
+// per-slot deliverMutex). The contract is documented on
+// IMessageBus::post and is the substrate every messaging facade
+// relies on for its own thread-safety reasoning.
+//
+// What this scenario pins
+// -----------------------
+//   - Spawn N publisher threads on the thread-manager pool. Each
+//     publisher posts M envelopes back to back.
+//   - One CountingSubscriber is the only consumer for the test's
+//     filter; it counts in-flight onMessage entries via an atomic
+//     canary. Whenever a second thread enters onMessage while a first
+//     is still inside, the canary catches the violation.
+//   - After every publisher handle waits to completion, the test
+//     asserts:
+//       1. The subscriber received exactly N * M dispatches.
+//       2. The reentry-violation counter is 0.
+//
+// The scenario uses a private Shared-policy stack (not the inline-only
+// fixture stack) precisely because the FF-70 contract is meaningful
+// only when several worker threads can race on a slot. Inline-only
+// dispatch is single-threaded by construction and would not exercise
+// the deliverMutex.
+// ---------------------------------------------------------------------------
+
+#include "fixtures/contract_helpers.h"
+#include "fixtures/engine_fixture.h"
+
+#include "vigine/api/messaging/busconfig.h"
+#include "vigine/api/messaging/factory.h"
+#include "vigine/api/messaging/imessagebus.h"
+#include "vigine/api/messaging/isubscriber.h"
+#include "vigine/api/messaging/isubscriptiontoken.h"
+#include "vigine/api/messaging/messagefilter.h"
+#include "vigine/api/messaging/messagekind.h"
+#include "vigine/api/messaging/routemode.h"
+#include "vigine/api/messaging/payload/payloadtypeid.h"
+#include "vigine/core/threading/factory.h"
+#include "vigine/core/threading/irunnable.h"
+#include "vigine/core/threading/itaskhandle.h"
+#include "vigine/core/threading/ithreadmanager.h"
+#include "vigine/core/threading/threadaffinity.h"
+#include "vigine/core/threading/threadmanagerconfig.h"
+#include "vigine/result.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace vigine::contract
+{
+namespace
+{
+
+using SubscriberSerialization = EngineFixture;
+
+constexpr vigine::payload::PayloadTypeId kSerialPayloadTypeId{0x90201u};
+constexpr int kPublisherCount  = 8;
+constexpr int kMessagesPer     = 100;
+constexpr int kExpectedTotal   = kPublisherCount * kMessagesPer;
+
+// Subscriber that counts dispatches and detects concurrent onMessage
+// entries on the same slot via an atomic in-flight canary. The "prior"
+// value of fetch_add must always be 0 for a slot the bus serialises;
+// any non-zero observation increments the violation counter.
+class SerialisationSubscriber final : public vigine::messaging::ISubscriber
+{
+  public:
+    [[nodiscard]] vigine::messaging::DispatchResult
+        onMessage(const vigine::messaging::IMessage & /*message*/) override
+    {
+        const int prior = _inFlight.fetch_add(1, std::memory_order_acq_rel);
+        if (prior != 0)
+        {
+            _violations.fetch_add(1, std::memory_order_acq_rel);
+        }
+        // A small spin keeps the entry window wide enough that a racing
+        // dispatcher would actually observe the in-flight state, without
+        // adding a real sleep that would slow the test down.
+        for (volatile int i = 0; i < 32; ++i)
+        {
+            (void)i;
+        }
+        _hits.fetch_add(1, std::memory_order_acq_rel);
+        _inFlight.fetch_sub(1, std::memory_order_acq_rel);
+        return vigine::messaging::DispatchResult::Handled;
+    }
+
+    [[nodiscard]] int hits() const noexcept
+    {
+        return _hits.load(std::memory_order_acquire);
+    }
+
+    [[nodiscard]] int violations() const noexcept
+    {
+        return _violations.load(std::memory_order_acquire);
+    }
+
+  private:
+    std::atomic<int> _inFlight{0};
+    std::atomic<int> _hits{0};
+    std::atomic<int> _violations{0};
+};
+
+// IRunnable that posts a fixed batch of envelopes to the shared bus.
+class BatchPublisher final : public vigine::core::threading::IRunnable
+{
+  public:
+    BatchPublisher(vigine::messaging::IMessageBus &bus, int messages) noexcept
+        : _bus(bus)
+        , _messages(messages)
+    {
+    }
+
+    [[nodiscard]] vigine::Result run() override
+    {
+        for (int i = 0; i < _messages; ++i)
+        {
+            const vigine::Result r = _bus.post(std::make_unique<ContractMessage>(
+                vigine::messaging::MessageKind::Signal,
+                vigine::messaging::RouteMode::FirstMatch,
+                kSerialPayloadTypeId));
+            if (r.isError())
+            {
+                return r;
+            }
+        }
+        return vigine::Result{};
+    }
+
+  private:
+    vigine::messaging::IMessageBus &_bus;
+    int                             _messages;
+};
+
+TEST_F(SubscriberSerialization, ConcurrentPublishersNeverReenterOnMessage)
+{
+    // Build a Shared-policy bus on a fresh thread-manager so the
+    // dispatcher actually runs on the post()-caller thread. The fixture
+    // stack offers an InlineOnly variant which would not exercise the
+    // FF-70 contract (single-threaded by construction).
+    vigine::core::threading::ThreadManagerConfig tmCfg{};
+    auto tm = vigine::core::threading::createThreadManager(tmCfg);
+    ASSERT_NE(tm, nullptr);
+
+    vigine::messaging::BusConfig busCfg{};
+    busCfg.name         = "scenario15-serialisation";
+    busCfg.priority     = vigine::messaging::BusPriority::Normal;
+    busCfg.threading    = vigine::messaging::ThreadingPolicy::Shared;
+    busCfg.capacity     = vigine::messaging::QueueCapacity{
+        /*maxMessages=*/static_cast<std::size_t>(kExpectedTotal * 2),
+        /*bounded=*/true};
+    busCfg.backpressure = vigine::messaging::BackpressurePolicy::Block;
+
+    auto bus = vigine::messaging::createMessageBus(busCfg, *tm);
+    ASSERT_NE(bus, nullptr);
+
+    SerialisationSubscriber subscriber{};
+
+    vigine::messaging::MessageFilter filter{};
+    filter.kind   = vigine::messaging::MessageKind::Signal;
+    filter.typeId = kSerialPayloadTypeId;
+
+    auto token = bus->subscribe(filter, &subscriber);
+    ASSERT_NE(token, nullptr);
+    EXPECT_TRUE(token->active());
+
+    // Schedule kPublisherCount runnables on the worker pool. The
+    // handles stay on the stack so the bus + subscriber remain alive
+    // until every post() and its triggered drain has returned.
+    std::vector<std::unique_ptr<vigine::core::threading::ITaskHandle>> handles;
+    handles.reserve(kPublisherCount);
+
+    for (int i = 0; i < kPublisherCount; ++i)
+    {
+        auto runnable = std::make_unique<BatchPublisher>(*bus, kMessagesPer);
+        auto handle   = tm->schedule(
+            std::move(runnable),
+            vigine::core::threading::ThreadAffinity::Pool);
+        ASSERT_NE(handle, nullptr);
+        handles.push_back(std::move(handle));
+    }
+
+    // Wait every publisher to completion. Each successful wait() means
+    // every post() in that runnable returned; with Shared dispatch the
+    // drain (and therefore every onMessage call) has returned too.
+    for (auto &h : handles)
+    {
+        const vigine::Result waited = h->waitFor(std::chrono::seconds{30});
+        EXPECT_TRUE(waited.isSuccess())
+            << "publisher must finish; got: " << waited.message();
+    }
+
+    EXPECT_EQ(subscriber.hits(), kExpectedTotal)
+        << "subscriber must observe every posted dispatch";
+    EXPECT_EQ(subscriber.violations(), 0)
+        << "FF-70: onMessage must never run concurrently for the same subscriber";
+}
+
+} // namespace
+} // namespace vigine::contract

--- a/test/contract/scenario_16_dtor_blocks_in_flight.cpp
+++ b/test/contract/scenario_16_dtor_blocks_in_flight.cpp
@@ -1,0 +1,203 @@
+// ---------------------------------------------------------------------------
+// Scenario 16 -- FF-69 token destruction blocks until in-flight onMessage
+// drains.
+//
+// The FF-69 contract is the lifecycle handshake that lets subscribers
+// own callback memory without racing the dispatcher: when a caller
+// drops the SubscriptionToken (or calls cancel() explicitly), the
+// teardown must not return until every onMessage already in flight on
+// that slot has returned. The mechanism in AbstractMessageBus is the
+// pair of reader/writer locks -- deliver() acquires the slot's
+// lifecycleMutex in shared mode for the duration of onMessage, and
+// IBusControlBlock::unregisterSubscription() (the call chained from
+// the token destructor / cancel()) acquires the same mutex in
+// exclusive mode, which blocks until every shared holder releases.
+//
+// What this scenario pins
+// -----------------------
+//   1. A subscriber sleeps inside onMessage long enough for the test
+//      thread to observe it has entered (signal flag set).
+//   2. The test thread waits on that flag, then calls token->cancel().
+//      The cancel call must NOT return before the slow onMessage
+//      returns -- the test thread captures wall-clock timestamps on
+//      both sides of the cancel call.
+//   3. The slow handler also captures the wall-clock instant it is
+//      about to return. The post-condition is:
+//          handler_returned_at <= cancel_returned_at,
+//      i.e. the cancel completed at or after the handler released
+//      the slot. Conversely, the cancel call must have stayed
+//      blocked for "long enough" -- we assert it took at least the
+//      handler's sleep duration minus a generous tolerance.
+//
+// Without FF-69, cancel() would race ahead of the in-flight onMessage
+// and the subscriber object could be torn down with a callback still
+// running on top of its memory. The contract makes RAII tokens safe;
+// this scenario is the regression pin.
+// ---------------------------------------------------------------------------
+
+#include "fixtures/contract_helpers.h"
+#include "fixtures/engine_fixture.h"
+
+#include "vigine/api/messaging/busconfig.h"
+#include "vigine/api/messaging/factory.h"
+#include "vigine/api/messaging/imessagebus.h"
+#include "vigine/api/messaging/isubscriber.h"
+#include "vigine/api/messaging/isubscriptiontoken.h"
+#include "vigine/api/messaging/messagefilter.h"
+#include "vigine/api/messaging/messagekind.h"
+#include "vigine/api/messaging/routemode.h"
+#include "vigine/api/messaging/payload/payloadtypeid.h"
+#include "vigine/core/threading/factory.h"
+#include "vigine/core/threading/ithreadmanager.h"
+#include "vigine/core/threading/threadmanagerconfig.h"
+#include "vigine/result.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <utility>
+
+namespace vigine::contract
+{
+namespace
+{
+
+using DtorBlocksInFlight = EngineFixture;
+
+constexpr vigine::payload::PayloadTypeId kSlowPayloadTypeId{0x90301u};
+constexpr auto                           kHandlerSleep =
+    std::chrono::milliseconds{200};
+
+// Subscriber that signals "entered" on the way in, sleeps for a fixed
+// window so the test thread can race a cancel against it, then signals
+// "about to return" with a timestamp captured immediately before the
+// onMessage call returns.
+class SlowSubscriber final : public vigine::messaging::ISubscriber
+{
+  public:
+    [[nodiscard]] vigine::messaging::DispatchResult
+        onMessage(const vigine::messaging::IMessage & /*message*/) override
+    {
+        // Tell the test thread we are inside the callback. The mutex
+        // pairs the flag write with the wait predicate; without the
+        // lock the test thread could observe the bool before
+        // notify_one's release, which is a benign data race here but
+        // not worth diagnosing under TSan.
+        {
+            std::lock_guard<std::mutex> lock{_mtx};
+            _entered = true;
+        }
+        _cv.notify_one();
+
+        std::this_thread::sleep_for(kHandlerSleep);
+
+        // Capture the instant we are about to release the slot's
+        // lifecycleMutex. The test thread captures its own instant
+        // either side of cancel(); the relative ordering between
+        // those instants is what the FF-69 assertion compares.
+        _returnedAt =
+            std::chrono::steady_clock::now().time_since_epoch().count();
+        return vigine::messaging::DispatchResult::Handled;
+    }
+
+    void waitForEnter()
+    {
+        std::unique_lock<std::mutex> lock{_mtx};
+        _cv.wait(lock, [this] { return _entered; });
+    }
+
+    [[nodiscard]] long long returnedAt() const noexcept
+    {
+        return _returnedAt.load(std::memory_order_acquire);
+    }
+
+  private:
+    std::mutex                _mtx;
+    std::condition_variable   _cv;
+    bool                      _entered{false};
+    std::atomic<long long>    _returnedAt{0};
+};
+
+TEST_F(DtorBlocksInFlight, CancelWaitsForInFlightOnMessage)
+{
+    // Shared-policy bus so dispatch runs synchronously on the
+    // post()-caller (a separate poster thread). Inline-only would
+    // dispatch on the main thread and we could not race a cancel
+    // against the in-flight handler at all.
+    vigine::core::threading::ThreadManagerConfig tmCfg{};
+    auto tm = vigine::core::threading::createThreadManager(tmCfg);
+    ASSERT_NE(tm, nullptr);
+
+    vigine::messaging::BusConfig busCfg{};
+    busCfg.name         = "scenario16-dtor-block";
+    busCfg.priority     = vigine::messaging::BusPriority::Normal;
+    busCfg.threading    = vigine::messaging::ThreadingPolicy::Shared;
+    busCfg.capacity     = vigine::messaging::QueueCapacity{16, true};
+    busCfg.backpressure = vigine::messaging::BackpressurePolicy::Block;
+
+    auto bus = vigine::messaging::createMessageBus(busCfg, *tm);
+    ASSERT_NE(bus, nullptr);
+
+    SlowSubscriber subscriber{};
+
+    vigine::messaging::MessageFilter filter{};
+    filter.kind   = vigine::messaging::MessageKind::Signal;
+    filter.typeId = kSlowPayloadTypeId;
+
+    auto token = bus->subscribe(filter, &subscriber);
+    ASSERT_NE(token, nullptr);
+    EXPECT_TRUE(token->active());
+
+    // Poster thread: drives one post() into the bus. Because the bus
+    // is Shared-policy, this thread runs the dispatcher synchronously,
+    // which means it is the thread that sits inside SlowSubscriber's
+    // onMessage for kHandlerSleep.
+    std::thread poster{[&bus]() {
+        const vigine::Result r = bus->post(std::make_unique<ContractMessage>(
+            vigine::messaging::MessageKind::Signal,
+            vigine::messaging::RouteMode::FirstMatch,
+            kSlowPayloadTypeId));
+        EXPECT_TRUE(r.isSuccess()) << "post must succeed; got: " << r.message();
+    }};
+
+    // Wait until we know the dispatcher is inside onMessage. From this
+    // point cancel() must block on the slot's lifecycle mutex until
+    // the handler returns.
+    subscriber.waitForEnter();
+
+    const auto cancelStart = std::chrono::steady_clock::now();
+    token->cancel();
+    const auto cancelEnd = std::chrono::steady_clock::now();
+
+    // The handler captures its own return instant inside onMessage just
+    // before returning. The cancel call must observe that instant on
+    // its way out: cancelEnd must be at-or-after handlerReturnedAt.
+    const long long handlerReturnedNs = subscriber.returnedAt();
+    ASSERT_NE(handlerReturnedNs, 0)
+        << "handler must have returned by the time cancel observed the gate";
+
+    const auto cancelEndNs = cancelEnd.time_since_epoch().count();
+    EXPECT_GE(cancelEndNs, handlerReturnedNs)
+        << "FF-69: cancel must not return before in-flight onMessage returns";
+
+    // The cancel call must also have stayed blocked for "long enough".
+    // We allow a generous slack so a slow CI box does not flake: at
+    // least half the handler-sleep window must have elapsed between
+    // cancelStart and cancelEnd (the test thread may have started
+    // racing slightly before the handler entered the sleep, but it
+    // cannot have finished before the sleep was over).
+    const auto blockedFor = cancelEnd - cancelStart;
+    EXPECT_GE(blockedFor, kHandlerSleep / 2)
+        << "FF-69: cancel must remain blocked while onMessage is in flight";
+
+    poster.join();
+}
+
+} // namespace
+} // namespace vigine::contract

--- a/test/contract/scenario_16_dtor_blocks_in_flight.cpp
+++ b/test/contract/scenario_16_dtor_blocks_in_flight.cpp
@@ -58,6 +58,7 @@
 #include <chrono>
 #include <condition_variable>
 #include <cstddef>
+#include <future>
 #include <memory>
 #include <mutex>
 #include <thread>
@@ -101,15 +102,36 @@ class SlowSubscriber final : public vigine::messaging::ISubscriber
         // lifecycleMutex. The test thread captures its own instant
         // either side of cancel(); the relative ordering between
         // those instants is what the FF-69 assertion compares.
-        _returnedAt =
-            std::chrono::steady_clock::now().time_since_epoch().count();
+        //
+        // Convert to nanoseconds explicitly: steady_clock::duration::rep
+        // is implementation-defined, so blindly storing the raw .count()
+        // in a long long is not portable (e.g. a future libc++ that
+        // widened rep to int128 would silently truncate). The
+        // duration_cast<nanoseconds>() expresses the unit of the stored
+        // value and the cast itself is well-defined for any rep.
+        const auto nowNs = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                               std::chrono::steady_clock::now().time_since_epoch())
+                               .count();
+        _returnedAt.store(nowNs, std::memory_order_release);
         return vigine::messaging::DispatchResult::Handled;
     }
 
     void waitForEnter()
     {
         std::unique_lock<std::mutex> lock{_mtx};
-        _cv.wait(lock, [this] { return _entered; });
+        // Bounded wait so a regression that prevents the dispatcher
+        // from ever reaching onMessage cannot hang the test process
+        // forever (which would jam the whole CI run). 5 s is generous
+        // relative to kHandlerSleep (200 ms) and the surrounding
+        // schedule + post() latency; a real entry happens in under a
+        // millisecond on every platform we care about.
+        const bool entered = _cv.wait_for(
+            lock, std::chrono::seconds{5}, [this] { return _entered; });
+        if (!entered)
+        {
+            FAIL() << "SlowSubscriber::onMessage was never entered within "
+                      "5 s -- dispatcher likely never delivered the message";
+        }
     }
 
     [[nodiscard]] long long returnedAt() const noexcept
@@ -171,8 +193,20 @@ TEST_F(DtorBlocksInFlight, CancelWaitsForInFlightOnMessage)
     // the handler returns.
     subscriber.waitForEnter();
 
+    // Run cancel() on a worker future with a bounded wait. If FF-69
+    // regresses (the lifecycle mutex isn't held for the dispatch
+    // window) cancel() could deadlock with the in-flight handler and
+    // hang the whole test binary. Asserting wait_for == ready bounds
+    // the failure to this single test instead of a CI-wide stall.
     const auto cancelStart = std::chrono::steady_clock::now();
-    token->cancel();
+    auto       cancelFut   = std::async(std::launch::async, [&token] {
+        token->cancel();
+    });
+    const auto status = cancelFut.wait_for(std::chrono::seconds{5});
+    ASSERT_EQ(status, std::future_status::ready)
+        << "FF-69: token->cancel() did not return within 5 s -- the "
+           "dispatcher and the lifecycle gate are likely deadlocked";
+    cancelFut.get();
     const auto cancelEnd = std::chrono::steady_clock::now();
 
     // The handler captures its own return instant inside onMessage just
@@ -182,7 +216,13 @@ TEST_F(DtorBlocksInFlight, CancelWaitsForInFlightOnMessage)
     ASSERT_NE(handlerReturnedNs, 0)
         << "handler must have returned by the time cancel observed the gate";
 
-    const auto cancelEndNs = cancelEnd.time_since_epoch().count();
+    // Same unit conversion as the handler side: store nanoseconds so
+    // the comparison is apples-to-apples regardless of the
+    // platform-specific steady_clock::duration::rep.
+    const long long cancelEndNs =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            cancelEnd.time_since_epoch())
+            .count();
     EXPECT_GE(cancelEndNs, handlerReturnedNs)
         << "FF-69: cancel must not return before in-flight onMessage returns";
 

--- a/test/contract/scenario_17_fsm_thread_affinity.cpp
+++ b/test/contract/scenario_17_fsm_thread_affinity.cpp
@@ -1,0 +1,161 @@
+// ---------------------------------------------------------------------------
+// Scenario 17 -- FSM controller-thread affinity assertion.
+//
+// IStateMachine::bindToControllerThread installs a one-shot binding:
+// the bound thread is the only thread allowed to call sync mutators
+// (setInitial / transition / addChildState / processQueuedTransitions
+// once a binding is in place). The Debug build enforces the binding
+// via assert() inside AbstractStateMachine::checkThreadAffinity, fired
+// at the entry of every gated mutator. Release intentionally drops the
+// gate: the entire body is wrapped in #ifndef NDEBUG.
+//
+// What this scenario pins
+// -----------------------
+//   - A second-call rebind is rejected: the contract says the binding
+//     is one-shot, so a follow-up bindToControllerThread must NOT
+//     overwrite the original. We exercise that by reading
+//     controllerThread() back and confirming the second call did not
+//     change the bound id. This case is portable across Debug and
+//     Release builds: the early-out path uses a CAS, not an assert,
+//     so the observable effect (no overwrite) holds in both modes.
+//
+//   - A wrong-thread sync mutation aborts in Debug. We use
+//     EXPECT_DEATH to spawn a child gtest process that calls
+//     transition() from a thread that is NOT the bound controller;
+//     the assert fires, the child aborts, and the parent observes
+//     the death-test pass. The case is gated on a Debug build via
+//     #ifndef NDEBUG so a Release run reports a single SUCCEED
+//     stub instead of trying to assert on a binding the build
+//     skipped wiring up.
+//
+// Both cases run on the EngineFixture so the FSM is reached through
+// the public IContext aggregator like every other contract scenario.
+// ---------------------------------------------------------------------------
+
+#include "fixtures/engine_fixture.h"
+
+#include "vigine/api/context/icontext.h"
+#include "vigine/api/statemachine/istatemachine.h"
+#include "vigine/api/statemachine/stateid.h"
+#include "vigine/result.h"
+
+#include <gtest/gtest.h>
+
+#include <thread>
+
+namespace vigine::contract
+{
+namespace
+{
+
+using FsmThreadAffinity = EngineFixture;
+
+// -- Case 1 ------------------------------------------------------------------
+//
+// One-shot rebind rejection. The contract says
+// bindToControllerThread is one-shot: a second call must not
+// overwrite the original binding. The implementation reaches that
+// by a compare-exchange on a sentinel (default-constructed
+// std::thread::id), so the no-overwrite outcome is observable in
+// Release without hitting the Debug assert.
+//
+// We bind the test thread, capture the bound id, then attempt to
+// rebind from another thread. Reading back the controller thread
+// must still return the original test-thread id.
+
+TEST_F(FsmThreadAffinity, RebindIsRejectedAndDoesNotOverwrite)
+{
+    auto &sm = context().stateMachine();
+
+    const auto testThreadId = std::this_thread::get_id();
+    sm.bindToControllerThread(testThreadId);
+    EXPECT_EQ(sm.controllerThread(), testThreadId)
+        << "first bind must record the calling thread id";
+
+    // Second bind from another thread. In Debug this fires an assert
+    // (the contract says rebind is rejected); in Release the CAS path
+    // silently keeps the original binding. We isolate the assert in
+    // the worker thread so the test process itself does not abort, and
+    // we capture the worker's bound id afterwards.
+    std::thread worker{[&sm] {
+#ifdef NDEBUG
+        // Release: the CAS in bindToControllerThread fails silently,
+        // so calling it from the worker is a no-op.
+        sm.bindToControllerThread(std::this_thread::get_id());
+#endif
+        // Debug: do nothing here -- the assert path would abort the
+        // whole test binary. The Case-2 EXPECT_DEATH fixture is the
+        // surface that exercises the assert in isolation.
+    }};
+    worker.join();
+
+    EXPECT_EQ(sm.controllerThread(), testThreadId)
+        << "rebind must not overwrite the original controller thread id";
+}
+
+// -- Case 2 ------------------------------------------------------------------
+//
+// Wrong-thread sync mutation aborts in Debug.
+//
+// A fresh fixture binds the test thread as the controller, then a
+// worker thread calls transition() through the EXPECT_DEATH
+// statement. Debug builds fire the assert inside checkThreadAffinity,
+// the child gtest process aborts, and the parent observes the
+// death-test pass. Release builds skip the case because the
+// affinity gate is compiled out.
+
+#if !defined(NDEBUG) && defined(GTEST_HAS_DEATH_TEST) && GTEST_HAS_DEATH_TEST
+
+// Death-test naming convention: gtest reorders DeathTest fixtures
+// to run before non-death ones. The "DeathTest" suffix on the
+// fixture name opts into that ordering and silences the
+// "Death tests use fork()" warning emitted in some sanitiser
+// configurations.
+using FsmThreadAffinityDeathTest = EngineFixture;
+
+TEST_F(FsmThreadAffinityDeathTest, WrongThreadSyncMutationAbortsInDebug)
+{
+    auto &sm = context().stateMachine();
+
+    sm.bindToControllerThread(std::this_thread::get_id());
+
+    // Add an extra state so transition() has a valid target. The
+    // worker thread itself is the contract violation; the target id
+    // does not matter as long as it is a registered state.
+    const auto target = sm.addState();
+    ASSERT_TRUE(target.valid());
+
+    // Use the threadsafe death-test style on Windows / multi-threaded
+    // hosts so the child process is spawned via re-exec instead of
+    // fork(). The default style is sometimes `fast` which on
+    // multi-threaded parents can deadlock if a child inherits a
+    // partially-locked mutex.
+    GTEST_FLAG_SET(death_test_style, "threadsafe");
+
+    EXPECT_DEATH(
+        ([&sm, target] {
+            std::thread worker{[&sm, target] {
+                // This call is from the wrong thread: the assert in
+                // AbstractStateMachine::checkThreadAffinity fires,
+                // the child process aborts. The Result return value
+                // is ignored on the death path.
+                (void)sm.transition(target);
+            }};
+            worker.join();
+        })(),
+        ".*");
+}
+
+#else // Release / no death-test support
+
+TEST_F(FsmThreadAffinity, WrongThreadCaseSkippedInRelease)
+{
+    SUCCEED()
+        << "checkThreadAffinity is compiled out in Release; the assert "
+           "case is exercised only in Debug builds.";
+}
+
+#endif // NDEBUG / GTEST_HAS_DEATH_TEST
+
+} // namespace
+} // namespace vigine::contract

--- a/test/contract/scenario_17_fsm_thread_affinity.cpp
+++ b/test/contract/scenario_17_fsm_thread_affinity.cpp
@@ -50,6 +50,16 @@ namespace
 
 using FsmThreadAffinity = EngineFixture;
 
+// Death-test fixture alias declared up-front so both Debug-only
+// EXPECT_DEATH cases (Case 1b and Case 2) can share it. gtest
+// reorders DeathTest fixtures to run before non-death ones; the
+// "DeathTest" suffix on the fixture name opts into that ordering and
+// silences the "Death tests use fork()" warning emitted in some
+// sanitiser configurations.
+#if !defined(NDEBUG) && defined(GTEST_HAS_DEATH_TEST) && GTEST_HAS_DEATH_TEST
+using FsmThreadAffinityDeathTest = EngineFixture;
+#endif
+
 // -- Case 1 ------------------------------------------------------------------
 //
 // One-shot rebind rejection. The contract says
@@ -72,26 +82,73 @@ TEST_F(FsmThreadAffinity, RebindIsRejectedAndDoesNotOverwrite)
     EXPECT_EQ(sm.controllerThread(), testThreadId)
         << "first bind must record the calling thread id";
 
-    // Second bind from another thread. In Debug this fires an assert
-    // (the contract says rebind is rejected); in Release the CAS path
-    // silently keeps the original binding. We isolate the assert in
-    // the worker thread so the test process itself does not abort, and
-    // we capture the worker's bound id afterwards.
+    // Second bind from another thread. In Release the CAS path silently
+    // keeps the original binding, which is the observable contract we
+    // pin here. In Debug the same call would abort via assert, so we
+    // skip it from this non-death test; the dedicated DeathTest below
+    // exercises the abort surface explicitly without aborting the
+    // current test process.
     std::thread worker{[&sm] {
 #ifdef NDEBUG
         // Release: the CAS in bindToControllerThread fails silently,
         // so calling it from the worker is a no-op.
         sm.bindToControllerThread(std::this_thread::get_id());
+#else
+        // Debug: do nothing here. The
+        // FsmThreadAffinityDeathTest.SecondBindAbortsInDebug case below
+        // is the surface that fires the assert in isolation.
+        (void)sm;
 #endif
-        // Debug: do nothing here -- the assert path would abort the
-        // whole test binary. The Case-2 EXPECT_DEATH fixture is the
-        // surface that exercises the assert in isolation.
     }};
     worker.join();
 
     EXPECT_EQ(sm.controllerThread(), testThreadId)
         << "rebind must not overwrite the original controller thread id";
 }
+
+// -- Case 1b -----------------------------------------------------------------
+//
+// Debug-only: the second bindToControllerThread call must fire the
+// rebind assert. Case 1 above pins the *observable* outcome (no
+// overwrite) which is portable across Debug and Release; this case
+// pins the *fatal* surface that Debug builds also expose, by spawning
+// a child gtest process that performs two binds in a row.
+//
+// Without this case the documented "second bind asserts" path would
+// never actually be exercised by the suite -- a regression that
+// quietly turned the assert into a no-op would slip through.
+
+#if !defined(NDEBUG) && defined(GTEST_HAS_DEATH_TEST) && GTEST_HAS_DEATH_TEST
+
+TEST_F(FsmThreadAffinityDeathTest, SecondBindAbortsInDebug)
+{
+    auto &sm = context().stateMachine();
+
+    // Use threadsafe style for the same reason as Case 2: the
+    // multi-threaded parent must not fork() with partially-locked
+    // mutexes.
+    GTEST_FLAG_SET(death_test_style, "threadsafe");
+
+    EXPECT_DEATH(
+        ([&sm] {
+            // First bind succeeds in the child process (the death-test
+            // child re-execs into a fresh FSM under threadsafe style).
+            sm.bindToControllerThread(std::this_thread::get_id());
+
+            // Spawn a worker so the second bind comes from a thread
+            // that is genuinely different from the one that took the
+            // CAS slot. The assert inside bindToControllerThread fires,
+            // the child aborts, the parent observes the death-test
+            // pass.
+            std::thread worker{[&sm] {
+                sm.bindToControllerThread(std::this_thread::get_id());
+            }};
+            worker.join();
+        })(),
+        ".*");
+}
+
+#endif // !NDEBUG && GTEST_HAS_DEATH_TEST
 
 // -- Case 2 ------------------------------------------------------------------
 //
@@ -106,13 +163,9 @@ TEST_F(FsmThreadAffinity, RebindIsRejectedAndDoesNotOverwrite)
 
 #if !defined(NDEBUG) && defined(GTEST_HAS_DEATH_TEST) && GTEST_HAS_DEATH_TEST
 
-// Death-test naming convention: gtest reorders DeathTest fixtures
-// to run before non-death ones. The "DeathTest" suffix on the
-// fixture name opts into that ordering and silences the
-// "Death tests use fork()" warning emitted in some sanitiser
-// configurations.
-using FsmThreadAffinityDeathTest = EngineFixture;
-
+// FsmThreadAffinityDeathTest fixture is declared once at the top of
+// the anonymous namespace so it is in scope for every Debug-only
+// EXPECT_DEATH case below (Case 1b and Case 2).
 TEST_F(FsmThreadAffinityDeathTest, WrongThreadSyncMutationAbortsInDebug)
 {
     auto &sm = context().stateMachine();

--- a/test/contract/scenario_19_parallel_for.cpp
+++ b/test/contract/scenario_19_parallel_for.cpp
@@ -53,6 +53,7 @@
 #include <chrono>
 #include <cstddef>
 #include <memory>
+#include <thread>
 #include <vector>
 
 namespace vigine::contract
@@ -130,16 +131,21 @@ TEST_F(ParallelForCoverage, WaitBlocksUntilBodiesComplete)
     std::atomic<std::size_t> started{0};
     std::atomic<std::size_t> finished{0};
 
+    // Use a small subrange + a per-body sleep so the wait() barrier
+    // is genuinely under test. With a tight body that fanned out over
+    // 1024 indices the chunks complete before wait() is even called,
+    // which makes a broken barrier indistinguishable from a working
+    // one (false-pass risk). A 64-index range + 5 ms sleep keeps the
+    // body running long enough that the dispatcher must really gate
+    // wait() until the last chunk has returned.
+    constexpr std::size_t kBarrierIndexCount = 64;
+
     auto handle = vigine::core::threading::parallelFor(
         tm,
-        kIndexCount,
+        kBarrierIndexCount,
         [&](std::size_t /*i*/) {
             started.fetch_add(1, std::memory_order_acq_rel);
-            // No artificial sleep -- a tight body still guarantees
-            // every chunk has been dispatched and run by the time
-            // wait() returns. The counters expose the "didn't quite
-            // wait" failure mode without needing a sleep that would
-            // slow the contract suite down.
+            std::this_thread::sleep_for(std::chrono::milliseconds{5});
             finished.fetch_add(1, std::memory_order_acq_rel);
         });
     ASSERT_NE(handle, nullptr);
@@ -149,8 +155,8 @@ TEST_F(ParallelForCoverage, WaitBlocksUntilBodiesComplete)
     ASSERT_TRUE(waited.isSuccess())
         << "parallelFor wait must succeed; got: " << waited.message();
 
-    EXPECT_EQ(started.load(std::memory_order_acquire), kIndexCount);
-    EXPECT_EQ(finished.load(std::memory_order_acquire), kIndexCount)
+    EXPECT_EQ(started.load(std::memory_order_acquire), kBarrierIndexCount);
+    EXPECT_EQ(finished.load(std::memory_order_acquire), kBarrierIndexCount)
         << "wait() must not return before every body has completed";
 }
 
@@ -158,11 +164,18 @@ TEST_F(ParallelForCoverage, EmptyRangeReturnsImmediateSuccess)
 {
     auto &tm = context().threadManager();
 
-    bool bodyInvoked = false;
-    auto handle      = vigine::core::threading::parallelFor(
+    // Atomic flag so a regression that *does* invoke the body on a
+    // pool worker thread cannot race the main thread's read. With a
+    // plain bool the assertion would still fire, but the write/read
+    // pair would be UB (data race), masking the true failure cause
+    // under a sanitiser.
+    std::atomic<bool> bodyInvoked{false};
+    auto handle = vigine::core::threading::parallelFor(
         tm,
         /*count=*/0,
-        [&bodyInvoked](std::size_t) { bodyInvoked = true; });
+        [&bodyInvoked](std::size_t) {
+            bodyInvoked.store(true, std::memory_order_release);
+        });
     ASSERT_NE(handle, nullptr)
         << "parallelFor must return a non-null handle even for an empty range";
 
@@ -171,7 +184,7 @@ TEST_F(ParallelForCoverage, EmptyRangeReturnsImmediateSuccess)
     const vigine::Result waited = handle->wait();
     EXPECT_TRUE(waited.isSuccess())
         << "empty-range wait must report Success; got: " << waited.message();
-    EXPECT_FALSE(bodyInvoked)
+    EXPECT_FALSE(bodyInvoked.load(std::memory_order_acquire))
         << "an empty range must not invoke the body even once";
 }
 

--- a/test/contract/scenario_19_parallel_for.cpp
+++ b/test/contract/scenario_19_parallel_for.cpp
@@ -1,0 +1,179 @@
+// ---------------------------------------------------------------------------
+// Scenario 19 -- vigine::core::threading::parallelFor coverage.
+//
+// parallelFor is the free helper that fans out a [0, count) range
+// across the thread-manager pool and returns one aggregated
+// ITaskHandle whose wait() blocks until every chunk has finished.
+// The contract is documented in
+// include/vigine/core/threading/parallel_for.h:
+//
+//   - Returns a non-null ITaskHandle (never a raw pointer).
+//   - Splits the range into roughly poolSize() chunks; with a
+//     degenerate pool (poolSize() == 0) the helper falls back to a
+//     single chunk covering the whole range.
+//   - wait() blocks until every chunk's body has returned. Once
+//     wait() reports success, every index in [0, count) has been
+//     visited exactly once.
+//   - Body callbacks may run on any pool worker; concurrent
+//     invocations are expected for non-trivial counts.
+//
+// What this scenario pins
+// -----------------------
+//   1. EveryIndexVisitedOnce -- run a 1024-index range and verify
+//      every index is touched exactly once after wait() returns.
+//      Catches both "missed an index" (chunk boundary off-by-one)
+//      and "visited an index twice" (overlapping ranges) regressions.
+//
+//   2. WaitBlocksUntilBodiesComplete -- the aggregated handle's
+//      wait() must not return until the last chunk's body has
+//      returned. We synchronise via an atomic counter the body
+//      bumps on entry/exit and assert the in-flight counter is 0
+//      after wait() returns successfully.
+//
+//   3. EmptyRangeReturnsImmediateSuccess -- count == 0 yields a
+//      handle that is already settled (ready() reports true and
+//      wait() returns Success without blocking).
+//
+//   4. HandleNonNull -- the helper never hands the caller a null
+//      unique_ptr<ITaskHandle>, even on the empty-range edge case.
+// ---------------------------------------------------------------------------
+
+#include "fixtures/engine_fixture.h"
+
+#include "vigine/api/context/icontext.h"
+#include "vigine/core/threading/itaskhandle.h"
+#include "vigine/core/threading/ithreadmanager.h"
+#include "vigine/core/threading/parallel_for.h"
+#include "vigine/core/threading/threadaffinity.h"
+#include "vigine/result.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+namespace vigine::contract
+{
+namespace
+{
+
+using ParallelForCoverage = EngineFixture;
+
+constexpr std::size_t kIndexCount = 1024;
+
+TEST_F(ParallelForCoverage, EveryIndexVisitedOnce)
+{
+    auto &tm = context().threadManager();
+
+    // Visit counters per index so we can assert each one is touched
+    // exactly once. Atomic so the body can increment under concurrent
+    // worker invocations without UB.
+    std::vector<std::atomic<int>> visits(kIndexCount);
+    for (auto &v : visits)
+    {
+        v.store(0, std::memory_order_relaxed);
+    }
+
+    auto handle = vigine::core::threading::parallelFor(
+        tm,
+        kIndexCount,
+        [&visits](std::size_t i) {
+            // Bump the per-index counter. Out-of-range indices are a
+            // contract violation that the per-index assertion below
+            // surfaces.
+            if (i < visits.size())
+            {
+                visits[i].fetch_add(1, std::memory_order_acq_rel);
+            }
+        });
+    ASSERT_NE(handle, nullptr) << "parallelFor must return a non-null handle";
+
+    const vigine::Result waited =
+        handle->waitFor(std::chrono::seconds{30});
+    ASSERT_TRUE(waited.isSuccess())
+        << "parallelFor wait must succeed within 30 s; got: "
+        << waited.message();
+    EXPECT_TRUE(handle->ready()) << "handle must report ready after wait()";
+
+    // Verify every index visited exactly once. We compute the sum
+    // first as a fast smoke (any miss / double-visit shifts the sum
+    // away from kIndexCount), then walk the array to attribute
+    // failures.
+    std::size_t totalVisits = 0;
+    std::size_t unique      = 0;
+    for (const auto &v : visits)
+    {
+        const int n = v.load(std::memory_order_acquire);
+        totalVisits += static_cast<std::size_t>(n);
+        if (n == 1)
+        {
+            ++unique;
+        }
+    }
+    EXPECT_EQ(totalVisits, kIndexCount)
+        << "every index must be visited exactly once; total visits=" << totalVisits;
+    EXPECT_EQ(unique, kIndexCount)
+        << "every index must have a visit count of 1; unique=" << unique;
+}
+
+TEST_F(ParallelForCoverage, WaitBlocksUntilBodiesComplete)
+{
+    auto &tm = context().threadManager();
+
+    // The body bumps a "started" counter on entry and a "finished"
+    // counter on exit. After wait() returns success, both counters
+    // must equal kIndexCount: the helper's contract is that wait()
+    // does not return until every chunk's body has returned.
+    std::atomic<std::size_t> started{0};
+    std::atomic<std::size_t> finished{0};
+
+    auto handle = vigine::core::threading::parallelFor(
+        tm,
+        kIndexCount,
+        [&](std::size_t /*i*/) {
+            started.fetch_add(1, std::memory_order_acq_rel);
+            // No artificial sleep -- a tight body still guarantees
+            // every chunk has been dispatched and run by the time
+            // wait() returns. The counters expose the "didn't quite
+            // wait" failure mode without needing a sleep that would
+            // slow the contract suite down.
+            finished.fetch_add(1, std::memory_order_acq_rel);
+        });
+    ASSERT_NE(handle, nullptr);
+
+    const vigine::Result waited =
+        handle->waitFor(std::chrono::seconds{30});
+    ASSERT_TRUE(waited.isSuccess())
+        << "parallelFor wait must succeed; got: " << waited.message();
+
+    EXPECT_EQ(started.load(std::memory_order_acquire), kIndexCount);
+    EXPECT_EQ(finished.load(std::memory_order_acquire), kIndexCount)
+        << "wait() must not return before every body has completed";
+}
+
+TEST_F(ParallelForCoverage, EmptyRangeReturnsImmediateSuccess)
+{
+    auto &tm = context().threadManager();
+
+    bool bodyInvoked = false;
+    auto handle      = vigine::core::threading::parallelFor(
+        tm,
+        /*count=*/0,
+        [&bodyInvoked](std::size_t) { bodyInvoked = true; });
+    ASSERT_NE(handle, nullptr)
+        << "parallelFor must return a non-null handle even for an empty range";
+
+    EXPECT_TRUE(handle->ready())
+        << "an empty-range handle must already be settled";
+    const vigine::Result waited = handle->wait();
+    EXPECT_TRUE(waited.isSuccess())
+        << "empty-range wait must report Success; got: " << waited.message();
+    EXPECT_FALSE(bodyInvoked)
+        << "an empty range must not invoke the body even once";
+}
+
+} // namespace
+} // namespace vigine::contract


### PR DESCRIPTION
Closes #294.

## Summary

4 new contract tests under test/contract/:
- scenario_15 FF-70 per-subscriber onMessage serial under concurrent publishers (8 publishers x 100 envelopes; reentry canary asserts 0 violations).
- scenario_16 FF-69 dtor / cancel blocks until in-flight dispatch drains (slow handler + race; cancel must observe handler return instant).
- scenario_17 FSM thread-affinity — Debug EXPECT_DEATH when wrong-thread sync mutator after bindToControllerThread; one-shot rebind rejection portable to Release.
- scenario_19 parallelFor distributes work across pool, joins via ITaskHandle (1024-index visit-once, wait-blocks-until-bodies-complete, empty-range immediate-success).

Note: scenario_18 (FSM async transition) was already added via #267 wave 2.

## Tests

- ctest count: 212 / 212 (delta +7 from baseline 205; scenario_15 +1, scenario_16 +1, scenario_17 +2, scenario_19 +3).
- Build clean at /WX MSVC (Insiders 14.50, x64 Debug, 281 targets).
- Demos:
  - example-parallel-fsm: 100/100 exchanges
  - example-threaded-bus: 800/800 received, 0 reentry violations
  - example-fanout-fsm: 16/16 FSMs reached final state