### PR TITLE
Address 14 Copilot findings on services and experimental postgresql (#333)

### DIFF
--- a/example/experimental/postgres_demo/task/data/addsomedatatask.cpp
+++ b/example/experimental/postgres_demo/task/data/addsomedatatask.cpp
@@ -24,23 +24,32 @@ void AddSomeDataTask::contextChanged()
 }
 
 // COPILOT_TODO: Either implement a real insert scenario or remove
-// this task; it currently returns Success without doing any work and
-// without validating entity/_dbService.
+// this task; it currently returns Success without doing any work
+// (the per-row insert loop is commented out below).
 vigine::Result AddSomeDataTask::run()
 {
     std::println("-- AddSomeDataTask::run()");
 
+    if (!_dbService)
+        return vigine::Result(vigine::Result::Code::Error,
+                              "AddSomeDataTask::run: database service is not bound");
+
     auto *entityManager = context()->entityManager();
     auto *entity        = entityManager->getEntityByAlias("PostgresBDLocal");
 
-    _dbService->bindEntity(entity);
+    if (!entity)
+        return vigine::Result(vigine::Result::Code::Error,
+                              "AddSomeDataTask::run: entity 'PostgresBDLocal' not found");
+
+    // Post-#330: legacy @c bindEntity / @c unbindEntity removed; the
+    // modern @c vigine::service::AbstractService base does not expose
+    // them. See @c RemoveSomeDataTask for the migration note.
     {
         // for (int i = 0; i < 100; i += 3)
         //     _dbService->insertData("Test", {vigine::Name("testData_" + std::to_string(i)),
         //                                     vigine::Name("testData_" + std::to_string(i + 1)),
         //                                     vigine::Name("testData_" + std::to_string(i + 2))});
     }
-    _dbService->unbindEntity();
 
     return vigine::Result();
 }

--- a/example/experimental/postgres_demo/task/data/readsomedatatask.cpp
+++ b/example/experimental/postgres_demo/task/data/readsomedatatask.cpp
@@ -23,20 +23,29 @@ void ReadSomeDataTask::contextChanged()
         context()->service("Database", vigine::Name("TestDB"), vigine::Property::Exist));
 }
 
-// COPILOT_TODO: Validate entity/_dbService and return an error while
-// DatabaseService::readData() stays unfinished; the current path masks
-// incomplete code as success.
+// COPILOT_TODO: @c DatabaseService::readData() still returns an empty
+// vector unconditionally; the loop below masks that as success. Real
+// row-fetch wiring is a separate follow-up.
 vigine::Result ReadSomeDataTask::run()
 {
     std::println("-- ReadSomeDataTask::run()");
 
+    if (!_dbService)
+        return vigine::Result(vigine::Result::Code::Error,
+                              "ReadSomeDataTask::run: database service is not bound");
+
     auto *entityManager = context()->entityManager();
     auto *entity        = entityManager->getEntityByAlias("PostgresBDLocal");
 
-    _dbService->bindEntity(entity);
+    if (!entity)
+        return vigine::Result(vigine::Result::Code::Error,
+                              "ReadSomeDataTask::run: entity 'PostgresBDLocal' not found");
+
+    // Post-#330: legacy @c bindEntity / @c unbindEntity removed; see
+    // @c RemoveSomeDataTask for the migration note.
     {
         std::vector<std::vector<std::string>> result = _dbService->readData("Test");
-        for (int i = 0; i < result.size(); ++i)
+        for (std::size_t i = 0; i < result.size(); ++i)
         {
             auto item          = result[i];
             std::string rowStr = "Row (" + std::to_string(i + 1) + ") data: ";
@@ -46,7 +55,6 @@ vigine::Result ReadSomeDataTask::run()
             std::println("{}", rowStr);
         }
     }
-    _dbService->unbindEntity();
 
     return vigine::Result();
 }

--- a/example/experimental/postgres_demo/task/data/removesomedatatask.cpp
+++ b/example/experimental/postgres_demo/task/data/removesomedatatask.cpp
@@ -23,21 +23,24 @@ void RemoveSomeDataTask::contextChanged()
         context()->service("Database", vigine::Name("TestDB"), vigine::Property::Exist));
 }
 
-// COPILOT_TODO: Validate entity/_dbService and provide an error-return
-// path from clearTable/queryRequest; otherwise database failures here
-// go unnoticed.
 vigine::Result RemoveSomeDataTask::run()
 {
     std::println("-- RemoveSomeDataTask::run()");
 
+    if (!_dbService)
+        return vigine::Result(vigine::Result::Code::Error,
+                              "RemoveSomeDataTask::run: database service is not bound");
+
     auto *entityManager = context()->entityManager();
     auto *entity        = entityManager->getEntityByAlias("PostgresBDLocal");
 
+    if (!entity)
+        return vigine::Result(vigine::Result::Code::Error,
+                              "RemoveSomeDataTask::run: entity 'PostgresBDLocal' not found");
+
     _dbService->bindEntity(entity);
-    {
-        _dbService->clearTable("Test");
-    }
+    auto clearResult = _dbService->clearTable("Test");
     _dbService->unbindEntity();
 
-    return vigine::Result();
+    return clearResult;
 }

--- a/example/experimental/postgres_demo/task/data/removesomedatatask.cpp
+++ b/example/experimental/postgres_demo/task/data/removesomedatatask.cpp
@@ -38,9 +38,15 @@ vigine::Result RemoveSomeDataTask::run()
         return vigine::Result(vigine::Result::Code::Error,
                               "RemoveSomeDataTask::run: entity 'PostgresBDLocal' not found");
 
-    _dbService->bindEntity(entity);
+    // Post-#330: @c DatabaseService derives from the modern
+    // @c vigine::service::AbstractService, which does not carry the
+    // legacy @c bindEntity / @c unbindEntity surface. The postgres
+    // system is now wired through @c DatabaseService::setPostgresSystem
+    // by the engine bootstrapper; this demo's full wiring migration is
+    // tracked as a follow-up. The previous calls were no-ops on the
+    // modern base anyway because @c DatabaseService never overrode the
+    // entity-bind hooks.
     auto clearResult = _dbService->clearTable("Test");
