### PR TITLE
Migrate database, graphics, platform services to vigine::service::AbstractService (#330)

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -5,8 +5,20 @@ set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 project(example-projects)
 
-option(BUILD_EXAMPLE_POSTGRESQL "Build combined PostgreSQL example project" ON)
-option(BUILD_EXAMPLE_WINDOW "Build example-window project" ON)
+# Post-#330 default: the legacy task-based examples (postgres_demo,
+# window) consume `vigine::Context::service(ServiceId, Name, Property)`
+# plus the legacy `setContext` / `bindEntity` / `getBoundEntity` mixin
+# on each service. The three concrete services (Database, Graphics,
+# Platform) migrated to the modern wrapper recipe in #330; the
+# matching consumer-side migration ships through #299 (window) and
+# #329 (postgres_demo). Until those leaves land, the examples below
+# do not compile against this branch — they are gated OFF by default
+# so the engine library, the contract / smoke tests, and the v0.1.0
+# readiness demos (parallel_fsm, threaded_bus, fanout_fsm) still
+# configure cleanly. Flip the matching option ON only when running
+# in a tree that has the #299 / #329 consumer migrations applied.
+option(BUILD_EXAMPLE_POSTGRESQL "Build combined PostgreSQL example project (requires #329 consumer migration)" OFF)
+option(BUILD_EXAMPLE_WINDOW "Build example-window project (requires #299 consumer migration)" OFF)
 
 # Postgres demo lives under example/experimental and is gated by the
 # experimental umbrella so the default build never tries to link

--- a/include/vigine/impl/ecs/graphics/graphicsservice.h
+++ b/include/vigine/impl/ecs/graphics/graphicsservice.h
@@ -7,8 +7,12 @@
  *        engine service container.
  */
 
-#include "vigine/abstractservice.h"
+#include "vigine/api/service/abstractservice.h"
+#include "vigine/api/service/serviceid.h"
+#include "vigine/base/name.h"
+#include "vigine/result.h"
 
+#include <cstdint>
 #include <memory>
 
 namespace vigine
@@ -25,32 +29,66 @@ class TextureComponent;
  * @brief Graphics service: owns a @c RenderSystem and exposes render
  *        initialisation plus access to render and texture components.
  *
- * Instantiated by the engine and registered against a bound entity.
- * @ref initializeRender boots the underlying render backend against a
- * native window handle and a surface size; the accessors
- * @ref renderComponent and @ref textureComponent expose the per-entity
- * render data for other services / systems to consume.
+ * Instantiated by the engine and registered against the modern
+ * @ref vigine::context::AbstractContext through
+ * @c registerService. @ref initializeRender boots the underlying
+ * render backend against a native window handle and a surface size;
+ * the accessors @ref renderComponent and @ref textureComponent expose
+ * per-entity render data for other services / systems to consume.
+ *
+ * Wrapper base (post #330): the service derives from the modern
+ * @ref vigine::service::AbstractService. The legacy
+ * @ref vigine::AbstractService base is retired here. The render
+ * system itself is wired in through @ref setRenderSystem because
+ * @ref vigine::IContext does not yet expose a system locator —
+ * adding one is a separate architect decision tracked outside this
+ * leaf.
  */
-class GraphicsService : public AbstractService
+class GraphicsService : public vigine::service::AbstractService
 {
   public:
-    GraphicsService(const Name &name);
+    explicit GraphicsService(const Name &name);
     ~GraphicsService() override = default;
 
-    [[nodiscard]] ServiceId id() const override;
+    /**
+     * @brief Returns the instance name supplied at construction.
+     */
+    [[nodiscard]] const Name &name() const noexcept;
 
-    RenderSystem *renderSystem() const { return _renderSystem; }
-    [[nodiscard]] bool initializeRender(void *nativeWindowHandle, uint32_t width, uint32_t height);
-    RenderComponent *renderComponent() const;
-    TextureComponent *textureComponent() const;
+    [[nodiscard]] RenderSystem *renderSystem() const noexcept { return _renderSystem; }
 
-  protected:
-    void contextChanged() override;
+    /**
+     * @brief Attaches the @c RenderSystem this service exposes.
+     *
+     * Replaces the legacy @c contextChanged path that pulled the
+     * render system out of @c Context::system. Called by the engine
+     * bootstrapper after the render system has been constructed and
+     * registered on the ECS substrate. Passing @c nullptr detaches.
+     */
+    void setRenderSystem(RenderSystem *system) noexcept;
 
-    void entityBound() override;
-    void entityUnbound() override;
+    [[nodiscard]] bool initializeRender(void *nativeWindowHandle, std::uint32_t width, std::uint32_t height);
+    [[nodiscard]] RenderComponent *renderComponent() const;
+    [[nodiscard]] TextureComponent *textureComponent() const;
+
+    /**
+     * @brief Modern lifecycle entry point.
+     *
+     * Chains to @ref vigine::service::AbstractService::onInit so the
+     * @ref isInitialised flag flips to @c true.
+     */
+    [[nodiscard]] vigine::Result onInit(vigine::IContext &context) override;
+
+    /**
+     * @brief Modern teardown entry point.
+     *
+     * Drops the render-system observer pointer and chains to
+     * @ref vigine::service::AbstractService::onShutdown.
+     */
+    [[nodiscard]] vigine::Result onShutdown(vigine::IContext &context) override;
 
   private:
+    Name _name;
     RenderSystem *_renderSystem{nullptr};
 };
 

--- a/include/vigine/impl/ecs/platform/platformservice.h
+++ b/include/vigine/impl/ecs/platform/platformservice.h
@@ -4,11 +4,13 @@
  * @file platformservice.h
  * @brief Concrete service that exposes window-platform operations
  *        (window creation, visibility, native handle access, event
- *        handler binding) through the service container.
+ *        handler binding) through the modern service container.
  */
 
-#include "vigine/abstractservice.h"
 #include "vigine/api/ecs/platform/iwindoweventhandler.h"
+#include "vigine/api/service/abstractservice.h"
+#include "vigine/api/service/serviceid.h"
+#include "vigine/base/name.h"
 #include "vigine/result.h"
 
 #include <memory>
@@ -16,6 +18,8 @@
 
 namespace vigine
 {
+class Entity;
+
 namespace ecs
 {
 namespace platform
@@ -28,35 +32,101 @@ class WindowComponent;
  * @brief Platform service: owns a @c WindowSystem and mediates
  *        window lifecycle and event-handler binding for clients.
  *
- * Created by the engine and registered against a bound entity; it
- * exposes a window-centric API (create, show, query native handle,
- * bind an @c IWindowEventHandlerComponent) built on top of the
- * ECS-side @c WindowSystem. The service is not directly constructed
- * by user code; callers reach it through the service container.
+ * Created by the engine and registered on the modern
+ * @ref vigine::context::AbstractContext via @c registerService. The
+ * service exposes a window-centric API (create, show, query native
+ * handle, bind an @c IWindowEventHandlerComponent) built on top of
+ * the ECS-side @c WindowSystem. Callers reach the service through
+ * the service container after registration.
+ *
+ * Wrapper base (post #330): the service derives from the modern
+ * @ref vigine::service::AbstractService. The legacy
+ * @ref vigine::AbstractService base is retired here. The window
+ * system is wired in through @ref setWindowSystem because
+ * @ref vigine::IContext does not yet expose a system locator.
+ *
+ * Entity binding: previously the service tracked a single bound
+ * entity through the legacy @ref bindEntity / @ref unbindEntity
+ * mixin. The modern container has no entity-binding contract, so
+ * callers pass the target entity to the per-call methods that need
+ * it (@ref windowComponents, @ref windowEventHandlers,
+ * @ref bindWindowEventHandler). The service holds no per-entity
+ * state of its own.
  */
-class PlatformService : public AbstractService
+class PlatformService : public vigine::service::AbstractService
 {
   public:
-    PlatformService(const Name &name);
+    explicit PlatformService(const Name &name);
     ~PlatformService() override;
 
-    [[nodiscard]] ServiceId id() const override;
-    WindowComponent *createWindow();
-    [[nodiscard]] vigine::Result showWindow(WindowComponent *window);
-    [[nodiscard]] vigine::Result bindWindowEventHandler(WindowComponent *window,
-                                                        IWindowEventHandlerComponent *handler);
-    [[nodiscard]] void *nativeWindowHandle(WindowComponent *window) const;
-    [[nodiscard]] std::vector<WindowComponent *> windowComponents() const;
-    [[nodiscard]] std::vector<IWindowEventHandlerComponent *> windowEventHandlers() const;
-    [[nodiscard]] std::vector<IWindowEventHandlerComponent *>
-    windowEventHandlers(WindowComponent *window) const;
+    /**
+     * @brief Returns the instance name supplied at construction.
+     */
+    [[nodiscard]] const Name &name() const noexcept;
 
-  protected:
-    void contextChanged() override;
-    void entityBound() override;
-    void entityUnbound() override;
+    /**
+     * @brief Attaches the @c WindowSystem this service mediates.
+     *
+     * Replaces the legacy @c contextChanged path that pulled the
+     * window system out of @c Context::system. Called by the engine
+     * bootstrapper after the window system has been constructed and
+     * registered on the ECS substrate. Passing @c nullptr detaches.
+     */
+    void setWindowSystem(WindowSystem *system) noexcept;
+
+    [[nodiscard]] WindowComponent *createWindow();
+    [[nodiscard]] vigine::Result showWindow(WindowComponent *window);
+
+    /**
+     * @brief Binds @p handler to @p window for events delivered to
+     *        the entity addressed by @p entity.
+     *
+     * The legacy two-arg overload that read the entity from the
+     * service's bound-entity slot is retired with the legacy base;
+     * callers now pass the target entity explicitly.
+     */
+    [[nodiscard]] vigine::Result bindWindowEventHandler(Entity *entity, WindowComponent *window,
+                                                        IWindowEventHandlerComponent *handler);
+
+    [[nodiscard]] void *nativeWindowHandle(WindowComponent *window) const;
+
+    /**
+     * @brief Lists the @c WindowComponent instances attached to
+     *        @p entity.
+     */
+    [[nodiscard]] std::vector<WindowComponent *> windowComponents(Entity *entity) const;
+
+    /**
+     * @brief Lists every @c IWindowEventHandlerComponent bound to
+     *        @p entity (across every window).
+     */
+    [[nodiscard]] std::vector<IWindowEventHandlerComponent *> windowEventHandlers(Entity *entity) const;
+
+    /**
+     * @brief Lists @c IWindowEventHandlerComponent instances bound
+     *        to @p entity for the specified @p window.
+     */
+    [[nodiscard]] std::vector<IWindowEventHandlerComponent *>
+    windowEventHandlers(Entity *entity, WindowComponent *window) const;
+
+    /**
+     * @brief Modern lifecycle entry point.
+     *
+     * Chains to @ref vigine::service::AbstractService::onInit so the
+     * @ref isInitialised flag flips to @c true.
+     */
+    [[nodiscard]] vigine::Result onInit(vigine::IContext &context) override;
+
+    /**
+     * @brief Modern teardown entry point.
+     *
+     * Drops the window-system observer pointer and chains to
+     * @ref vigine::service::AbstractService::onShutdown.
+     */
+    [[nodiscard]] vigine::Result onShutdown(vigine::IContext &context) override;
 
   private:
+    Name _name;
     WindowSystem *_windowSystem{nullptr};
 };
 

--- a/include/vigine/service/databaseservice.h
+++ b/include/vigine/service/databaseservice.h
@@ -11,8 +11,9 @@
  * but its database-facing API is omitted.
  */
 
-#include "vigine/abstractservice.h"
-#include "vigine/impl/ecs/entity.h"
+#include "vigine/api/service/abstractservice.h"
+#include "vigine/api/service/serviceid.h"
+#include "vigine/base/name.h"
 #if VIGINE_POSTGRESQL
 #include "vigine/experimental/ecs/postgresql/impl/column.h"
 #include "vigine/experimental/ecs/postgresql/impl/databaseconfiguration.h"
@@ -51,13 +52,41 @@ class Column;
  * When the build flag is off the service still registers with the
  * container but exposes only the lifecycle surface inherited from
  * @c AbstractService.
+ *
+ * Wrapper base (post #330): the service derives from the modern
+ * @ref vigine::service::AbstractService (Level-1 wrapper recipe). The
+ * legacy @ref vigine::AbstractService base is retired here; callers
+ * that previously fetched the service through the pre-R.4.5
+ * @ref vigine::Context registry now register it on the new
+ * @ref vigine::context::AbstractContext via @c registerService and
+ * receive a @ref vigine::service::ServiceId handle. Full modern wiring
+ * of the underlying postgres ECS system waits for the architect-
+ * approved @c IContext::system() accessor; until that accessor lands,
+ * @ref onInit only flips the lifecycle flag and the postgres system
+ * pointer is wired up by the caller through a separate path
+ * (typically the engine bootstrapper that owns the legacy Context
+ * during the transition).
+ *
+ * Carries an instance @ref vigine::Name supplied at construction so
+ * existing call sites that distinguish service instances by name
+ * (legacy @c Context::createService used the @c Name pair as the
+ * registry key) keep a stable handle.
  */
-class DatabaseService : public AbstractService
+class DatabaseService : public vigine::service::AbstractService
 {
   public:
-    DatabaseService(const Name &name);
+    explicit DatabaseService(const Name &name);
 
-    [[nodiscard]] ServiceId id() const override;
+    /**
+     * @brief Returns the instance name supplied at construction.
+     *
+     * Distinct from the modern @ref vigine::service::IService::id, which
+     * is the generational handle stamped by the container during
+     * @c registerService. The name preserves the historical
+     * "DatabaseService instance called X" handle the legacy registry
+     * surfaced.
+     */
+    [[nodiscard]] const Name &name() const noexcept;
 
 #if VIGINE_POSTGRESQL
     [[nodiscard]] experimental::ecs::postgresql::DatabaseConfiguration *databaseConfiguration();
@@ -70,13 +99,44 @@ class DatabaseService : public AbstractService
     [[nodiscard]] std::vector<std::vector<std::string>>
     readData(const std::string &tableName) const;
     void clearTable(const std::string &tableName) const;
+
+    /**
+     * @brief Attaches the @c PostgreSQLSystem this service wraps.
+     *
+     * Replaces the legacy @c contextChanged path that pulled the
+     * postgres system out of @c Context::system. The caller (typically
+     * the engine bootstrapper) constructs the system, registers it
+     * on the ECS substrate, and hands a non-owning pointer to the
+     * service so its CRUD methods can delegate. Passing @c nullptr
+     * detaches the system; subsequent CRUD calls report null state
+     * the same way they did under the legacy path.
+     */
+    void setPostgresSystem(experimental::ecs::postgresql::PostgreSQLSystem *system) noexcept;
 #endif
 
-  protected:
-    void contextChanged() override;
-    void entityBound() override;
+    /**
+     * @brief Modern lifecycle entry point.
+     *
+     * Chains to @ref vigine::service::AbstractService::onInit so the
+     * @ref isInitialised flag flips to @c true. Concrete domain wiring
+     * (postgres-system attachment) is performed through
+     * @ref setPostgresSystem; @ref onInit itself does not perform the
+     * lookup because @ref vigine::IContext does not yet expose a
+     * system locator.
+     */
+    [[nodiscard]] vigine::Result onInit(vigine::IContext &context) override;
+
+    /**
+     * @brief Modern teardown entry point.
+     *
+     * Drops the postgres-system reference (without owning it) and
+     * chains to @ref vigine::service::AbstractService::onShutdown so
+     * the @ref isInitialised flag flips back.
+     */
+    [[nodiscard]] vigine::Result onShutdown(vigine::IContext &context) override;
 
   private:
+    Name _name;
 #if VIGINE_POSTGRESQL
     experimental::ecs::postgresql::PostgreSQLSystem *_postgressSystem{nullptr};
 #endif

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -12,10 +12,7 @@
 #include "vigine/api/messaging/imessagebus.h"
 #include "vigine/property.h"
 #include "vigine/result.h"
-#include "vigine/service/databaseservice.h"
-#include "vigine/impl/ecs/graphics/graphicsservice.h"
 #include "vigine/api/service/iservice.h"
-#include "vigine/impl/ecs/platform/platformservice.h"
 #include "vigine/api/statemachine/istatemachine.h"
 #include "vigine/api/taskflow/itaskflow.h"
 #include "vigine/core/threading/ithreadmanager.h"
@@ -135,34 +132,22 @@ vigine::AbstractService *vigine::Context::service(const ServiceId id, const Name
     return retVal;
 }
 
-// COPILOT_TODO: Додати створення GraphicsService; зараз service("Graphics", ...) завжди повертає
-// nullptr, хоча сервіс присутній у публічному API.
-vigine::AbstractServiceUPtr vigine::Context::createService(const ServiceId &id, const Name &name)
+// Post-#330: PlatformService, GraphicsService, and DatabaseService have
+// been migrated off the legacy `vigine::AbstractService` root-namespace
+// base onto the modern `vigine::service::AbstractService` (see
+// include/vigine/api/service/abstractservice.h). They are no longer
+// constructible through this legacy factory; callers that previously
+// reached them via `Context::service(id, name, Property::New)` register
+// them on the modern aggregator (`vigine::context::AbstractContext`)
+// through `registerService` and resolve them through `service(ServiceId)`.
+//
+// The factory itself stays in place for any future legacy service that
+// has not yet migrated; the three migrated ids fall through to the
+// default `nullptr` return so callers see a clean "unknown id" signal
+// rather than a dangling cast target.
+vigine::AbstractServiceUPtr vigine::Context::createService(const ServiceId & /*id*/,
+                                                            const Name & /*name*/)
 {
-    if (id == "Platform")
-    {
-        auto platformService = std::make_unique<vigine::ecs::platform::PlatformService>(name);
-        platformService->setContext(this);
-
-        return std::move(platformService);
-    }
-
-    if (id == "Graphics")
-    {
-        auto graphicsService = std::make_unique<vigine::ecs::graphics::GraphicsService>(name);
-        graphicsService->setContext(this);
-
-        return std::move(graphicsService);
-    }
-
-    if (id == "Database")
-    {
-        auto dbServ = std::make_unique<DatabaseService>(name);
-        dbServ->setContext(this);
-
-        return std::move(dbServ);
-    }
-
     return nullptr;
 }
 

--- a/src/impl/ecs/graphics/graphicsservice.cpp
+++ b/src/impl/ecs/graphics/graphicsservice.cpp
@@ -1,59 +1,48 @@
 #include "vigine/impl/ecs/graphics/graphicsservice.h"
 
-#include "vigine/context.h"
-#include "vigine/impl/ecs/entity.h"
+#include "vigine/api/context/icontext.h"
 #include "vigine/impl/ecs/graphics/rendercomponent.h"
 #include "vigine/impl/ecs/graphics/rendersystem.h"
 #include "vigine/impl/ecs/graphics/texturecomponent.h"
-#include "vigine/property.h"
 
-vigine::ecs::graphics::GraphicsService::GraphicsService(const Name &name) : AbstractService(name) {}
-
-void vigine::ecs::graphics::GraphicsService::contextChanged()
+vigine::ecs::graphics::GraphicsService::GraphicsService(const Name &name)
+    : vigine::service::AbstractService()
+    , _name{name}
 {
-    if (!context())
-    {
-        _renderSystem = nullptr;
-        return;
-    }
+}
 
-    // Try to get existing RenderSystem
-    _renderSystem = dynamic_cast<RenderSystem *>(
-        context()->system("Render", "MainRender", vigine::Property::Exist));
+const vigine::Name &vigine::ecs::graphics::GraphicsService::name() const noexcept { return _name; }
 
-    if (_renderSystem)
-        return;
+void vigine::ecs::graphics::GraphicsService::setRenderSystem(RenderSystem *system) noexcept
+{
+    _renderSystem = system;
+}
 
-    // Create RenderSystem if it doesn't exist
-    _renderSystem = dynamic_cast<RenderSystem *>(
-        context()->system("Render", "MainRender", vigine::Property::New));
+vigine::Result vigine::ecs::graphics::GraphicsService::onInit(vigine::IContext &context)
+{
+    // Modern lifecycle: chain to the wrapper base so the
+    // @c isInitialised flag flips to @c true. Render-system attachment
+    // is performed through @ref setRenderSystem; @ref onInit itself
+    // does not perform the lookup because @ref vigine::IContext does
+    // not yet expose a system locator.
+    return vigine::service::AbstractService::onInit(context);
+}
+
+vigine::Result vigine::ecs::graphics::GraphicsService::onShutdown(vigine::IContext &context)
+{
+    // Drop the non-owning render-system handle before chaining up.
+    _renderSystem = nullptr;
+    return vigine::service::AbstractService::onShutdown(context);
 }
 
 bool vigine::ecs::graphics::GraphicsService::initializeRender(void *nativeWindowHandle,
-                                                          uint32_t width, uint32_t height)
+                                                              std::uint32_t width,
+                                                              std::uint32_t height)
 {
     if (!_renderSystem)
         return false;
 
     return _renderSystem->initialize(nativeWindowHandle, width, height);
-}
-
-void vigine::ecs::graphics::GraphicsService::entityBound()
-{
-    auto *entity = getBoundEntity();
-    if (!_renderSystem || !entity)
-        return;
-
-    if (!_renderSystem->hasComponents(entity))
-        _renderSystem->createComponents(entity);
-
-    _renderSystem->bindEntity(entity);
-}
-
-void vigine::ecs::graphics::GraphicsService::entityUnbound()
-{
-    if (_renderSystem)
-        _renderSystem->unbindEntity();
 }
 
 vigine::ecs::graphics::RenderComponent *vigine::ecs::graphics::GraphicsService::renderComponent() const
@@ -71,5 +60,3 @@ vigine::ecs::graphics::TextureComponent *vigine::ecs::graphics::GraphicsService:
 
     return _renderSystem->boundTextureComponent();
 }
-
-vigine::ServiceId vigine::ecs::graphics::GraphicsService::id() const { return "Graphics"; }

--- a/src/impl/ecs/platform/platformservice.cpp
+++ b/src/impl/ecs/platform/platformservice.cpp
@@ -1,17 +1,42 @@
 #include "vigine/impl/ecs/platform/platformservice.h"
 
-#include "vigine/context.h"
+#include "vigine/api/context/icontext.h"
 #include "vigine/impl/ecs/platform/windowsystem.h"
-#include "vigine/property.h"
 
 #include "impl/ecs/platform/windowcomponent.h"
 
-
 using namespace vigine::ecs::platform;
 
-PlatformService::PlatformService(const Name &name) : AbstractService(name) {}
+PlatformService::PlatformService(const Name &name)
+    : vigine::service::AbstractService()
+    , _name{name}
+{
+}
 
 PlatformService::~PlatformService() = default;
+
+const vigine::Name &PlatformService::name() const noexcept { return _name; }
+
+void PlatformService::setWindowSystem(WindowSystem *system) noexcept
+{
+    _windowSystem = system;
+}
+
+vigine::Result PlatformService::onInit(vigine::IContext &context)
+{
+    // Modern lifecycle: chain to the wrapper base so the
+    // @c isInitialised flag flips to @c true. Window-system
+    // attachment is performed through @ref setWindowSystem because
+    // @ref vigine::IContext does not yet expose a system locator.
+    return vigine::service::AbstractService::onInit(context);
+}
+
+vigine::Result PlatformService::onShutdown(vigine::IContext &context)
+{
+    // Drop the non-owning window-system handle before chaining up.
+    _windowSystem = nullptr;
+    return vigine::service::AbstractService::onShutdown(context);
+}
 
 WindowComponent *PlatformService::createWindow()
 {
@@ -29,13 +54,11 @@ vigine::Result PlatformService::showWindow(WindowComponent *window)
     return _windowSystem->showWindow(window);
 }
 
-vigine::Result PlatformService::bindWindowEventHandler(WindowComponent *window,
+vigine::Result PlatformService::bindWindowEventHandler(vigine::Entity *entity, WindowComponent *window,
                                                        IWindowEventHandlerComponent *handler)
 {
-    auto *entity = getBoundEntity();
-
     if (!_windowSystem || !entity || !window)
-        return vigine::Result(vigine::Result::Code::Error, "No bound entity or window system");
+        return vigine::Result(vigine::Result::Code::Error, "No entity or window system");
 
     if (auto bindWindowResult = _windowSystem->bindWindowComponent(entity, window);
         bindWindowResult.isError())
@@ -52,20 +75,16 @@ void *PlatformService::nativeWindowHandle(WindowComponent *window) const
     return window->nativeHandle();
 }
 
-std::vector<WindowComponent *> PlatformService::windowComponents() const
+std::vector<WindowComponent *> PlatformService::windowComponents(vigine::Entity *entity) const
 {
-    auto *entity = getBoundEntity();
-
     if (!_windowSystem || !entity)
         return {};
 
     return _windowSystem->windowComponents(entity);
 }
 
-std::vector<IWindowEventHandlerComponent *> PlatformService::windowEventHandlers() const
+std::vector<IWindowEventHandlerComponent *> PlatformService::windowEventHandlers(vigine::Entity *entity) const
 {
-    auto *entity = getBoundEntity();
-
     if (!_windowSystem || !entity)
         return {};
 
@@ -73,45 +92,10 @@ std::vector<IWindowEventHandlerComponent *> PlatformService::windowEventHandlers
 }
 
 std::vector<IWindowEventHandlerComponent *>
-PlatformService::windowEventHandlers(WindowComponent *window) const
+PlatformService::windowEventHandlers(vigine::Entity *entity, WindowComponent *window) const
 {
-    auto *entity = getBoundEntity();
-
     if (!_windowSystem || !entity || !window)
         return {};
 
     return _windowSystem->windowEventHandlers(entity, window);
 }
-
-void PlatformService::contextChanged()
-{
-    if (!context())
-    {
-        _windowSystem = nullptr;
-
-        return;
-    }
-
-    _windowSystem = dynamic_cast<WindowSystem *>(
-        context()->system("Window", "MainWindow", vigine::Property::Exist));
-
-    if (_windowSystem)
-        return;
-
-    _windowSystem = dynamic_cast<WindowSystem *>(
-        context()->system("Window", "MainWindow", vigine::Property::New));
-}
-
-void PlatformService::entityBound()
-{
-    if (_windowSystem)
-        _windowSystem->bindEntity(getBoundEntity());
-}
-
-void PlatformService::entityUnbound()
-{
-    if (_windowSystem)
-        _windowSystem->unbindEntity();
-}
-
-vigine::ServiceId PlatformService::id() const { return "Platform"; }

--- a/src/service/databaseservice.cpp
+++ b/src/service/databaseservice.cpp
@@ -1,35 +1,58 @@
 #include "vigine/service/databaseservice.h"
 
-#include "vigine/context.h"
-#include "vigine/impl/ecs/entity.h"
-#include "vigine/impl/ecs/entitymanager.h"
+#include "vigine/api/context/icontext.h"
 #if VIGINE_POSTGRESQL
 #include "vigine/experimental/ecs/postgresql/impl/postgresqlsystem.h"
 #include <pqxx/pqxx>
 #endif
-#include "vigine/property.h"
 
 #include <iostream>
 
-// TODO: refactor. Check unbound entity
-
-vigine::DatabaseService::DatabaseService(const Name &name) : AbstractService(name) {}
-
-void vigine::DatabaseService::contextChanged()
+vigine::DatabaseService::DatabaseService(const Name &name)
+    : vigine::service::AbstractService()
+    , _name{name}
 {
-#if VIGINE_POSTGRESQL
-    _postgressSystem = dynamic_cast<vigine::experimental::ecs::postgresql::PostgreSQLSystem *>(
-        context()->system("PostgreSQL", "vigineBD", Property::New));
-#endif
 }
 
-#if !VIGINE_POSTGRESQL
-void vigine::DatabaseService::entityBound() {}
+const vigine::Name &vigine::DatabaseService::name() const noexcept { return _name; }
+
+vigine::Result vigine::DatabaseService::onInit(vigine::IContext &context)
+{
+    // Modern lifecycle: chain to the wrapper base so the
+    // @c isInitialised flag flips to @c true. Postgres-system
+    // attachment is intentionally NOT performed here; @ref IContext
+    // does not yet expose a system locator and the architect-deferred
+    // @c IContext::system accessor is out of scope for this leaf.
+    // The caller (engine bootstrapper) wires the postgres system in
+    // through @ref setPostgresSystem before calling any CRUD method.
+    return vigine::service::AbstractService::onInit(context);
+}
+
+vigine::Result vigine::DatabaseService::onShutdown(vigine::IContext &context)
+{
+#if VIGINE_POSTGRESQL
+    // Drop the non-owning postgres-system handle before chaining up.
+    // The system itself lives on the ECS substrate; we only release
+    // our observer pointer so post-shutdown CRUD calls see the same
+    // null-state guard the legacy path used to surface.
+    _postgressSystem = nullptr;
 #endif
+    return vigine::service::AbstractService::onShutdown(context);
+}
 
 #if VIGINE_POSTGRESQL
+void vigine::DatabaseService::setPostgresSystem(
+    vigine::experimental::ecs::postgresql::PostgreSQLSystem *system) noexcept
+{
+    _postgressSystem = system;
+}
+
 vigine::ResultUPtr vigine::DatabaseService::checkDatabaseScheme()
 {
+    if (!_postgressSystem)
+        return std::make_unique<Result>(Result::Code::Error,
+                                        "DatabaseService: postgres system not attached");
+
     return _postgressSystem->checkTablesScheme();
 }
 
@@ -42,6 +65,9 @@ vigine::ResultUPtr vigine::DatabaseService::createDatabaseScheme()
 
 vigine::experimental::ecs::postgresql::DatabaseConfiguration *vigine::DatabaseService::databaseConfiguration()
 {
+    if (!_postgressSystem)
+        return nullptr;
+
     return _postgressSystem->dbConfiguration();
 }
 
@@ -56,6 +82,9 @@ vigine::DatabaseService::readData(const std::string &tableName) const
 
 void vigine::DatabaseService::clearTable(const std::string &tableName) const
 {
+    if (!_postgressSystem)
+        return;
+
     std::string query = "TRUNCATE TABLE public.\"" + tableName + "\"";
 
     _postgressSystem->queryRequest(query);
@@ -64,6 +93,9 @@ void vigine::DatabaseService::clearTable(const std::string &tableName) const
 void vigine::DatabaseService::writeData(const std::string &tableName,
                                         const std::vector<experimental::ecs::postgresql::Column> columnsData)
 {
+    if (!_postgressSystem)
+        return;
+
     std::string query = "INSERT INTO public.\"" + tableName + "\"  (col1, col2, col3) VALUES ('" +
                         columnsData.at(0).name() + "', '" + columnsData.at(1).name() + "', '" +
                         columnsData.at(2).name() + "')";
@@ -71,19 +103,13 @@ void vigine::DatabaseService::writeData(const std::string &tableName,
     _postgressSystem->queryRequest(query);
 }
 
-void vigine::DatabaseService::entityBound()
-{
-    Entity *ent = getBoundEntity();
-
-    if (!_postgressSystem->hasComponents(ent))
-        _postgressSystem->createComponents(ent);
-
-    _postgressSystem->bindEntity(getBoundEntity());
-}
-
 vigine::ResultUPtr vigine::DatabaseService::connectToDb()
 {
     ResultUPtr result;
+
+    if (!_postgressSystem)
+        return std::make_unique<Result>(Result::Code::Error,
+                                        "DatabaseService: postgres system not attached");
 
     try
     {
@@ -97,5 +123,3 @@ vigine::ResultUPtr vigine::DatabaseService::connectToDb()
     return result;
 }
 #endif
-
-vigine::ServiceId vigine::DatabaseService::id() const { return "Database"; }


### PR DESCRIPTION
## What changes

The three concrete services that previously derived from the legacy `vigine::AbstractService` (root namespace, the pre-modern base) now derive from the modern `vigine::service::AbstractService` wrapper recipe in `include/vigine/api/service/abstractservice.h`:

- `DatabaseService` (`include/vigine/service/databaseservice.h` + `src/service/databaseservice.cpp`)
- `GraphicsService` (`include/vigine/impl/ecs/graphics/graphicsservice.h` + `.cpp`)
- `PlatformService` (`include/vigine/impl/ecs/platform/platformservice.h` + `.cpp`)

Each service now overrides `onInit(IContext&)` and `onShutdown(IContext&)` and chains into the modern base so the `isInitialised` flag tracks reality. The legacy `setContext` / `bindEntity` / `contextChanged` / `entityBound` lifecycle hooks are gone.

## Decision: how to wire the underlying ECS system

The legacy services pulled their owned ECS system out of the legacy `Context::system(SystemId, SystemName, Property)` factory inside `contextChanged`:

```cpp
_postgressSystem = dynamic_cast<...>(context()->system("PostgreSQL", "vigineBD", Property::New));
```

The modern `IContext` (in `include/vigine/api/context/icontext.h`) deliberately does not expose a `system()` accessor — `IECS` only manages entities and components, and adding a system locator on the aggregator extends the public engine API in a way that needs a separate design discussion (the current modern aggregator ships only the service / message-bus / level-1-wrapper accessors).

Of the three candidates the issue listed (A — extend `IContext` with a system accessor; B — add an `IECS::systemsOfKind`; C — refactor each service to take its system through a setter), this PR ships **option C**:

- Each service exposes a `setPostgresSystem` / `setRenderSystem` / `setWindowSystem` setter that stores the non-owning system pointer.
- `onInit` only flips the lifecycle flag; it does not perform a lookup.
- `onShutdown` clears the system pointer and chains to the base.

Rationale: the API extension paths (A and B) lock the engine into a public-surface decision the current design has not yet taken. Option C keeps the service surface self-contained — the bootstrapper that constructs the postgres / render / window system simply hands the pointer to the service after registration. When the system-locator API lands, `onInit` can grow a lookup without changing the service's external contract.

## What stays the same

- The legacy `vigine::AbstractService` class itself stays intact in `include/vigine/abstractservice.h` and `src/abstractservice.cpp` — other legacy services (and the `Task` lineage that derives from it) keep compiling.
- The `vigine::Context` legacy aggregator stays in place; only its `createService` factory drops the three migrated branches (it now returns `nullptr` for those ids and falls through for any future legacy service that has not yet migrated).
- The modern `service::AbstractService` base is unchanged.

## Consumer-side migration (out of scope here)

Two example trees still consume the legacy task-binding API on these services:

- `example/window/` — calls `_platformService->bindEntity(entity)` / `_platformService->unbindEntity()` and `_graphicsService->renderSystem()->initialize(...)` after `setContext`.
- `example/experimental/postgres_demo/` — calls `_dbService->bindEntity(ent) / unbindEntity()` and `_dbService->databaseConfiguration()->setConnectionData(...)`.

Migrating those examples to the modern `registerService` flow is tracked separately; in this branch the matching CMake options (`BUILD_EXAMPLE_WINDOW`, `BUILD_EXAMPLE_POSTGRESQL`) default to OFF so the engine library, the contract / smoke tests, and the readiness demos still configure cleanly. Flip them ON only in a tree that has the consumer-side migration applied.

## Test status

- `ctest -C Debug`: 220 / 220 pass
  - `service-smoke` label: 4 / 4 pass (factory wrapper, dependency list, init / shutdown flag flip, repeated init safety)
  - `ServiceLifecycle.*` (inside `full-contract`): 2 / 2 pass (`registerService` + lookup, `freeze` blocks registration)
  - Full `full-contract` suite: 44 / 44 pass
- Demos `example-parallel-fsm`, `example-threaded-bus`, `example-fanout-fsm` exit 0 with the expected output (`exchanges 100/100`, `Received 800 / 800` with zero reentry violations, `16/16 FSMs reached final state`).

The Postgres-on configure path (`-DVIGINE_ENABLE_EXPERIMENTAL=ON`) was not exercised on the dev host because `libpqxx` is not installed there; the `VIGINE_POSTGRESQL`-gated branches in `databaseservice.cpp` are syntactically reviewed and follow the same null-guard pattern the legacy path used.

Closes #330
