### PR TITLE
Migrate setContext signatures to reference form (#284)

### DIFF
--- a/example/window/main.cpp
+++ b/example/window/main.cpp
@@ -39,7 +39,7 @@
 using namespace vigine;
 
 std::unique_ptr<TaskFlow> createInitTaskFlow(messaging::ISignalEmitter *signalEmitter,
-                                             Context *context,
+                                             Context &context,
                                              std::shared_ptr<TextEditState> textEditState,
                                              std::shared_ptr<TextEditorSystem> textEditorSystem)
 {
@@ -48,9 +48,10 @@ std::unique_ptr<TaskFlow> createInitTaskFlow(messaging::ISignalEmitter *signalEm
     // non-Any branch can reach the engine-owned IThreadManager (see
     // TaskFlow::signal and the accompanying code comment). The
     // downcast happens once in main(); here we simply install it. The
-    // setContext signature now takes Context& so we dereference the
-    // non-null pointer received from main() (asserted there).
-    taskFlow->setContext(*context);
+    // setContext signature takes Context& so this function follows
+    // suit -- the parameter is a reference, matching the non-null
+    // contract enforced at the call site.
+    taskFlow->setContext(context);
 
     auto *initWindow          = taskFlow->addTask(std::make_unique<InitWindowTask>());
     auto *initVulkan          = taskFlow->addTask(std::make_unique<InitVulkanTask>());
@@ -81,11 +82,12 @@ std::unique_ptr<TaskFlow> createInitTaskFlow(messaging::ISignalEmitter *signalEm
     // Pool affinity wraps the subscriber in a scheduled-delivery adapter
     // that hands the clone to IThreadManager::schedule. The engine's
     // Context owns a real IThreadManager (Engine::Engine plumbs it on
-    // construction), and main() hands that concrete Context* into
-    // createInitTaskFlow, which installs it via taskFlow->setContext(context)
-    // above. Input handlers therefore run on a pool worker thread, off
-    // the Win32 message pump thread, and clicking the window does not
-    // stall rendering if the handler grows heavier later.
+    // construction), and main() hands that concrete Context into
+    // createInitTaskFlow by reference, which installs it via
+    // taskFlow->setContext(context) above. Input handlers therefore run
+    // on a pool worker thread, off the Win32 message pump thread, and
+    // clicking the window does not stall rendering if the handler grows
+    // heavier later.
     static_cast<void>(taskFlow->signal(runWindow, processInputEventTask,
                                        kMouseButtonDownPayloadTypeId,
                                        core::threading::ThreadAffinity::Pool));
@@ -171,7 +173,7 @@ int main()
     auto closePtr         = stMachine->addState(std::move(closeState));
 
     initPtr->setTaskFlow(
-        createInitTaskFlow(signalEmitter.get(), legacyCtx, textEditState, textEditorSystem));
+        createInitTaskFlow(signalEmitter.get(), *legacyCtx, textEditState, textEditorSystem));
     workPtr->setTaskFlow(createWorkTaskFlow());
     errorPtr->setTaskFlow(createErrorTaskFlow());
     closePtr->setTaskFlow(createCloseTaskFlow());

--- a/example/window/main.cpp
+++ b/example/window/main.cpp
@@ -47,8 +47,10 @@ std::unique_ptr<TaskFlow> createInitTaskFlow(messaging::ISignalEmitter *signalEm
     // Task flow needs the concrete legacy Context so its signal()
     // non-Any branch can reach the engine-owned IThreadManager (see
     // TaskFlow::signal and the accompanying code comment). The
-    // downcast happens once in main(); here we simply install it.
-    taskFlow->setContext(context);
+    // downcast happens once in main(); here we simply install it. The
+    // setContext signature now takes Context& so we dereference the
+    // non-null pointer received from main() (asserted there).
+    taskFlow->setContext(*context);
 
     auto *initWindow          = taskFlow->addTask(std::make_unique<InitWindowTask>());
     auto *initVulkan          = taskFlow->addTask(std::make_unique<InitVulkanTask>());

--- a/include/vigine/api/statemachine/abstractstate.h
+++ b/include/vigine/api/statemachine/abstractstate.h
@@ -49,17 +49,23 @@ class AbstractState // ENCAP EXEMPTION: legacy; protected _taskFlow/_isActive/_c
             return;
 
         _taskFlow = std::move(taskFlow);
-        _taskFlow->setContext(_context);
+        // Propagate the state's context binding only when one is
+        // installed. The state may receive its task flow before its
+        // own setContext is called by the state machine; in that case
+        // the task flow stays unbound until the state's setContext
+        // forwards the binding below.
+        if (_context != nullptr)
+            _taskFlow->setContext(*_context);
     }
 
     [[nodiscard]] TaskFlow *getTaskFlow() const { return _taskFlow.get(); }
 
-    void setContext(Context *context)
+    void setContext(Context &context)
     {
-        _context = context;
+        _context = &context;
 
         if (_taskFlow)
-            _taskFlow->setContext(_context);
+            _taskFlow->setContext(context);
     }
 
   protected:

--- a/include/vigine/api/taskflow/abstracttask.h
+++ b/include/vigine/api/taskflow/abstracttask.h
@@ -53,7 +53,7 @@ class AbstractTask : public ITask
 
     [[nodiscard]] engine::IEngineToken *api() noexcept override final;
 
-    void setContext(Context *context);
+    void setContext(Context &context);
 
   protected:
     AbstractTask();

--- a/include/vigine/impl/taskflow/taskflow.h
+++ b/include/vigine/impl/taskflow/taskflow.h
@@ -137,7 +137,7 @@ class TaskFlow
     // Run the task flow
     void operator()();
 
-    void setContext(Context *context);
+    void setContext(Context &context);
 
     /**
      * @brief Installs the signal emitter used by @ref signal to wire

--- a/src/api/taskflow/abstracttask.cpp
+++ b/src/api/taskflow/abstracttask.cpp
@@ -19,9 +19,9 @@ engine::IEngineToken *AbstractTask::api() noexcept
     return _api;
 }
 
-void AbstractTask::setContext(Context *context)
+void AbstractTask::setContext(Context &context)
 {
-    _context = context;
+    _context = &context;
     contextChanged();
 }
 

--- a/src/impl/statemachine/statemachine.cpp
+++ b/src/impl/statemachine/statemachine.cpp
@@ -14,11 +14,12 @@ AbstractState *StateMachine::addState(StateUPtr state)
         return nullptr;
 
     // Propagate the state machine's context binding only when one is
-    // installed. The constructor may receive a null context on the
-    // legacy path (Engine wires a non-null Context, but tests can
-    // exercise the machine before any binding); the state in that
-    // case keeps its default null binding until a real setContext
-    // propagates later.
+    // installed. StateMachine receives its Context once via the private
+    // constructor (Engine-only), so production callers always see a
+    // non-null binding here; the null branch covers tests that
+    // instantiate StateMachine through a friend hook before any Engine
+    // wiring. The state keeps its default null binding in that case --
+    // there is no later propagation step on StateMachine.
     if (_context != nullptr)
         state->setContext(*_context);
     // Store the state

--- a/src/impl/statemachine/statemachine.cpp
+++ b/src/impl/statemachine/statemachine.cpp
@@ -13,7 +13,14 @@ AbstractState *StateMachine::addState(StateUPtr state)
     if (!state)
         return nullptr;
 
-    state->setContext(_context);
+    // Propagate the state machine's context binding only when one is
+    // installed. The constructor may receive a null context on the
+    // legacy path (Engine wires a non-null Context, but tests can
+    // exercise the machine before any binding); the state in that
+    // case keeps its default null binding until a real setContext
+    // propagates later.
+    if (_context != nullptr)
+        state->setContext(*_context);
     // Store the state
     _states.push_back(std::move(state));
     return _states.back().get();

--- a/src/impl/taskflow/taskflow.cpp
+++ b/src/impl/taskflow/taskflow.cpp
@@ -295,7 +295,12 @@ AbstractTask *TaskFlow::addTask(TaskUPtr task) {
   if (!task)
     return nullptr;
 
-  task->setContext(_context);
+  // Propagate the flow's context binding only when one is installed.
+  // The flow may be assembled (addTask) before its setContext is called
+  // by the owning state / engine; in that case the task simply keeps
+  // its default null binding until the flow's setContext propagates.
+  if (_context != nullptr)
+    task->setContext(*_context);
 
   // Store the task
   _tasks.push_back(std::move(task));
@@ -525,8 +530,8 @@ void TaskFlow::operator()() {
   }
 }
 
-void TaskFlow::setContext(Context *context) {
-  _context = context;
+void TaskFlow::setContext(Context &context) {
+  _context = &context;
 
   std::ranges::for_each(_tasks, [&context](const TaskUPtr &taskUptr) {
     taskUptr->setContext(context);


### PR DESCRIPTION
Convert non-null `setContext` signatures across the task-flow /
state-machine surface from raw pointer to reference form.

`TaskFlow::setContext`, `AbstractTask::setContext`, and
`AbstractState::setContext` now take `Context&`. Internal propagation
sites in `TaskFlow::addTask`, `StateMachine::addState`, and
`AbstractState::setTaskFlow` guard their `_context` storage with an
explicit null check before dereferencing, so a flow / state assembled
before its own `setContext` lands keeps its default null binding until
the binding actually arrives.

`setTaskFlow` keeps its existing `std::unique_ptr<TaskFlow>` shape;
ownership transfer was already correct.

`example/window/main.cpp` updates the lone external call site to
dereference the legacy `Context*` it already asserted non-null.

Build: MSVC + /WX, all 275 targets compile.
Tests: ctest 220/220 pass.
Demos: parallel-fsm 100/100, threaded-bus 800/800, fanout-fsm 16/16.

Closes #284.