-    _dbService->unbindEntity();
 
     return clearResult;
 }

--- a/example/experimental/postgres_demo/task/db/checkbdshecmetask.cpp
+++ b/example/experimental/postgres_demo/task/db/checkbdshecmetask.cpp
@@ -25,6 +25,10 @@ void CheckBDShecmeTask::contextChanged()
 
 vigine::Result CheckBDShecmeTask::run()
 {
+    if (!_dbService)
+        return vigine::Result(vigine::Result::Code::Error,
+                              "CheckBDShecmeTask::run: database service is not bound");
+
     vigine::Result result;
 
     using namespace vigine::experimental::ecs::postgresql;
@@ -51,20 +55,36 @@ vigine::Result CheckBDShecmeTask::run()
     auto *entityManager = context()->entityManager();
     auto *entity        = entityManager->getEntityByAlias("PostgresBDLocal");
 
-    _dbService->bindEntity(entity);
+    if (!entity)
+        return vigine::Result(vigine::Result::Code::Error,
+                              "CheckBDShecmeTask::run: entity 'PostgresBDLocal' not found");
+
+    // Post-#330: legacy @c bindEntity / @c unbindEntity removed; see
+    // @c RemoveSomeDataTask for the migration note.
     {
-        _dbService->databaseConfiguration()->setTables({table});
-        result = *_dbService->checkDatabaseScheme();
+        if (auto *dbConfig = _dbService->databaseConfiguration())
+            dbConfig->setTables({table});
+
+        auto checkResultUPtr = _dbService->checkDatabaseScheme();
+        if (!checkResultUPtr)
+            return vigine::Result(vigine::Result::Code::Error,
+                                  "CheckBDShecmeTask::run: checkDatabaseScheme returned a null result");
+
+        result = *checkResultUPtr;
         if (!result.isSuccess())
         {
             std::println("Needed tables don't exist. Let's create them. Error message: {}",
                          result.message());
-            result = *_dbService->createDatabaseScheme();
+            auto createResultUPtr = _dbService->createDatabaseScheme();
+            if (!createResultUPtr)
+                return vigine::Result(vigine::Result::Code::Error,
+                                      "CheckBDShecmeTask::run: createDatabaseScheme returned a null result");
+
+            result = *createResultUPtr;
             if (result.isSuccess())
                 std::println("Needed Table was created");
         }
     }
-    _dbService->unbindEntity();
 
     return result;
 }

--- a/example/experimental/postgres_demo/task/db/initbdtask.cpp
+++ b/example/experimental/postgres_demo/task/db/initbdtask.cpp
@@ -26,11 +26,19 @@ void InitBDTask::contextChanged()
 
 vigine::Result InitBDTask::run()
 {
+    if (!_dbService)
+        return vigine::Result(vigine::Result::Code::Error,
+                              "InitBDTask::run: database service is not bound");
+
     auto *entityManager       = context()->entityManager();
     vigine::Entity *ent       = entityManager->createEntity();
     vigine::Entity *entSignal = entityManager->createEntity();
 
-    _dbService->bindEntity(ent);
+    // Post-#330: legacy @c bindEntity / @c unbindEntity removed; see
+    // @c RemoveSomeDataTask for the migration note. The
+    // @c databaseConfiguration / @c connectToDb calls below now run
+    // against the postgres system the engine bootstrapper attaches via
+    // @c DatabaseService::setPostgresSystem.
     {
         auto connectionDataUPtr = std::make_unique<vigine::experimental::ecs::postgresql::ConnectionData>();
         connectionDataUPtr->setHost("localhost");
@@ -39,12 +47,13 @@ vigine::Result InitBDTask::run()
         connectionDataUPtr->setDbUserName(vigine::Name("postgres"));
         connectionDataUPtr->setPassword(vigine::Password("postgres"));
 
-        _dbService->databaseConfiguration()->setConnectionData(std::move(connectionDataUPtr));
+        if (auto *dbConfig = _dbService->databaseConfiguration())
+            dbConfig->setConnectionData(std::move(connectionDataUPtr));
+
         auto connectResult = _dbService->connectToDb();
         if (connectResult && connectResult->isError())
             std::println("DB connection failed: {}", connectResult->message());
     }
-    _dbService->unbindEntity();
 
     entityManager->addAlias(ent, "PostgresBDLocal");
     entityManager->addAlias(entSignal, "KeyRleaseEvent");

--- a/example/window/CMakeLists.txt
+++ b/example/window/CMakeLists.txt
@@ -1,20 +1,21 @@
 cmake_minimum_required(VERSION 3.10)
 
+# Portability skip-guard: this example needs the Vulkan SDK (glslc) and
+# the Win32 platform service. Linux/macOS CI runs without the Vulkan SDK
+# installed and without the Win32 platform implementation, so opting in
+# only on Windows keeps the cross-platform configure step clean. The
+# guard MUST sit immediately after cmake_minimum_required, BEFORE
+# project() and find_program(GLSLC_EXECUTABLE), so non-Windows hosts
+# never enable the example-window project at all.
+if(NOT WIN32)
+    return()
+endif()
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 set(PROJECT_WINDOW_NAME example-window)
 project(${PROJECT_WINDOW_NAME})
-
-# Portability skip-guard: this example needs the Vulkan SDK (glslc) and
-# the Win32 platform service. Linux/macOS CI runs without the Vulkan SDK
-# installed and without the Win32 platform implementation, so opting in
-# only on Windows keeps the cross-platform configure step clean. The
-# guard MUST be the first effective statement so we never reach
-# find_program(GLSLC_EXECUTABLE) on non-Windows hosts.
-if(NOT WIN32)
-    return()
-endif()
 
 set(EXAMPLE_WINDOW_HANDLER_SOURCES
     handler/windoweventhandler.h handler/windoweventhandler.cpp)
@@ -306,13 +307,18 @@ endif()
 # automatically -- the manual reach into ${CMAKE_SOURCE_DIR}/include is
 # unnecessary and would leak the wrong include root when Vigine is
 # added via add_subdirectory under a parent project. The
-# ${CMAKE_SOURCE_DIR} entry below stays in place because
+# ${VIGINE_ROOT_DIR} entry below stays in place because
 # task/vulkan/imageloader.cpp resolves the bundled stb header through
 # `external/stb/stb_image.h`, which needs the engine root on the path.
+# Using ${VIGINE_ROOT_DIR} (set in the top-level CMakeLists) instead of
+# ${CMAKE_SOURCE_DIR} keeps the include resolution correct when Vigine
+# is consumed via add_subdirectory under a parent project — in that
+# case ${CMAKE_SOURCE_DIR} would point at the parent's source root,
+# not the engine root.
 target_include_directories(${PROJECT_WINDOW_NAME}
     PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}
-    ${CMAKE_SOURCE_DIR}
+    ${VIGINE_ROOT_DIR}
 )
 
 # Apply the central warning / strict-mode compile flags so the example

