### PR TITLE
Add cross-platform skip-guard to example/window CMakeLists (#299)

### DIFF
--- a/example/window/CMakeLists.txt
+++ b/example/window/CMakeLists.txt
@@ -6,6 +6,16 @@ set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(PROJECT_WINDOW_NAME example-window)
 project(${PROJECT_WINDOW_NAME})
 
+# Portability skip-guard: this example needs the Vulkan SDK (glslc) and
+# the Win32 platform service. Linux/macOS CI runs without the Vulkan SDK
+# installed and without the Win32 platform implementation, so opting in
+# only on Windows keeps the cross-platform configure step clean. The
+# guard MUST be the first effective statement so we never reach
+# find_program(GLSLC_EXECUTABLE) on non-Windows hosts.
+if(NOT WIN32)
+    return()
+endif()
+
 set(EXAMPLE_WINDOW_HANDLER_SOURCES
     handler/windoweventhandler.h handler/windoweventhandler.cpp)
 
@@ -291,10 +301,17 @@ if(WIN32)
     target_compile_definitions(${PROJECT_WINDOW_NAME} PRIVATE WIN32_LEAN_AND_MEAN)
 endif()
 
+# vigine target PUBLIC-exports its `include/` directory, so consumers
+# linking against it (PRIVATE here) inherit `vigine/...` headers
+# automatically -- the manual reach into ${CMAKE_SOURCE_DIR}/include is
+# unnecessary and would leak the wrong include root when Vigine is
+# added via add_subdirectory under a parent project. The
+# ${CMAKE_SOURCE_DIR} entry below stays in place because
+# task/vulkan/imageloader.cpp resolves the bundled stb header through
+# `external/stb/stb_image.h`, which needs the engine root on the path.
 target_include_directories(${PROJECT_WINDOW_NAME}
     PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}
-    ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}
 )
 


### PR DESCRIPTION
## Summary

Lands the **portability skip-guard + CMake hygiene** half of #299 — the part that the cross-platform CI matrix actually blocks on.

The deeper Engine/Context rename was deferred because modern `vigine::engine::Engine` does not yet drive an FSM, while `example/window/` is built around the legacy FSM-driven workflow. A separate leaf will land that migration after the FSM-drive infrastructure ships (Option B path).

## Changes

- `example/window/CMakeLists.txt`: `if(NOT WIN32) return() endif()` early-return at top of file, BEFORE `find_program(GLSLC_EXECUTABLE)` — Linux/macOS CI no longer trips on missing Vulkan SDK.
- `example/window/CMakeLists.txt`: dropped `${CMAKE_SOURCE_DIR}/include` reach (vigine target exports include dirs PUBLIC).

## Tests

- 220/220 ctest green.
- example-window.exe links cleanly on Windows MSVC.
- Linux/macOS CI configures cleanly past example/window subdir (verified by skip-guard logic; full CI run on push to PR).

## Deferred

Issue #299 stays open after this PR for the full Engine/Context rename + FSM migration, which becomes feasible once FSM-drive lands in `vigine::engine::Engine::run()`.

(Does not close #299; partial value-only PR.)