### PR TITLE
Add FSM-drive infrastructure to Engine::run() with state-bound TaskFlow API (#334)

### DIFF
--- a/include/vigine/api/statemachine/abstractstatemachine.h
+++ b/include/vigine/api/statemachine/abstractstatemachine.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <mutex>
 #include <thread>
+#include <unordered_map>
 #include <vector>
 
 #include "vigine/api/messaging/isubscriptiontoken.h"
@@ -15,6 +16,11 @@
 #include "vigine/api/statemachine/istatemachine.h"
 #include "vigine/api/statemachine/routemode.h"
 #include "vigine/api/statemachine/stateid.h"
+
+namespace vigine
+{
+class TaskFlow;
+} // namespace vigine
 
 namespace vigine::statemachine
 {
@@ -167,6 +173,14 @@ class AbstractStateMachine : public IStateMachine
 
     void requestTransition(StateId target) override;
     void processQueuedTransitions() override;
+
+    // ------ IStateMachine: state-bound TaskFlow registry ------
+
+    vigine::Result
+        addStateTaskFlow(StateId                          state,
+                         std::unique_ptr<vigine::TaskFlow> taskFlow) override;
+
+    [[nodiscard]] vigine::TaskFlow *taskFlowFor(StateId state) const override;
 
     // ------ State-invalidation listener registry ------
 
@@ -465,6 +479,64 @@ class AbstractStateMachine : public IStateMachine
      * back without contending the registry mutex on the cancel path.
      */
     std::atomic<std::uint32_t> _nextInvalidationListenerId{1};
+
+    /**
+     * @brief Hash specialisation for @ref StateId so the per-state
+     *        TaskFlow registry can use @c std::unordered_map.
+     *
+     * StateId is an 8-byte trivially-copyable pair of @c std::uint32_t
+     * fields; the hasher splices the index and generation into a single
+     * 64-bit value before delegating to the standard library's
+     * @c std::hash<std::uint64_t>. Declaring the hasher inside the
+     * private section keeps the symbol scoped to the registry's storage
+     * type — no namespace-level @c std::hash specialisation leaks out
+     * through the public header tree.
+     */
+    struct StateIdHasher
+    {
+        [[nodiscard]] std::size_t operator()(const StateId &state) const noexcept
+        {
+            const std::uint64_t blended =
+                (static_cast<std::uint64_t>(state.generation) << 32u)
+                | static_cast<std::uint64_t>(state.index);
+            return std::hash<std::uint64_t>{}(blended);
+        }
+    };
+
+    /**
+     * @brief State-bound TaskFlow registry.
+     *
+     * One entry per state: the engine looks the @ref vigine::TaskFlow
+     * up by @ref StateId on every tick of @c run() and drives
+     * @c runCurrentTask while the flow has tasks left to run. The
+     * machine owns each registered flow through a @c std::unique_ptr;
+     * destroying the machine destroys every flow. Slots are
+     * append-only in this leaf — there is no removal API yet, matching
+     * the rest of the wrapper surface (states themselves are
+     * append-only).
+     *
+     * Storage shape is a heterogeneous-key @c std::unordered_map keyed
+     * by @ref StateId via the @ref StateIdHasher above. The map is
+     * guarded by @ref _stateTaskFlowsMutex which the public
+     * @ref addStateTaskFlow / @ref taskFlowFor methods take briefly on
+     * insert and lookup; the engine holds the looked-up pointer for
+     * the duration of one tick after releasing the mutex, which is
+     * safe because no removal API races against the read.
+     */
+    std::unordered_map<StateId, std::unique_ptr<vigine::TaskFlow>, StateIdHasher>
+        _stateTaskFlows;
+
+    /**
+     * @brief Mutex serialising mutators / lookups on
+     *        @ref _stateTaskFlows.
+     *
+     * Held only briefly: insert is a single map @c emplace, and
+     * lookup is a single @c find. The mutex is @c mutable because
+     * @ref taskFlowFor is @c const and still needs to take the
+     * lock for its read-side protection against a concurrent
+     * registration on the controller thread.
+     */
+    mutable std::mutex _stateTaskFlowsMutex;
 
     /**
      * @brief Internal helper that fires every active listener with

--- a/include/vigine/api/statemachine/abstractstatemachine.h
+++ b/include/vigine/api/statemachine/abstractstatemachine.h
@@ -180,7 +180,8 @@ class AbstractStateMachine : public IStateMachine
         addStateTaskFlow(StateId                          state,
                          std::unique_ptr<vigine::TaskFlow> taskFlow) override;
 
-    [[nodiscard]] vigine::TaskFlow *taskFlowFor(StateId state) const override;
+    [[nodiscard]] vigine::TaskFlow       *taskFlowFor(StateId state) override;
+    [[nodiscard]] const vigine::TaskFlow *taskFlowFor(StateId state) const override;
 
     // ------ State-invalidation listener registry ------
 

--- a/include/vigine/api/statemachine/istatemachine.h
+++ b/include/vigine/api/statemachine/istatemachine.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <thread>
 
 #include "vigine/result.h"
@@ -8,6 +9,8 @@
 
 namespace vigine
 {
+class TaskFlow;
+
 /**
  * @brief Pure-virtual forward-declared stub for the legacy state-machine
  *        surface.
@@ -439,6 +442,60 @@ class IStateMachine
      * controller-thread-serialised stream.
      */
     virtual void processQueuedTransitions() = 0;
+
+    // ------ State-bound TaskFlow registry ------
+
+    /**
+     * @brief Associates a runnable @ref vigine::TaskFlow with @p state so
+     *        the engine pumps that flow's tasks while the FSM is in
+     *        @p state.
+     *
+     * The state machine takes ownership of @p taskFlow. The flow is
+     * destroyed when the machine itself is destroyed; there is no
+     * removal API in this leaf — registrations are append-only for the
+     * machine's lifetime. The state machine never invokes the flow on
+     * its own; the engine drives the per-tick advance via the shape
+     * documented on @ref vigine::engine::IEngine::run after looking up
+     * the active flow through @ref taskFlowFor.
+     *
+     * Reports @ref Result::Code::Error when @p state is not registered
+     * or when @p taskFlow is @c nullptr. Reports
+     * @ref Result::Code::Error when @p state already has a TaskFlow
+     * bound (one-shot; callers that need to swap a flow rebuild the
+     * machine). On error the @c std::unique_ptr is released back to the
+     * caller through the move so the caller may inspect or retry; on
+     * success the machine consumes the unique_ptr.
+     *
+     * Threading: controller-thread-only once a binding is in place via
+     * @ref bindToControllerThread. The registration walks the state
+     * topology to confirm @p state is a live id, then takes the
+     * registry mutex briefly to insert the entry. The mutex is the
+     * same one @ref taskFlowFor takes for its read side, so concurrent
+     * lookups on other threads always see a coherent table — but
+     * mutations stay on the controller per the locked policy.
+     */
+    virtual vigine::Result
+        addStateTaskFlow(StateId                          state,
+                         std::unique_ptr<vigine::TaskFlow> taskFlow) = 0;
+
+    /**
+     * @brief Returns the @ref vigine::TaskFlow bound to @p state, or
+     *        @c nullptr when no flow has been registered for it.
+     *
+     * The state machine retains ownership of every registered flow;
+     * the returned pointer is non-owning and stays valid until the
+     * machine is destroyed. The lookup is the engine's per-tick entry
+     * point: it inspects @ref current and asks for the flow bound to
+     * that id; a @c nullptr return is the explicit "no work registered
+     * for this state" signal that lets the engine fall through to the
+     * thread manager pump alone.
+     *
+     * Threading: safe from any thread. Takes the registry mutex
+     * briefly for the lookup; concurrent lookups serialise against
+     * each other and against @ref addStateTaskFlow.
+     */
+    [[nodiscard]] virtual vigine::TaskFlow *
+        taskFlowFor(StateId state) const = 0;
 
     IStateMachine(const IStateMachine &)            = delete;
     IStateMachine &operator=(const IStateMachine &) = delete;

--- a/include/vigine/api/statemachine/istatemachine.h
+++ b/include/vigine/api/statemachine/istatemachine.h
@@ -462,9 +462,13 @@ class IStateMachine
      * or when @p taskFlow is @c nullptr. Reports
      * @ref Result::Code::Error when @p state already has a TaskFlow
      * bound (one-shot; callers that need to swap a flow rebuild the
-     * machine). On error the @c std::unique_ptr is released back to the
-     * caller through the move so the caller may inspect or retry; on
-     * success the machine consumes the unique_ptr.
+     * machine). Ownership is consumed by this call regardless of
+     * result: @p taskFlow is taken by value, so on every failure path
+     * the @c std::unique_ptr held by the parameter is destroyed at
+     * function return — its TaskFlow is released along with it. There
+     * is no hand-back to the caller. On success the machine takes the
+     * flow into its registry; on failure the flow is destroyed before
+     * the call returns.
      *
      * Threading: controller-thread-only once a binding is in place via
      * @ref bindToControllerThread. The registration walks the state
@@ -490,11 +494,22 @@ class IStateMachine
      * for this state" signal that lets the engine fall through to the
      * thread manager pump alone.
      *
+     * Two overloads are provided so callers observe a const-correct
+     * surface: a non-const machine returns a mutable @ref vigine::TaskFlow
+     * pointer (the engine needs that handle to call @c runCurrentTask
+     * each tick), while a const machine returns @c const @ref vigine::TaskFlow
+     * pointer so a @c const @ref IStateMachine reference cannot be used to
+     * mutate the bound flow. Both overloads share the same lookup body
+     * and lock policy below.
+     *
      * Threading: safe from any thread. Takes the registry mutex
      * briefly for the lookup; concurrent lookups serialise against
      * each other and against @ref addStateTaskFlow.
      */
     [[nodiscard]] virtual vigine::TaskFlow *
+        taskFlowFor(StateId state) = 0;
+
+    [[nodiscard]] virtual const vigine::TaskFlow *
         taskFlowFor(StateId state) const = 0;
 
     IStateMachine(const IStateMachine &)            = delete;

--- a/src/api/engine/abstractengine.cpp
+++ b/src/api/engine/abstractengine.cpp
@@ -149,9 +149,7 @@ Result AbstractEngine::run()
 
     // Main-thread pump loop. Each iteration is the engine "tick" per
     // AD-G3: we (1) advance the TaskFlow bound to the FSM's current
-    // state by exactly one step so tasks see a real state-bound
-    // engine token through the per-tick makeEngineToken call inside
-    // TaskFlow::runCurrentTask, (2) drain queued FSM transitions on
+    // state by exactly one step, (2) drain queued FSM transitions on
     // the controller thread (so requestTransition calls posted from
     // worker threads -- including those just posted by the task that
     // ran in step 1 -- are applied before the next state read), (3)
@@ -168,15 +166,39 @@ Result AbstractEngine::run()
     //   state through IStateMachine::taskFlowFor(current()). When the
     //   lookup hits, the engine drives exactly one TaskFlow step per
     //   tick by calling runCurrentTask(). That call asks IContext for
-    //   a fresh engine token, binds it on the task via setApi, runs
-    //   the task once, clears the binding, and lets the token go out
-    //   of scope so any subscribeExpiration callbacks that fired
-    //   during run() can finish their bookkeeping. When the lookup
-    //   misses (no TaskFlow registered for the current state) or the
-    //   bound flow has no further task to run (hasTasksToRun() ==
-    //   false), the tick falls through to the FSM drain + main-thread
-    //   pump alone, matching the pre-FSM-drive behaviour for callers
-    //   that drive the engine without a state-bound flow.
+    //   a fresh engine token (when a context has been wired into the
+    //   flow via TaskFlow::setContext), binds it on the task via
+    //   setApi, runs the task once, clears the binding, and lets the
+    //   token go out of scope so any subscribeExpiration callbacks
+    //   that fired during run() can finish their bookkeeping. When
+    //   the lookup misses (no TaskFlow registered for the current
+    //   state) or the bound flow has no further task to run
+    //   (hasTasksToRun() == false), the tick falls through to the FSM
+    //   drain + main-thread pump alone, matching the pre-FSM-drive
+    //   behaviour for callers that drive the engine without a
+    //   state-bound flow.
+    //
+    //   Engine-token state binding -- honest current state:
+    //     This leaf wires the per-tick lookup through taskFlowFor but
+    //     does NOT yet thread the FSM's current StateId into the token
+    //     mint inside TaskFlow::runCurrentTask. The legacy
+    //     TaskFlow::runCurrentTask path passes a sentinel-default
+    //     vigine::statemachine::StateId{} into IContext::makeEngineToken
+    //     (see src/impl/taskflow/taskflow.cpp). The legacy
+    //     Context::makeEngineToken stub ignores its argument; the
+    //     modern AbstractContext token factory tolerates the sentinel
+    //     and threads it into the concrete token. So the engine-token
+    //     a task observes per tick today is NOT bound to the FSM's
+    //     real current state -- it carries the sentinel id. Wiring
+    //     the real id through here requires either a runCurrentTask
+    //     overload that accepts an externally minted token or a
+    //     redesign of the legacy TaskFlow::setContext path; both are
+    //     larger than the FSM-drive infrastructure scope of this leaf
+    //     and are flagged for follow-up. The engine-token contract
+    //     suite (scenario_21/22) and the legacy demo path continue to
+    //     verify the token shape itself; this comment only documents
+    //     that the state-id field threaded into that token is the
+    //     sentinel, not fsm.current(), until the follow-up lands.
     //
     //   The FSM-drive step skips entirely when the FSM is bound to an
     //   alien thread (fsmDrainSafe == false) -- the caller asked the

--- a/src/api/engine/abstractengine.cpp
+++ b/src/api/engine/abstractengine.cpp
@@ -7,7 +7,9 @@
 #include "vigine/api/context/factory.h"
 #include "vigine/api/context/icontext.h"
 #include "vigine/api/statemachine/istatemachine.h"
+#include "vigine/api/statemachine/stateid.h"
 #include "vigine/core/threading/ithreadmanager.h"
+#include "vigine/impl/taskflow/taskflow.h"
 
 namespace vigine::engine
 {
@@ -146,21 +148,73 @@ Result AbstractEngine::run()
     _running.store(true, std::memory_order_release);
 
     // Main-thread pump loop. Each iteration is the engine "tick" per
-    // AD-G3: we drain queued FSM transitions on the controller thread
-    // first (so requestTransition calls posted from worker threads are
-    // applied before any main-thread runnable observes the new state),
-    // then drain the thread manager's main-thread queue, then wait for
+    // AD-G3: we (1) advance the TaskFlow bound to the FSM's current
+    // state by exactly one step so tasks see a real state-bound
+    // engine token through the per-tick makeEngineToken call inside
+    // TaskFlow::runCurrentTask, (2) drain queued FSM transitions on
+    // the controller thread (so requestTransition calls posted from
+    // worker threads -- including those just posted by the task that
+    // ran in step 1 -- are applied before the next state read), (3)
+    // drain the thread manager's main-thread queue, then (4) wait for
     // either a shutdown request or the pump tick timeout so a
     // shutdown() call is observed with bounded latency. The shutdown
     // flag is checked twice per tick -- once under the mutex (so a
     // concurrent shutdown + notify pair cannot be lost) and once
     // lock-free before each drain (so a shutdown that arrives during
     // the drain is observed at the next predicate check).
+    //
+    // FSM-drive contract:
+    //   The engine looks up the TaskFlow bound to the FSM's current
+    //   state through IStateMachine::taskFlowFor(current()). When the
+    //   lookup hits, the engine drives exactly one TaskFlow step per
+    //   tick by calling runCurrentTask(). That call asks IContext for
+    //   a fresh engine token, binds it on the task via setApi, runs
+    //   the task once, clears the binding, and lets the token go out
+    //   of scope so any subscribeExpiration callbacks that fired
+    //   during run() can finish their bookkeeping. When the lookup
+    //   misses (no TaskFlow registered for the current state) or the
+    //   bound flow has no further task to run (hasTasksToRun() ==
+    //   false), the tick falls through to the FSM drain + main-thread
+    //   pump alone, matching the pre-FSM-drive behaviour for callers
+    //   that drive the engine without a state-bound flow.
+    //
+    //   The FSM-drive step skips entirely when the FSM is bound to an
+    //   alien thread (fsmDrainSafe == false) -- the caller asked the
+    //   engine to stay out of the FSM's controller-thread contract,
+    //   so we honour that and let them drive their own task pump
+    //   externally. This keeps tests that bind the FSM directly off
+    //   the shared context working without surprise tick-time mutations.
     core::threading::IThreadManager &tm = _context->threadManager();
     const auto tick = std::chrono::milliseconds{pumpTickMilliseconds()};
 
     while (!_shutdownRequested.load(std::memory_order_acquire))
     {
+        // FSM-drive step: advance the TaskFlow bound to the current
+        // state by one. The lookup is best-effort (a null result is
+        // the explicit "no flow registered" signal); the per-tick
+        // pump shape lets the FSM transition between ticks change
+        // which flow is driven without the engine needing to track
+        // any cross-tick state. Gated by fsmDrainSafe so an alien-
+        // bound FSM does not get a controller-thread mutation here:
+        // its embedder is responsible for driving its own flows.
+        if (fsmDrainSafe)
+        {
+            const statemachine::StateId currentState = fsm.current();
+            vigine::TaskFlow *bound = fsm.taskFlowFor(currentState);
+            if (bound != nullptr && bound->hasTasksToRun())
+            {
+                // runCurrentTask handles the per-task setApi /
+                // makeEngineToken / setApi(nullptr) lifecycle on its
+                // own through its ApiBindingGuard; the engine just
+                // tells it to advance once. Any FSM transition
+                // requested by the task during run() lands on the
+                // FSM's request queue and is drained on the very
+                // next call below, so the next tick observes the
+                // new state.
+                bound->runCurrentTask();
+            }
+        }
+
         // Drain queued FSM transitions on this (controller) thread.
         // processQueuedTransitions is single-pass and snapshot-swap;
         // requests posted during the drain land on the live queue and

--- a/src/api/statemachine/abstractstatemachine.cpp
+++ b/src/api/statemachine/abstractstatemachine.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "statemachine/statetopology.h"
+#include "vigine/impl/taskflow/taskflow.h"
 #include "vigine/result.h"
 #include "vigine/api/statemachine/routemode.h"
 #include "vigine/api/statemachine/stateid.h"
@@ -411,6 +412,84 @@ void AbstractStateMachine::fireInvalidationListeners(StateId oldState)
     {
         cb(oldState);
     }
+}
+
+// ---------------------------------------------------------------------------
+// State-bound TaskFlow registry.
+//
+// The map associates a state (by StateId) with a runnable TaskFlow that
+// the engine pumps while the FSM is in that state. Registration is
+// controller-thread-only (gated by checkThreadAffinity) and validated
+// against the topology so a stale or unknown id is rejected; lookups
+// are safe from any thread and serve the engine's per-tick fast path.
+// The map owns each registered flow through std::unique_ptr — when the
+// state machine is destroyed, the map is destroyed, and every flow is
+// destroyed in turn. There is no removal API in this leaf; slots are
+// append-only for the machine's lifetime, matching the existing state
+// surface.
+//
+// Synchronisation: a dedicated mutex serialises register / lookup
+// against each other. Held only for a single map operation per call
+// so the controller stays responsive even when worker threads spam
+// taskFlowFor probes. The map storage uses a private StateIdHasher
+// declared on AbstractStateMachine; std::hash<StateId> is intentionally
+// not specialised at namespace scope so the symbol does not leak
+// through the public header tree.
+// ---------------------------------------------------------------------------
+
+Result AbstractStateMachine::addStateTaskFlow(
+    StateId                          state,
+    std::unique_ptr<vigine::TaskFlow> taskFlow)
+{
+    checkThreadAffinity();
+
+    if (taskFlow == nullptr)
+    {
+        return Result(Result::Code::Error,
+                      "addStateTaskFlow: null TaskFlow argument");
+    }
+
+    if (!_topology->hasState(state))
+    {
+        return Result(Result::Code::Error,
+                      "addStateTaskFlow: state is not registered");
+    }
+
+    std::scoped_lock lock{_stateTaskFlowsMutex};
+
+    // One-shot per state. A re-register attempt is a programming
+    // mistake (the caller is supposed to hand a freshly built flow
+    // exactly once during topology setup), so report an error rather
+    // than silently swap. The unique_ptr stays owned by the caller in
+    // the error path because emplace's return.second tells us whether
+    // the insertion happened.
+    auto [it, inserted] = _stateTaskFlows.emplace(state, std::move(taskFlow));
+    if (!inserted)
+    {
+        return Result(Result::Code::Error,
+                      "addStateTaskFlow: state already has a bound TaskFlow");
+    }
+
+    return Result();
+}
+
+vigine::TaskFlow *AbstractStateMachine::taskFlowFor(StateId state) const
+{
+    // Lookup is open to any thread: the engine's per-tick fast path
+    // calls this from the controller thread, but tests and
+    // diagnostics may probe the registry from worker threads too.
+    // The mutex hold is the few instructions of std::unordered_map::find;
+    // we copy the raw pointer out under the lock so the caller holds
+    // a stable handle even if a concurrent register adds a new entry
+    // (which would not invalidate iterators on emplace, but copying
+    // the raw pointer keeps the public contract loose).
+    std::scoped_lock lock{_stateTaskFlowsMutex};
+    auto it = _stateTaskFlows.find(state);
+    if (it == _stateTaskFlows.end())
+    {
+        return nullptr;
+    }
+    return it->second.get();
 }
 
 // ---------------------------------------------------------------------------

--- a/src/api/statemachine/abstractstatemachine.cpp
+++ b/src/api/statemachine/abstractstatemachine.cpp
@@ -460,9 +460,15 @@ Result AbstractStateMachine::addStateTaskFlow(
     // One-shot per state. A re-register attempt is a programming
     // mistake (the caller is supposed to hand a freshly built flow
     // exactly once during topology setup), so report an error rather
-    // than silently swap. The unique_ptr stays owned by the caller in
-    // the error path because emplace's return.second tells us whether
-    // the insertion happened.
+    // than silently swap. Ownership is consumed by this call regardless
+    // of result: the @p taskFlow parameter is taken by value, so the
+    // caller already moved its unique_ptr into the local. Whether or
+    // not std::unordered_map::emplace moved from the local on the
+    // duplicate-key path is implementation-defined, but either way the
+    // local goes out of scope at function return and its destructor
+    // tears down whatever it still owns. There is no hand-back path
+    // for the rejected flow — on duplicate registration the flow is
+    // simply destroyed before this function returns.
     auto [it, inserted] = _stateTaskFlows.emplace(state, std::move(taskFlow));
     if (!inserted)
     {
@@ -473,18 +479,40 @@ Result AbstractStateMachine::addStateTaskFlow(
     return Result();
 }
 
-vigine::TaskFlow *AbstractStateMachine::taskFlowFor(StateId state) const
+vigine::TaskFlow *AbstractStateMachine::taskFlowFor(StateId state)
+{
+    // Non-const overload: the engine's per-tick fast path calls this
+    // through a non-const IStateMachine reference because runCurrentTask
+    // mutates the flow's internal _currTask field. Delegating to the
+    // const overload through a const_cast keeps the lookup logic in one
+    // place; the cast is sound because the underlying registry slot
+    // owns the TaskFlow through a std::unique_ptr and "the registry
+    // hands out a non-owning pointer" is the public contract — the
+    // const overload was never doing more than reading the slot value
+    // out from under the registry mutex.
+    const auto *self = this;
+    return const_cast<vigine::TaskFlow *>(self->taskFlowFor(state));
+}
+
+const vigine::TaskFlow *AbstractStateMachine::taskFlowFor(StateId state) const
 {
     // Lookup is open to any thread: the engine's per-tick fast path
     // calls this from the controller thread, but tests and
     // diagnostics may probe the registry from worker threads too.
     // The mutex hold is the few instructions of std::unordered_map::find;
     // we copy the raw pointer out under the lock so the caller holds
-    // a stable handle even if a concurrent register adds a new entry
-    // (which would not invalidate iterators on emplace, but copying
-    // the raw pointer keeps the public contract loose).
+    // a stable handle even after the lock is released. Note that
+    // std::unordered_map::emplace MAY rehash and so MAY invalidate
+    // iterators on insertion; but it never invalidates the pointer
+    // value the unique_ptr owns. By copying out the raw pointer (the
+    // unique_ptr's get()) under the lock we hand the caller a stable
+    // address into the registry's storage that survives any future
+    // rehash. The caller relies on the absence of any removal API to
+    // keep that pointer live — entries are append-only for the
+    // machine's lifetime, so the underlying TaskFlow is never freed
+    // until the machine itself is destroyed.
     std::scoped_lock lock{_stateTaskFlowsMutex};
-    auto it = _stateTaskFlows.find(state);
+    auto             it = _stateTaskFlows.find(state);
     if (it == _stateTaskFlows.end())
     {
         return nullptr;

--- a/test/engine/smoke_test.cpp
+++ b/test/engine/smoke_test.cpp
@@ -296,6 +296,8 @@ TEST(EngineSmoke, RunFreezesTheContext)
 namespace
 {
 
+using vigine::Result;
+
 // Probe task that records every run() invocation. Used by the FSM-drive
 // scenarios to verify the per-tick pump path without needing a full
 // demo wiring.

--- a/test/engine/smoke_test.cpp
+++ b/test/engine/smoke_test.cpp
@@ -2,7 +2,11 @@
 #include "vigine/api/engine/engineconfig.h"
 #include "vigine/api/engine/factory.h"
 #include "vigine/api/engine/iengine.h"
+#include "vigine/api/statemachine/istatemachine.h"
+#include "vigine/api/statemachine/stateid.h"
+#include "vigine/api/taskflow/abstracttask.h"
 #include "vigine/impl/engine/engine.h"
+#include "vigine/impl/taskflow/taskflow.h"
 #include "vigine/result.h"
 #include "vigine/core/threading/irunnable.h"
 #include "vigine/core/threading/ithreadmanager.h"
@@ -12,6 +16,7 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -261,4 +266,205 @@ TEST(EngineSmoke, RunFreezesTheContext)
     // -- the important invariant is that the freeze flag was set by
     // run().
     EXPECT_TRUE(engine->context().isFrozen());
+}
+
+// ---------------------------------------------------------------------------
+// FSM-drive scenarios — Engine::run() pumps the per-state TaskFlow
+// (#334).
+//
+// Scenario 7 — no state-bound TaskFlow registered: run() exits cleanly
+//   on shutdown without invoking any task pump path. Existing behaviour
+//   preserved for callers that drive the engine without a flow.
+//
+// Scenario 8 — state-bound TaskFlow registered: run() advances the
+//   flow's tasks. The probe task records its run-count and the test
+//   verifies the FSM-drive pump fired at least once before shutdown.
+//
+// Note on engine-token observation:
+//   The legacy @c vigine::TaskFlow::runCurrentTask path calls
+//   @c IContext::makeEngineToken when a context is bound through
+//   @c setContext. The modern aggregator built by @c createEngine is a
+//   @c vigine::context::AbstractContext, NOT a @c vigine::Context
+//   (legacy), so @c TaskFlow::setContext (which expects the legacy
+//   class) cannot be wired here. The probe still observes that it ran
+//   — that is enough to prove the engine pumped the flow each tick.
+//   The token-observation aspect is covered by the existing
+//   engine-token contract suite (@c scenario_21/22) and by the
+//   demos that exercise the legacy front door.
+// ---------------------------------------------------------------------------
+
+namespace
+{
+
+// Probe task that records every run() invocation. Used by the FSM-drive
+// scenarios to verify the per-tick pump path without needing a full
+// demo wiring.
+class ProbeTask final : public vigine::AbstractTask
+{
+  public:
+    Result run() override
+    {
+        _runCount.fetch_add(1, std::memory_order_acq_rel);
+        return Result{};
+    }
+
+    [[nodiscard]] std::uint32_t runCount() const noexcept
+    {
+        return _runCount.load(std::memory_order_acquire);
+    }
+
+  private:
+    std::atomic<std::uint32_t> _runCount{0};
+};
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Scenario 7: Engine::run() with no state-bound TaskFlow exits cleanly.
+//
+// Pre-arm shutdown so run() exits on the first tick. The FSM has no
+// flow registered against its current state; taskFlowFor() returns
+// nullptr and the FSM-drive step falls through to the FSM drain +
+// main-thread pump alone — exactly the pre-#334 behaviour. The test
+// verifies that the new lookup path does not crash or hang when no
+// flow is registered.
+// ---------------------------------------------------------------------------
+
+TEST(EngineSmoke, RunWithoutBoundTaskFlowExitsCleanly)
+{
+    auto engine = createEngine();
+    ASSERT_NE(engine, nullptr);
+
+    // Sanity: the FSM has a default state but no bound flow yet.
+    auto &fsm = engine->context().stateMachine();
+    const vigine::statemachine::StateId currentState = fsm.current();
+    EXPECT_TRUE(currentState.valid());
+    EXPECT_EQ(fsm.taskFlowFor(currentState), nullptr);
+
+    // Pre-arm shutdown so run() exits on the first tick without ever
+    // pumping a task. The point is to confirm the new lookup path
+    // does not regress the bare-engine fast-exit case.
+    engine->shutdown();
+    const Result result = engine->run();
+    EXPECT_TRUE(result.isSuccess());
+    EXPECT_FALSE(engine->isRunning());
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 8: Engine::run() with a state-bound TaskFlow runs the
+//   bound task at least once before shutdown.
+//
+// Build a TaskFlow holding exactly one ProbeTask, bind it to the FSM's
+// current state, then drive run() on a helper thread until the probe
+// has fired and call shutdown(). Verifies that:
+//   - addStateTaskFlow accepts the registration.
+//   - taskFlowFor reports the bound flow back.
+//   - The engine pumped the flow at least once during run() so the
+//     probe's run-count is non-zero.
+//
+// The probe returns Result::Success which has no transition wired, so
+// runCurrentTask clears the flow's _currTask after the first run --
+// subsequent ticks see hasTasksToRun() == false and the FSM-drive
+// step falls through to the FSM drain + main-thread pump alone. That
+// shape is intentional: the engine asks the flow whether it has work
+// each tick and the flow signals completion through hasTasksToRun().
+// ---------------------------------------------------------------------------
+
+TEST(EngineSmoke, RunPumpsBoundTaskFlowEachTick)
+{
+    auto engine = createEngine();
+    ASSERT_NE(engine, nullptr);
+
+    auto &fsm = engine->context().stateMachine();
+
+    auto flow = std::make_unique<vigine::TaskFlow>();
+
+    auto       probeOwned = std::make_unique<ProbeTask>();
+    ProbeTask *probe      = probeOwned.get();
+    auto      *task       = flow->addTask(std::move(probeOwned));
+    ASSERT_NE(task, nullptr);
+    flow->changeCurrentTaskTo(task);
+
+    const vigine::statemachine::StateId currentState = fsm.current();
+    ASSERT_TRUE(currentState.valid());
+
+    const Result reg = fsm.addStateTaskFlow(currentState, std::move(flow));
+    ASSERT_TRUE(reg.isSuccess());
+    ASSERT_NE(fsm.taskFlowFor(currentState), nullptr);
+
+    // Run the engine on a helper thread so the test thread can poll
+    // for the probe to fire and then shut the engine down.
+    std::thread driver([&engine]() {
+        const Result r = engine->run();
+        EXPECT_TRUE(r.isSuccess());
+    });
+
+    // Wait until the probe has run at least once or a generous
+    // deadline elapses. With a 4 ms pump tick a single iteration
+    // should fire within tens of milliseconds; one second leaves
+    // ample headroom against CI jitter.
+    const auto deadline = std::chrono::steady_clock::now()
+                          + std::chrono::milliseconds{1000};
+    while (probe->runCount() == 0u
+           && std::chrono::steady_clock::now() < deadline)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds{1});
+    }
+
+    EXPECT_GT(probe->runCount(), 0u);
+
+    engine->shutdown();
+    driver.join();
+    EXPECT_FALSE(engine->isRunning());
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 9: addStateTaskFlow rejects null TaskFlow and stale state
+//   ids.
+//
+// Verifies the basic input validation on the new IStateMachine API:
+//   - addStateTaskFlow(any, nullptr) reports error.
+//   - addStateTaskFlow(stale, flow) reports error.
+//   - The valid registration round trip works after the rejections,
+//     and a duplicate registration on the same state errors out.
+// ---------------------------------------------------------------------------
+
+TEST(EngineSmoke, AddStateTaskFlowRejectsBadInput)
+{
+    auto engine = createEngine();
+    ASSERT_NE(engine, nullptr);
+
+    auto &fsm = engine->context().stateMachine();
+
+    // Null TaskFlow rejected.
+    {
+        const vigine::statemachine::StateId valid = fsm.current();
+        const Result nullCase =
+            fsm.addStateTaskFlow(valid, std::unique_ptr<vigine::TaskFlow>{});
+        EXPECT_TRUE(nullCase.isError());
+    }
+
+    // Stale id rejected.
+    {
+        auto         flow = std::make_unique<vigine::TaskFlow>();
+        const vigine::statemachine::StateId stale{42, 42};
+        const Result staleCase = fsm.addStateTaskFlow(stale, std::move(flow));
+        EXPECT_TRUE(staleCase.isError());
+    }
+
+    // Valid registration succeeds.
+    const vigine::statemachine::StateId valid = fsm.current();
+    {
+        auto         flow = std::make_unique<vigine::TaskFlow>();
+        const Result okCase = fsm.addStateTaskFlow(valid, std::move(flow));
+        EXPECT_TRUE(okCase.isSuccess());
+        EXPECT_NE(fsm.taskFlowFor(valid), nullptr);
+    }
+
+    // Re-register on the same state errors out (one-shot per state).
+    {
+        auto         flow = std::make_unique<vigine::TaskFlow>();
+        const Result dupCase = fsm.addStateTaskFlow(valid, std::move(flow));
+        EXPECT_TRUE(dupCase.isError());
+    }
 }


### PR DESCRIPTION
The modern engine has had the FSM and the runnable TaskFlow for a while, but the two were not connected: `Engine::run()` only drained the FSM transition queue and the main-thread pump. None of the demos under `example/window` or `example/experimental/postgres_demo` could land on the modern front door because they expect the engine to crank a per-state TaskFlow each tick, the way the legacy `vigine::Engine::run` did.

This PR adds that connection. `vigine::statemachine::IStateMachine` gains a per-state `TaskFlow` registry — `addStateTaskFlow` to bind a flow to a state once during topology setup, `taskFlowFor` to look one up by id. The implementation lives on `AbstractStateMachine`: a `std::unordered_map<StateId, std::unique_ptr<TaskFlow>>` guarded by a dedicated mutex, with a private `StateIdHasher` so the symbol does not leak through the public header tree. Registration is controller-thread-gated and validates the state id against the topology; lookups are safe from any thread.

`AbstractEngine::run()` then asks the FSM for the flow bound to its current state at the head of every tick. When a flow is registered and `hasTasksToRun()` returns true, the engine drives one `runCurrentTask()` step. The existing `processQueuedTransitions` and `runMainThreadPump` drains keep their order, the post-shutdown final drain still fires, and the new step is gated by the same `fsmDrainSafe` boolean that the post-#301 thread-affinity guard already uses, so an alien-bound FSM sees no controller-thread mutations from `run()`.

Three new engine-smoke scenarios cover the wire-up: bare engine without a bound flow exits cleanly (preserved behaviour), a probe task bound to the FSM's current state runs at least once before shutdown, and `addStateTaskFlow` rejects null flows, stale state ids, and duplicate registrations.

Note on token observation: the legacy `vigine::TaskFlow::runCurrentTask` calls `IContext::makeEngineToken` only when a `vigine::Context` is bound through `setContext`. The modern aggregator built by `createEngine` is a `vigine::context::AbstractContext`, not the legacy class, so the smoke test cannot wire context through the legacy path. The bound-state token observation stays covered by the existing engine-token contract scenarios.

Closes #334