--- a/include/vigine/api/messaging/payload/payloadtypeid.h
+++ b/include/vigine/api/messaging/payload/payloadtypeid.h
@@ -58,8 +58,15 @@ struct PayloadTypeId
 // promise. Keyed off the wrapped uint32_t and delegated to the std::hash
 // for uint32_t so the quality matches the standard library's default.
 // TEMPLATE EXEMPTION: std::hash specialization required for hash-map key support; sanctioned per architecture.md § R-NoTemplates.
+// Wrapped in `namespace std { ... }` (rather than the `template <>
+// struct std::hash<...>` global-scope form) for portability — the
+// global form is accepted by some compilers but the namespace-qualified
+// form is the form mandated by the standard for user specialisations
+// inside std.
+namespace std
+{
 template <>
-struct std::hash<vigine::payload::PayloadTypeId>
+struct hash<vigine::payload::PayloadTypeId>
 {
     [[nodiscard]] std::size_t
     operator()(vigine::payload::PayloadTypeId id) const noexcept
@@ -67,3 +74,4 @@ struct std::hash<vigine::payload::PayloadTypeId>
         return std::hash<std::uint32_t>{}(id.value);
     }
 };
+} // namespace std

--- a/include/vigine/api/topicbus/topicid.h
+++ b/include/vigine/api/topicbus/topicid.h
@@ -48,11 +48,19 @@ struct TopicId
 } // namespace vigine::topicbus
 
 // TEMPLATE EXEMPTION: std::hash specialization required for hash-map key support; sanctioned per architecture.md § R-NoTemplates.
+// Wrapped in `namespace std { ... }` (rather than the `template <>
+// struct std::hash<...>` global-scope form) for portability — the
+// global form is accepted by some compilers but the namespace-qualified
+// form is the form mandated by the standard for user specialisations
+// inside std.
+namespace std
+{
 template <>
-struct std::hash<vigine::topicbus::TopicId>
+struct hash<vigine::topicbus::TopicId>
 {
     [[nodiscard]] std::size_t operator()(vigine::topicbus::TopicId id) const noexcept
     {
         return std::hash<std::uint32_t>{}(id.value);
     }
 };
+} // namespace std

--- a/include/vigine/experimental/ecs/postgresql/impl/columntype.h
+++ b/include/vigine/experimental/ecs/postgresql/impl/columntype.h
@@ -44,7 +44,7 @@ struct Void
  * @brief Closed enum of PostgreSQL column types supported by the
  *        engine.
  *
- * @c NotRcognized is the sentinel returned when the engine cannot
+ * @c NotRecognized is the sentinel returned when the engine cannot
  * map a database-side type to one of the recognised kinds; the
  * remaining enumerators are generated from
  * @c VIGINE_POSTGRESQL_DATA_COLUMN_TYPE_LIST and mirror the C++
@@ -52,7 +52,7 @@ struct Void
  */
 enum class DataType
 {
-    NotRcognized,
+    NotRecognized,
 #define VIGINE_POSTGRESQL_DATA_X(name, type) name,
 
     VIGINE_POSTGRESQL_DATA_COLUMN_TYPE_LIST

--- a/include/vigine/experimental/ecs/postgresql/impl/postgresqlsystem.h
+++ b/include/vigine/experimental/ecs/postgresql/impl/postgresqlsystem.h
@@ -60,7 +60,24 @@ class PostgreSQLSystem : public AbstractSystem
     [[nodiscard]] PostgreSQLResultUPtr checkTablesScheme() const;
 
     void createTable(const std::string &tableName, const std::vector<std::string> tableColumns);
-    void queryRequest(const std::string &query);
+
+    /**
+     * @brief Executes the supplied SQL string against the bound entity
+     *        component and surfaces the outcome as a @c vigine::Result.
+     *
+     * Pre-#333 the API was @c void with a silent log-and-return when
+     * no entity was bound; callers (notably @c DatabaseService) had no
+     * way to distinguish "ran cleanly" from "skipped because nothing
+     * was bound" or "the driver reported an error". The signature now
+     * returns:
+     *   - @c Result::Code::Error with the unbound-state message when
+     *     no entity is bound;
+     *   - the underlying driver result on a successful exec (errors
+     *     surface through the driver's own @c isError payload, which
+     *     this method forwards as-is);
+     *   - @c Result::Code::Success otherwise.
+     */
+    [[nodiscard]] vigine::Result queryRequest(const std::string &query);
 
   protected:
     virtual void entityBound();

--- a/include/vigine/impl/ecs/graphics/graphicsservice.h
+++ b/include/vigine/impl/ecs/graphics/graphicsservice.h
@@ -68,7 +68,36 @@ class GraphicsService : public vigine::service::AbstractService
     void setRenderSystem(RenderSystem *system) noexcept;
 
     [[nodiscard]] bool initializeRender(void *nativeWindowHandle, std::uint32_t width, std::uint32_t height);
+
+    /**
+     * @brief Returns the render component bound to the underlying
+     *        @ref RenderSystem's currently bound entity.
+     *
+     * The service does not bind entities itself; binding happens at
+     * the @ref RenderSystem level (driven by ECS @c entityBound
+     * callbacks). This accessor is a thin pass-through to
+     * @c RenderSystem::boundRenderComponent and therefore returns
+     * @c nullptr in three observable cases:
+     *   1. The render system has not been attached yet
+     *      (see @ref setRenderSystem).
+     *   2. The render system has no bound entity.
+     *   3. The bound entity has no @c RenderComponent registered.
+     *
+     * Callers MUST null-check the return value; the accessor is
+     * intentionally tolerant of unbound state because example code
+     * inspects bindings opportunistically during input handling.
+     */
     [[nodiscard]] RenderComponent *renderComponent() const;
+
+    /**
+     * @brief Returns the texture component bound to the underlying
+     *        @ref RenderSystem's currently bound entity.
+     *
+     * Same null-state contract as @ref renderComponent: returns
+     * @c nullptr when the render system is unattached, has no bound
+     * entity, or the bound entity has no @c TextureComponent.
+     * Callers MUST null-check.
+     */
     [[nodiscard]] TextureComponent *textureComponent() const;
 
     /**

--- a/include/vigine/service/databaseservice.h
+++ b/include/vigine/service/databaseservice.h
@@ -6,9 +6,22 @@
  *        scheme check / create, row read / write / clear) through the
  *        service container.
  *
- * Database operations are compiled in only when the project is built
- * with @c VIGINE_POSTGRESQL enabled; otherwise the service still exists
- * but its database-facing API is omitted.
+ * Two-tier gating chain:
+ *   1. The experimental postgres example (@c example/experimental/postgres_demo)
+ *      is opted in at the top-level CMake through
+ *      @c VIGINE_ENABLE_EXPERIMENTAL combined with
+ *      @c BUILD_EXAMPLE_POSTGRESQL (see @c example/CMakeLists.txt).
+ *   2. Inside this header, the database-facing CRUD API is compiled in
+ *      only when the @c VIGINE_POSTGRESQL preprocessor define is set.
+ *      When the experimental umbrella is enabled the build system
+ *      defines @c VIGINE_POSTGRESQL automatically; otherwise this
+ *      service still exists as a lifecycle-only stub but its
+ *      database-facing API is omitted.
+ *
+ * The two flags are NOT redundant: @c VIGINE_ENABLE_EXPERIMENTAL gates
+ * the experimental tree as a whole (across multiple subsystems), while
+ * @c VIGINE_POSTGRESQL is the per-translation-unit compile-time switch
+ * that this header keys off.
  */
 
 #include "vigine/api/service/abstractservice.h"
@@ -95,10 +108,29 @@ class DatabaseService : public vigine::service::AbstractService
     [[nodiscard]] ResultUPtr checkDatabaseScheme();
     [[nodiscard]] ResultUPtr createDatabaseScheme();
 
-    void writeData(const std::string &tableName, const std::vector<experimental::ecs::postgresql::Column> columnsData);
+    /**
+     * @brief Inserts a row into the named table.
+     *
+     * Returns @c Result::Code::Error when the postgres system is
+     * unattached (previously the call returned @c void and silently
+     * dropped the request — a real CRUD failure was indistinguishable
+     * from a successful no-op). The @c columnsData parameter is taken
+     * by const-reference to avoid a vector copy on every call site.
+     */
+    [[nodiscard]] vigine::Result writeData(const std::string &tableName,
+                                           const std::vector<experimental::ecs::postgresql::Column> &columnsData);
     [[nodiscard]] std::vector<std::vector<std::string>>
     readData(const std::string &tableName) const;
-    void clearTable(const std::string &tableName) const;
+
+    /**
+     * @brief Truncates the named table.
+     *
+     * Returns @c Result::Code::Error when the postgres system is
+     * unattached (previously @c void with a silent return, hiding the
+     * failure). Callers can chain on @ref vigine::Result::isError to
+     * surface the issue up the task graph.
+     */
+    [[nodiscard]] vigine::Result clearTable(const std::string &tableName) const;
 
     /**
      * @brief Attaches the @c PostgreSQLSystem this service wraps.

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -139,7 +139,15 @@ vigine::AbstractService *vigine::Context::service(const ServiceId id, const Name
 // constructible through this legacy factory; callers that previously
 // reached them via `Context::service(id, name, Property::New)` register
 // them on the modern aggregator (`vigine::context::AbstractContext`)
-// through `registerService` and resolve them through `service(ServiceId)`.
+// through `registerService` and resolve them through the modern
+// generational accessor
+// `vigine::service::IService::service(vigine::service::ServiceId)` —
+// distinct from the deprecated legacy `service(ServiceId, Name, Property)`
+// signature defined in this file, where `ServiceId` is the
+// root-namespace `std::string` alias rather than the modern
+// `vigine::service::ServiceId` generational handle. The legacy
+// signature is retained for transitional callers but is scheduled for
+// removal once all services migrate.
 //
 // The factory itself stays in place for any future legacy service that
 // has not yet migrated; the three migrated ids fall through to the

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -141,8 +141,10 @@ vigine::AbstractService *vigine::Context::service(const ServiceId id, const Name
 // them on the modern aggregator (`vigine::context::AbstractContext`)
 // through `registerService` and resolve them through the modern
 // generational accessor
-// `vigine::service::IService::service(vigine::service::ServiceId)` —
-// distinct from the deprecated legacy `service(ServiceId, Name, Property)`
+// `vigine::IContext::service(vigine::service::ServiceId)` (also
+// available on `vigine::context::AbstractContext` and via the
+// engine-bound `vigine::engine::IEngineToken::service(...)`) — distinct
+// from the deprecated legacy `service(ServiceId, Name, Property)`
 // signature defined in this file, where `ServiceId` is the
 // root-namespace `std::string` alias rather than the modern
 // `vigine::service::ServiceId` generational handle. The legacy

--- a/src/experimental/ecs/postgresql/impl/postgresqlresult.cpp
+++ b/src/experimental/ecs/postgresql/impl/postgresqlresult.cpp
@@ -77,7 +77,7 @@ void vigine::experimental::ecs::postgresql::PostgreSQLResult::buildResultData(co
                 auto colTypeOID = data.column_type(i);
                 auto columnName = data.column_name(i);
 
-                switch (_converter->toColumnType(colTypeOID).value_or(DataType::NotRcognized))
+                switch (_converter->toColumnType(colTypeOID).value_or(DataType::NotRecognized))
                 {
                 case DataType::Boolean:
                     row->set(columnName, Data(rowData[i].as<bool>(), DataType::Boolean));

--- a/src/experimental/ecs/postgresql/impl/postgresqlsystem.cpp
+++ b/src/experimental/ecs/postgresql/impl/postgresqlsystem.cpp
@@ -243,21 +243,33 @@ void vigine::experimental::ecs::postgresql::PostgreSQLSystem::createTable(const 
         std::println("PostgreSQL createTable failed: {}", result->message());
 }
 
-// COPILOT_TODO: Додати guard на _boundEntityComponent і нормальний шлях повернення помилки;
-// void-API тут маскує критичні збої виконання запиту.
-void vigine::experimental::ecs::postgresql::PostgreSQLSystem::queryRequest(const std::string &query)
+// Post-#333: signature returns @c vigine::Result so callers can react
+// to the unbound-state and driver-error paths instead of treating a
+// silent no-op as success.
+vigine::Result
+vigine::experimental::ecs::postgresql::PostgreSQLSystem::queryRequest(const std::string &query)
 {
     if (!_boundEntityComponent)
     {
         std::println("PostgreSQL query skipped: entity component is not bound");
-        return;
+        return vigine::Result(vigine::Result::Code::Error,
+                              "PostgreSQLSystem::queryRequest: no entity component is bound");
     }
 
     _boundEntityComponent->setQuery(query);
     auto result = _boundEntityComponent->exec();
 
+    if (!result)
+        return vigine::Result(vigine::Result::Code::Error,
+                              "PostgreSQLSystem::queryRequest: driver returned a null result");
+
     if (result->isError())
+    {
         std::println("PostgreSQL query failed: {}", result->message());
+        return vigine::Result(vigine::Result::Code::Error, result->message());
+    }
+
+    return vigine::Result();
 }
 
 void vigine::experimental::ecs::postgresql::PostgreSQLSystem::entityBound()

--- a/src/experimental/ecs/postgresql/impl/postgresqlsystem.cpp
+++ b/src/experimental/ecs/postgresql/impl/postgresqlsystem.cpp
@@ -82,11 +82,18 @@ vigine::experimental::ecs::postgresql::PostgreSQLResultUPtr vigine::experimental
     return std::make_unique<PostgreSQLResult>();
 }
 
-// COPILOT_TODO: Перевіряти _boundEntityComponent перед доступом до dbConfiguration()/exec(), інакше
-// перевірка схеми падає ще до повернення Result::Error.
 vigine::experimental::ecs::postgresql::PostgreSQLResultUPtr
 vigine::experimental::ecs::postgresql::PostgreSQLSystem::checkTablesScheme() const
 {
+    // Defensive null-check: previously this routine dereferenced
+    // _boundEntityComponent directly and crashed when the system had
+    // no entity bound yet (Copilot finding A9). Surface the error as
+    // a Result so the call chain through DatabaseService::checkDatabaseScheme
+    // returns cleanly.
+    if (!_boundEntityComponent)
+        return std::make_unique<PostgreSQLResult>(Result::Code::Error,
+                                                  "PostgreSQL entity component is not bound");
+
     const auto &tables = _boundEntityComponent->dbConfiguration()->tables();
 
     bool hasError{false};

--- a/src/experimental/ecs/postgresql/impl/postgresqltypeconverter.cpp
+++ b/src/experimental/ecs/postgresql/impl/postgresqltypeconverter.cpp
@@ -21,7 +21,7 @@ void vigine::experimental::ecs::postgresql::PostgreSQLTypeConverter::setTypeRela
                                                                   BDExternalType bdExtType)
 {
     auto type = pgExternalToVigineDataType(bdExtType);
-    if (type == DataType::NotRcognized)
+    if (type == DataType::NotRecognized)
         return;
 
     _typesContainer.emplace_back(internalType, type);
@@ -42,7 +42,7 @@ vigine::experimental::ecs::postgresql::PostgreSQLTypeConverter::pgExternalToVigi
 #undef VIGINE_POSTGRESQL_DATA_X
 
     // convert from string to DataType
-    return DataType::NotRcognized;
+    return DataType::NotRecognized;
 }
 
 std::optional<vigine::experimental::ecs::postgresql::DataType>

--- a/src/experimental/ecs/postgresql/impl/query/querybuilder.cpp
+++ b/src/experimental/ecs/postgresql/impl/query/querybuilder.cpp
@@ -210,7 +210,7 @@ std::string vigine::experimental::ecs::postgresql::query::QueryBuilder::format(s
             {"table_name"sv, [this](const Data &data) -> std::string  { return std::format("'{}'", escapeString(data.as<DataType::Text>().value_or(""))); }},
             {"quoted"sv,     [this](const Data &data) -> std::string  { return std::format("'{}'", escape(data)); } },
             {"text"sv,       [](const Data &data)     -> std::string  { return data.as<DataType::Text>().value_or(""); }},
-            {"is_null"sv,    [](const Data &data)     -> std::string  { return "TRUE"; }                                },
+            {"is_null"sv,    [](const Data &/*data*/) -> std::string  { return "TRUE"; }                                },
             {"bool"sv,       [](const Data &data)     -> std::string  { return (data.as<DataType::Boolean>().value_or(false))?"true":"false"; }     },
             {"char"sv,       [](const Data &data)     -> std::string  { return "'" + std::string(1, data.as<DataType::Char>().value_or('\0')) + "'"; }},
     };

--- a/src/experimental/ecs/postgresql/impl/row.cpp
+++ b/src/experimental/ecs/postgresql/impl/row.cpp
@@ -9,7 +9,7 @@
 
 namespace vigine::experimental::ecs::postgresql
 {
-bool Row::operator==(const Row &other) const { return _columnsData == _columnsData; }
+bool Row::operator==(const Row &other) const { return _columnsData == other._columnsData; }
 
 void Row::set(const ColumnName &columnName, const Data &data)
 {
@@ -41,7 +41,7 @@ const Data &Row::operator[](const ColumnName &name) const
 
 size_t Row::size() const { return _columnsData.size(); }
 
-int Row::columnIndex(const ColumnName &columnName) const { return 0; }
+int Row::columnIndex(const ColumnName & /*columnName*/) const { return 0; }
 
 bool Row::empty() const noexcept { return _columnsData.empty(); }
 
@@ -60,7 +60,7 @@ int Row::findIndexByColumnName(const std::string &name) const
     for (size_t i = 0; i < _columnsData.size(); ++i)
     {
         if (_columnsData[i].first == name)
-            return i;
+            return static_cast<int>(i);
     }
 
     return -1;
@@ -71,7 +71,7 @@ int Row::findIndexByColumn(const Column &column) const
     for (size_t i = 0; i < _columnsData.size(); ++i)
     {
         if (_columnsData[i].first == column)
-            return i;
+            return static_cast<int>(i);
     }
 
     return -1;

--- a/src/impl/ecs/platform/platformservice.cpp
+++ b/src/impl/ecs/platform/platformservice.cpp
@@ -57,8 +57,19 @@ vigine::Result PlatformService::showWindow(WindowComponent *window)
 vigine::Result PlatformService::bindWindowEventHandler(vigine::Entity *entity, WindowComponent *window,
                                                        IWindowEventHandlerComponent *handler)
 {
-    if (!_windowSystem || !entity || !window)
-        return vigine::Result(vigine::Result::Code::Error, "No entity or window system");
+    // Surface the specific null arg so callers don't have to guess
+    // which of the three required handles came in null. The previous
+    // catch-all "No entity or window system" message swallowed the
+    // window argument entirely.
+    if (!_windowSystem)
+        return vigine::Result(vigine::Result::Code::Error,
+                              "PlatformService::bindWindowEventHandler: window system is unattached");
+    if (!entity)
+        return vigine::Result(vigine::Result::Code::Error,
+                              "PlatformService::bindWindowEventHandler: entity is null");
+    if (!window)
+        return vigine::Result(vigine::Result::Code::Error,
+                              "PlatformService::bindWindowEventHandler: window is null");
 
     if (auto bindWindowResult = _windowSystem->bindWindowComponent(entity, window);
         bindWindowResult.isError())

--- a/src/service/databaseservice.cpp
+++ b/src/service/databaseservice.cpp
@@ -80,27 +80,39 @@ vigine::DatabaseService::readData(const std::string &tableName) const
     return resultData;
 }
 
-void vigine::DatabaseService::clearTable(const std::string &tableName) const
+vigine::Result vigine::DatabaseService::clearTable(const std::string &tableName) const
 {
+    // Surface the unattached-system case as an explicit error so
+    // callers can react instead of treating a no-op as success
+    // (Copilot finding A5/B-cluster on PR #331+#332).
     if (!_postgressSystem)
-        return;
+        return vigine::Result(vigine::Result::Code::Error,
+                              "DatabaseService::clearTable: postgres system not attached");
 
     std::string query = "TRUNCATE TABLE public.\"" + tableName + "\"";
 
     _postgressSystem->queryRequest(query);
+    return vigine::Result();
 }
 
-void vigine::DatabaseService::writeData(const std::string &tableName,
-                                        const std::vector<experimental::ecs::postgresql::Column> columnsData)
+vigine::Result vigine::DatabaseService::writeData(
+    const std::string &tableName,
+    const std::vector<experimental::ecs::postgresql::Column> &columnsData)
 {
+    // Same surfacing rule as clearTable: explicit error rather than
+    // silent void-return when the postgres system is unattached.
+    // Parameter changed from by-value to const-ref to avoid copying
+    // the columns vector at every call site (Copilot finding A7).
     if (!_postgressSystem)
-        return;
+        return vigine::Result(vigine::Result::Code::Error,
+                              "DatabaseService::writeData: postgres system not attached");
 
     std::string query = "INSERT INTO public.\"" + tableName + "\"  (col1, col2, col3) VALUES ('" +
                         columnsData.at(0).name() + "', '" + columnsData.at(1).name() + "', '" +
                         columnsData.at(2).name() + "')";
 
     _postgressSystem->queryRequest(query);
+    return vigine::Result();
 }
 
 vigine::ResultUPtr vigine::DatabaseService::connectToDb()

--- a/src/service/databaseservice.cpp
+++ b/src/service/databaseservice.cpp
@@ -7,6 +7,56 @@
 #endif
 
 #include <iostream>
+#include <string>
+
+#if VIGINE_POSTGRESQL
+namespace
+{
+// Minimum SQL-identifier sanitiser used while the CRUD entry points
+// continue to splice table / column names directly into the query
+// string (Copilot finding #5 on PR #342). The shipping plan replaces
+// the splice with parameterised queries (libpqxx `$1` / `quote_name`)
+// in a follow-up; until that lands, every identifier the service
+// concatenates passes through this guard so a stray quote / backslash
+// / semicolon / `--` / NUL in a caller-supplied @c Name cannot break
+// out of its quoted context.
+//
+// The engine is the only sanctioned producer of these identifiers
+// (table names live in @c Table objects the engine creates;
+// @c Column names come from @c DatabaseConfiguration the engine wires
+// up). The validator therefore acts as a defence-in-depth check, not
+// as a substitute for parameterised queries.
+//
+// Note: PostgreSQL identifiers may contain a wide range of characters
+// when properly double-quoted, but the engine convention restricts
+// them to ASCII letters, digits, underscore, and hyphen. Allowing the
+// full PostgreSQL surface here would require literal "\"" doubling
+// (per the libpqxx `quote_name` contract) — out of scope for this
+// minimal fix.
+[[nodiscard]] bool isPostgresIdentifierSafe(const std::string &identifier)
+{
+    if (identifier.empty())
+        return false;
+
+    for (const char ch : identifier)
+    {
+        // Reject control characters (NUL included), quotes, backslashes,
+        // statement terminators, and SQL line-comment prefixes.
+        if (ch == '\0' || ch == '"' || ch == '\'' || ch == '\\' ||
+            ch == ';' || ch == '/' || ch == '*')
+            return false;
+
+        if (ch < 0x20)
+            return false;
+    }
+
+    if (identifier.find("--") != std::string::npos)
+        return false;
+
+    return true;
+}
+} // namespace
+#endif
 
 vigine::DatabaseService::DatabaseService(const Name &name)
     : vigine::service::AbstractService()
@@ -74,8 +124,28 @@ vigine::experimental::ecs::postgresql::DatabaseConfiguration *vigine::DatabaseSe
 std::vector<std::vector<std::string>>
 vigine::DatabaseService::readData(const std::string &tableName) const
 {
-    std::string query = "SELECT * FROM public.\"" + tableName + "\"";
     std::vector<std::vector<std::string>> resultData;
+
+    // Defence-in-depth identifier guard (Copilot finding #5 on PR #342).
+    // The query string is currently spliced rather than parameterised;
+    // the validator rejects identifiers that could break out of the
+    // double-quoted context. The full parameterised-query refactor is
+    // tracked as a follow-up.
+    if (!isPostgresIdentifierSafe(tableName))
+    {
+        std::cerr << "DatabaseService::readData: rejected unsafe table name '"
+                  << tableName << "'\n";
+        return resultData;
+    }
+
+    // Query construction kept inline so the splice is explicit; the
+    // current implementation does not yet exercise the bound entity
+    // component (the stub returns an empty result set). The full
+    // row-fetch wiring is tracked as a follow-up — flagging the
+    // unused variable to silence the @c /WX unused-local warning
+    // until the fetch path lands.
+    std::string query = "SELECT * FROM public.\"" + tableName + "\"";
+    static_cast<void>(query);
 
     return resultData;
 }
@@ -89,10 +159,19 @@ vigine::Result vigine::DatabaseService::clearTable(const std::string &tableName)
         return vigine::Result(vigine::Result::Code::Error,
                               "DatabaseService::clearTable: postgres system not attached");
 
+    // Defence-in-depth identifier guard (Copilot finding #5 on PR #342).
+    if (!isPostgresIdentifierSafe(tableName))
+        return vigine::Result(vigine::Result::Code::Error,
+                              "DatabaseService::clearTable: rejected unsafe table name '"
+                                  + tableName + "'");
+
     std::string query = "TRUNCATE TABLE public.\"" + tableName + "\"";
 
-    _postgressSystem->queryRequest(query);
-    return vigine::Result();
+    // Post-#333: queryRequest now returns @c vigine::Result so the
+    // unbound-component / driver-error paths surface to the caller
+    // (previously the void return silently masked the failure —
+    // Copilot finding #2 on PR #342).
+    return _postgressSystem->queryRequest(query);
 }
 
 vigine::Result vigine::DatabaseService::writeData(
@@ -107,12 +186,46 @@ vigine::Result vigine::DatabaseService::writeData(
         return vigine::Result(vigine::Result::Code::Error,
                               "DatabaseService::writeData: postgres system not attached");
 
+    // Hard-coded 3-column shape currently matches the demo schema
+    // (Test/id/name/email — see CheckBDShecmeTask). The legacy code
+    // called @c columnsData.at(0..2) which throws @c std::out_of_range
+    // when fewer columns are supplied, terminating the program with a
+    // less actionable error than a Result::Code::Error (Copilot
+    // finding #4 on PR #342). Surface the precondition explicitly.
+    constexpr std::size_t kRequiredColumns = 3;
+    if (columnsData.size() < kRequiredColumns)
+        return vigine::Result(vigine::Result::Code::Error,
+                              "DatabaseService::writeData: expected at least "
+                              + std::to_string(kRequiredColumns) + " columns, got "
+                              + std::to_string(columnsData.size()));
+
+    // Defence-in-depth identifier guard (Copilot finding #5 on PR #342).
+    if (!isPostgresIdentifierSafe(tableName))
+        return vigine::Result(vigine::Result::Code::Error,
+                              "DatabaseService::writeData: rejected unsafe table name '"
+                                  + tableName + "'");
+
+    // The current splice puts @c Column::name() inside SQL string
+    // literals (`'...'`), so the same identifier guard covers the
+    // single-quote / backslash / NUL / `--` cases that would let a
+    // crafted @c Name break out of the literal. Treating it identically
+    // to identifiers is a deliberate over-restriction while the
+    // parameterised-query refactor is pending.
+    for (std::size_t i = 0; i < kRequiredColumns; ++i)
+    {
+        const std::string &columnValue = columnsData.at(i).name();
+        if (!isPostgresIdentifierSafe(columnValue))
+            return vigine::Result(vigine::Result::Code::Error,
+                                  "DatabaseService::writeData: rejected unsafe column value at index "
+                                      + std::to_string(i) + ": '" + columnValue + "'");
+    }
+
     std::string query = "INSERT INTO public.\"" + tableName + "\"  (col1, col2, col3) VALUES ('" +
                         columnsData.at(0).name() + "', '" + columnsData.at(1).name() + "', '" +
                         columnsData.at(2).name() + "')";
 
-    _postgressSystem->queryRequest(query);
-    return vigine::Result();
+    // Post-#333: queryRequest returns @c vigine::Result; propagate.
+    return _postgressSystem->queryRequest(query);
 }
 
 vigine::ResultUPtr vigine::DatabaseService::connectToDb()


### PR DESCRIPTION
Closes #333.

Picks up 14 Copilot findings — 9 from PRs #331 / #332 (post-merge follow-up) and 5 from earlier umbrella #198 review.

## PR #331 / #332 follow-ups (Group A)

- **A1** — `example/window/CMakeLists.txt`: skip-guard `if(NOT WIN32) return() endif()` moved immediately after `cmake_minimum_required(...)`, before `project(...)` and before `find_program(GLSLC_EXECUTABLE)`. Non-Windows configure now exits cleanly without invoking the project() machinery.
- **A2** — `example/window/CMakeLists.txt`: stb_image.h include path switched from `${CMAKE_SOURCE_DIR}` to `${VIGINE_ROOT_DIR}` so the resolution stays correct when Vigine is consumed via `add_subdirectory` under a parent project.
- **A3** — `graphicsservice.h`: `renderComponent()` / `textureComponent()` accessors picked up an explicit doc-contract describing the three null-state cases (system unattached, no bound entity, no component on the bound entity). Accessors retained — 27+ call sites in `example/window/` use them; the underlying `RenderSystem` does bind via `entityBound`, so the accessors are not always-null.
- **A4** — `platformservice.cpp::bindWindowEventHandler`: the catch-all "No entity or window system" message was split into three branches — window system unattached, entity null, window null — so callers no longer have to guess which arg came in null.
- **A5** — `databaseservice.cpp::clearTable`: signature changed from `void` to `vigine::Result`. Unattached postgres system now surfaces `Result::Code::Error` instead of returning silently.
- **A6** — `databaseservice.cpp::writeData`: same surfacing change as A5.
- **A7** — `databaseservice.h::writeData`: `columnsData` parameter changed from by-value to `const std::vector<...> &` to avoid copying the column vector on every call.
- **A8** — `src/context.cpp`: comment that referenced `service(ServiceId)` reworded to specify the modern type signature `vigine::service::IService::service(vigine::service::ServiceId)` and explicitly distinguish it from the legacy `service(ServiceId, Name, Property)` defined in the same file (where `ServiceId` is the deprecated `std::string` alias).
- **A9** — `postgresqlsystem.cpp::checkTablesScheme`: defensive null-check on `_boundEntityComponent` added at the top of the routine. Previously the unbound case fell through and the call dereferenced a null pointer.

## Umbrella #198 review (Group B)

- **B10** — `row.cpp::operator==`: real bug — `_columnsData == _columnsData` always returned `true`. Fixed to `_columnsData == other._columnsData`.
- **B11** — `topicid.h`, `payloadtypeid.h`: `std::hash` specialization moved out of global-scope `template <> struct std::hash<...>` form into the portable `namespace std { template <> struct hash<...> { ... }; }` form. TEMPLATE EXEMPTION marker preserved.
- **B12 / B13** — `NotRcognized` -> `NotRecognized` typo fixed in `columntype.h` (doc-comment + enum value) and walked the repo for all usages — `postgresqltypeconverter.cpp`, `postgresqlresult.cpp` updated to match.
- **B14** — `databaseservice.h`: file-level doc-comment now describes the two-tier gating chain (`VIGINE_ENABLE_EXPERIMENTAL` umbrella at the CMake level + `VIGINE_POSTGRESQL` per-translation-unit compile-time switch) instead of mentioning only `VIGINE_POSTGRESQL` in isolation.

## /WX clean-up

Configuring with `VIGINE_ENABLE_EXPERIMENTAL=ON` defines `VIGINE_POSTGRESQL` for the engine library and pulls `experimental/ecs/postgresql/impl/*.cpp` into the build at /WX. The base branch (`feature/#197-v0.1.0-readiness`) was already broken at /WX with these flags due to pre-existing C4100 / C4267 warnings from #243 (postgres tree opt-in landed before the engine started compiling those translation units under the experimental umbrella). Three minimal silencers required to actually meet the "build at /WX MUST be clean" bar:

- `row.cpp:44` — `columnIndex(const ColumnName & /*columnName*/)` (stub returning 0)
- `row.cpp:62, 73` — `static_cast<int>(i)` on the find-loop returns
- `querybuilder.cpp:213` — `[](const Data & /*data*/)` on the `is_null` lambda

## Verification (Windows / VS Insiders 18, MSVC 19.50, Ninja, /WX)

- Configure: `cmake --preset windows-debug -DENABLE_UNITTEST=ON -DBUILD_EXAMPLE_THREADED_BUS=ON -DBUILD_EXAMPLE_PARALLEL_FSM=ON -DBUILD_EXAMPLE_FANOUT_FSM=ON -DVIGINE_ENABLE_EXPERIMENTAL=ON` — clean.
- Build: 147/147 targets compiled at /WX, no warnings.
- ctest: 220/220 passed (12.20s) — including topicbus-smoke (uses std::hash spec), service-smoke, full-contract scenario_12.
- Demos: parallel-fsm 100/100, threaded-bus 800/800 (0 reentry violations), fanout-fsm 16/16.

## Architectural notes

- A3 took the documentation-contract route rather than removing `renderComponent()` / `textureComponent()` outright (the task offered REMOVE-or-CONTRACT, defaulting to REMOVE if call sites are zero or trivial). Call sites are 27+ across `example/window/{task,system}/` and the underlying `RenderSystem` does bind via the ECS `entityBound` callback, so the accessors are not actually always-null. Removal would have cascaded into every example task. Documenting the three observable null cases satisfies the spirit of the finding.
- A5 / A6 / A7 changed `void clearTable / writeData` to `vigine::Result`. `clearTable` had one caller (`removesomedatatask.cpp`); `writeData` had zero. Both updated in the same commit. Surfacing errors through the existing `Result` pattern matches the rest of the service surface.
- A9 fixes the immediate dereference. There are similar `COPILOT_TODO` markers elsewhere in `postgresqlsystem.cpp` (queryRequest, dbConfiguration, etc.); deferred — out of scope for this leaf, would broaden the surface.