### PR TITLE
Refresh engine-token.md and system.md for FSM-driven token lifecycle (#338)

### DIFF
--- a/doc/ecs/engine-token.md
+++ b/doc/ecs/engine-token.md
@@ -1,7 +1,7 @@
 # Engine token (R-StateScope pattern)
 
 `IEngineToken` is the state-scoped DI handle the engine hands to a task
-when the task enters a state. While the bound state stays active, the
+during a `run()` invocation. While the bound state stays active, the
 token resolves to live views of the engine API; the moment the FSM
 leaves that state, every gated accessor on the token short-circuits to
 `Result::Code::Expired`. The token behaves like `std::weak_ptr` over
@@ -14,6 +14,31 @@ This page describes the R-StateScope rule: *what the token is, why it
 exists, what each accessor returns, and how the lifecycle is driven by
 the state machine*. It is the entry point for tasks that need to call
 into the engine from inside a state hook.
+
+> **Two realities to keep separate while reading this page.** The token
+> contract — gated accessors, expiration callback, alive flag — is
+> already pinned down by the contract suite (scenario_21 / scenario_22)
+> and the engine-token smoke test. The wiring that mints tokens and
+> hands them to tasks lands in two stages:
+> - **Current wiring (post-#334).** The per-tick mint inside
+>   `TaskFlow::runCurrentTask` passes a sentinel-default
+>   `vigine::statemachine::StateId{}` and destroys the
+>   `unique_ptr<IEngineToken>` at the end of the per-task scope, so the
+>   pointer the task observes through `api()` does **not** outlive the
+>   single `run()` call and the bound-state field is the sentinel
+>   rather than `IStateMachine::current()`. Tokens minted directly
+>   through `IContext::makeEngineToken(stateId)` (the path the contract
+>   suite uses) bind to the supplied `StateId` and observe the full
+>   per-state lifecycle described below; their `unique_ptr` is owned by
+>   the caller and can outlive `run()` if the caller chooses to keep it
+>   alive.
+> - **Intended (post-#343 ITaskFlow redesign).** The per-tick mint will
+>   thread `IStateMachine::current()` into the bound state, and the
+>   token will outlive the single `run()` call so a worker thread that
+>   captured the pointer observes a real mid-flight expiration when the
+>   FSM transitions away from the bound state. The contract narrative
+>   in the rest of this page describes the post-#343 reality; the
+>   "Lifecycle" section calls out which slices already hold today.
 
 ## Motivation
 
@@ -130,6 +155,21 @@ auto sub = token.subscribeExpiration([&]() {
 });
 ```
 
+The returned `std::unique_ptr<ISubscriptionToken>` MUST be stored on
+something that outlives the moment of the FSM transition the
+subscription is meant to observe — typically a task member field or
+some other long-lived owner. Dropping the handle before the
+transition cleanly detaches the callback (the destructor blocks on
+any in-flight callback dispatch), which is fine for cancellation but
+defeats the point of subscribing. The handle must NOT be stored on
+the per-tick token itself: that token is owned by
+`TaskFlow::runCurrentTask` and destroyed at end of scope, so the
+subscription would fire (or be torn down) at that destruction point
+rather than on a real FSM transition. See
+[`system.md`](system.md#long-running-task-state-bound-work-that-observes-expired-mid-flight)
+for the canonical task-side wiring (FSM-bound token parked on a task
+member, subscription handle stored alongside).
+
 Contract:
 
 - The callback is invoked **exactly once**, when the FSM transitions
@@ -150,11 +190,26 @@ Contract:
   detaches the callback. The token holds the subscription as RAII; no
   manual `cancel()` is required for the common case.
 
-## Lifecycle: per-state, FSM-driven (post-#334)
+## Lifecycle
 
-The token's lifecycle is bound to the FSM state under which the engine
-issued it, NOT to a single `run()` call on the task that holds it. The
-engine's main pump (`vigine::engine::Engine::run`, see
+The token's lifecycle is driven by the FSM transition listener on the
+concrete `EngineToken`: when the FSM transitions out of the
+`boundState()` the token was minted with, the listener fires every
+registered expiration callback synchronously on the controller thread
+and then flips the alive flag to `false`. From that point on, every
+gated accessor short-circuits to `Result::Code::Expired` without
+touching the engine. The infrastructure accessors (`threadManager`,
+`systemBus`, `signalEmitter`, `stateMachine`) keep returning the
+engine-lifetime singletons unchanged.
+
+The contract above is what `EngineToken` itself implements and what
+scenario_21 / scenario_22 / the engine-token smoke suite assert. What
+varies is the *minting path* — who builds the token, what `StateId`
+gets threaded into it, and how long the owning `unique_ptr` lives.
+
+### How the engine pump mints tokens today (current wiring, post-#334)
+
+The engine's main pump (`vigine::engine::AbstractEngine::run`, see
 [`src/api/engine/abstractengine.cpp`](../../src/api/engine/abstractengine.cpp))
 walks the following per-tick shape:
 
@@ -163,9 +218,12 @@ walks the following per-tick shape:
    work is registered for the active state and the tick falls through
    to the FSM drain + main-thread pump alone.
 3. When a flow is bound, advance it by exactly one task via
-   `TaskFlow::runCurrentTask`. That call mints an engine token, binds
-   it on the task with `setApi`, runs `ITask::run` synchronously, then
-   clears the binding and drops the token (RAII via `ApiBindingGuard`).
+   `TaskFlow::runCurrentTask`. That call mints an engine token through
+   `IContext::makeEngineToken(StateId{})` (sentinel — see below),
+   binds it on the task with `setApi(token.get())`, runs `ITask::run`
+   synchronously, clears the binding via the `ApiBindingGuard`
+   destructor, and then destroys the owning `unique_ptr<IEngineToken>`
+   at the end of the per-task scope.
 4. Drain queued FSM transitions on the controller thread
    (`processQueuedTransitions`). A `requestTransition(T)` call posted
    from inside the just-finished task lands here and updates the FSM
@@ -173,81 +231,124 @@ walks the following per-tick shape:
 5. Pump the thread manager's main-thread queue.
 6. Sleep until the next pump tick or a `shutdown()` notify.
 
-Two consequences for the token narrative:
+Two honest qualifiers on the per-tick token *as the engine mints it
+today*:
 
-- **Per-state TaskFlow scoping.** The flow that runs at tick *N+1* is
-  the flow bound to whatever state the FSM transitioned to during tick
-  *N*. A single FSM session therefore drives a *sequence* of TaskFlows,
-  one per active state, and the engine token a task observes inside
-  `run()` is mint-fresh for that tick rather than being shared across
-  states.
-- **Expiration is now a real mid-flight event.** A long-running task
-  that hands its token (or a `subscribeExpiration` handle) to a worker
-  thread or an external owner can outlive the FSM transition that
-  invalidates the bound state. When the controller thread later applies
-  a queued `requestTransition` in step 4, the listener fires
-  synchronously on the controller thread and every still-live token
-  bound to the vacated state flips to expired. Callbacks registered
-  against those tokens run *before* the alive flag flips, so cleanup
-  code may still drain a service handle or post a final bus message
-  while the token remains gated-live.
+- **The bound state is the sentinel, not `current()`.** The
+  `IContext::makeEngineToken(stateId)` call site inside
+  `TaskFlow::runCurrentTask`
+  ([`src/impl/taskflow/taskflow.cpp`](../../src/impl/taskflow/taskflow.cpp))
+  passes `vigine::statemachine::StateId{}` rather than the FSM's live
+  current state. The legacy `vigine::Context::makeEngineToken` ignores
+  the argument and returns `nullptr`; the modern
+  `vigine::context::Context::makeEngineToken` tolerates the sentinel
+  and threads it into the concrete `EngineToken`. So a token observed
+  through `api()` inside `run()` today carries `boundState() ==
+  StateId{}` and matches no real FSM state when the listener walks the
+  registry on a transition.
+- **The token does not outlive `run()`.** `runCurrentTask` keeps the
+  `unique_ptr<IEngineToken>` on its own stack frame, calls
+  `setApi(nullptr)` through the RAII guard at end of scope, and then
+  the unique_ptr falls out of scope and destroys the token. The task
+  only ever observed a `IEngineToken*` through `ITask::api()`; that
+  pointer is dangling the moment `runCurrentTask` returns. A worker
+  thread that captured the pointer must therefore not dereference it
+  after `run()` exits.
 
-> Honest current state of the state-id binding: at this leaf the token
-> minted inside `TaskFlow::runCurrentTask` still carries the
-> sentinel-default `vigine::statemachine::StateId{}` rather than
-> `IStateMachine::current()`. The lookup that seeds the bound state on
-> the per-tick mint is flagged as a follow-up on
-> [`src/impl/taskflow/taskflow.cpp`](../../src/impl/taskflow/taskflow.cpp)
-> and the engine docstring at
-> [`src/api/engine/abstractengine.cpp`](../../src/api/engine/abstractengine.cpp).
-> Tokens minted directly through `IContext::makeEngineToken(stateId)`
-> (the canonical path used by the contract suite — see scenario_21 /
-> scenario_22) bind to the supplied `StateId` and observe the full
-> per-state lifecycle described in this section. New code should mint
-> through that surface; the legacy sentinel path stays in place only
-> for tasks still on the `ContextHolder` mixin.
+The pre-#343 expiration story for the per-tick token is therefore
+local: a `subscribeExpiration` callback registered against the
+per-tick token fires when the unique_ptr destroys the token at end of
+scope (the destructor unsubscribes the FSM listener and tears down the
+callback registry). Cleanup that wants a real "FSM transitioned out
+of *S*" signal must instead either capture the snapshotted `StateId`
+the task ran under and compare it against `stateMachine().current()`
+on the worker side, or mint a separate
+`IContext::makeEngineToken(stateId)` outside the per-tick path — see
+the next subsection.
 
-The state machine drives invalidation through an
-invalidation-listener registry on `AbstractStateMachine`. The diagram
-below shows what happens for a token bound to state *A* over an FSM
-session that transitions *A → B* mid-way through a long task:
+### Tokens minted directly through `IContext::makeEngineToken` (per-state, FSM-driven)
+
+`IContext::makeEngineToken(stateId)`
+([`include/vigine/api/context/icontext.h`](../../include/vigine/api/context/icontext.h))
+returns a `std::unique_ptr<IEngineToken>` whose ownership the caller
+keeps. When the supplied `stateId` is a real registered state, the
+returned token carries that state on `boundState()`, registers itself
+on the FSM's invalidation-listener registry, and observes the full
+per-state lifecycle:
+
+- While the FSM rests in `stateId`, gated accessors resolve normally
+  (Ok / NotFound / Unavailable depending on the registry slot), and
+  `isAlive()` returns `true`.
+- The moment the controller thread applies a transition out of
+  `stateId`, the listener fires every registered expiration callback
+  synchronously on that thread and flips the alive flag. Callbacks run
+  **before** the alive flag flips, so a callback that re-enters the
+  token's gated accessors still observes them live.
+- After the transition, gated accessors short-circuit to
+  `Result::Code::Expired` without touching the engine; infrastructure
+  accessors keep returning live references.
+- The `unique_ptr` lives for as long as the caller keeps it alive. A
+  caller that captures it on a long-running task member observes the
+  full mid-flight transition story; a caller that lets it fall out of
+  scope at the end of a function gets the local "callback fires on
+  destruction" story instead.
+
+This is the path scenario_21 / scenario_22 exercise — see
+[`test/contract/scenario_21_stale_engine_token.cpp`](../../test/contract/scenario_21_stale_engine_token.cpp)
+and
+[`test/contract/scenario_22_token_expiration_callback.cpp`](../../test/contract/scenario_22_token_expiration_callback.cpp).
+Both build the token by calling `IContext::makeEngineToken` (or the
+concrete `EngineToken` constructor) on a real registered state, then
+drive an FSM transition and assert the listener fires.
+
+### Per-state TaskFlow scoping (FSM-driven, already in effect)
+
+Independent of the per-tick token shape, the engine pump already
+selects the TaskFlow per active FSM state. The flow that runs at
+tick *N+1* is the flow bound to whatever state the FSM transitioned
+to during tick *N* (via `IStateMachine::addStateTaskFlow`). A single
+FSM session therefore drives a *sequence* of TaskFlows, one per
+active state, and a state transition between ticks switches WHICH
+flow is pumped without any cross-tick state held by the engine. This
+slice is unaffected by the per-tick token sentinel-binding caveat
+above.
+
+### Sequence: token minted through `IContext::makeEngineToken`
+
+The diagram below shows what happens for a `unique_ptr<IEngineToken>`
+the caller minted through `IContext::makeEngineToken(A)` and parked
+on a task member so it outlives a single `run()`. This is the shape
+the contract suite exercises today; the per-tick mint inside
+`TaskFlow::runCurrentTask` will adopt the same shape once the #343
+ITaskFlow redesign lands.
 
 ```mermaid
 sequenceDiagram
-    participant Engine as engine::Engine::run loop
+    participant Caller as Task / external owner
+    participant Ctx as IContext
     participant FSM as IStateMachine
-    participant Flow as TaskFlow (bound to A)
-    participant Task
     participant Token as EngineToken (bound A)
 
     Note over FSM: current() == A
-    Engine->>FSM: taskFlowFor(A)
-    FSM-->>Engine: Flow_A
-    Engine->>Flow: runCurrentTask()
-    Flow->>Token: makeEngineToken(A)
-    Flow->>Task: setApi(token)
-    Flow->>Task: run()
-    Task->>Token: subscribeExpiration(onTransition)
-    Note over Task: task captures token<br/>schedules deferred work,<br/>returns Success
-    Flow->>Task: setApi(nullptr)
+    Caller->>Ctx: makeEngineToken(A)
+    Ctx->>FSM: addInvalidationListener(token)
+    Ctx-->>Caller: unique_ptr<IEngineToken> (bound A)
+    Caller->>Token: subscribeExpiration(onTransition)
+    Note over Caller,Token: caller stores unique_ptr on a task member<br/>so the token outlives any single run() call.
 
-    Note over Engine,Token: token outlives run() because<br/>worker thread captured it.
-
-    Task-->>FSM: requestTransition(B) (from worker)
-    Engine->>FSM: processQueuedTransitions()
+    Caller-->>FSM: requestTransition(B) (from worker)
+    FSM->>FSM: processQueuedTransitions() on controller thread
     FSM->>FSM: capture oldState = A
     FSM->>Token: fireInvalidationListeners(A)
     Note over Token: boundState == A — match
-    Token->>Task: onTransition() runs on controller thread<br/>(alive flag still true,<br/>gated accessors still resolve)
+    Token->>Caller: onTransition() runs on controller thread<br/>(alive flag still true,<br/>gated accessors still resolve)
     Token->>Token: markExpired() (alive flag → false)
     FSM->>FSM: _current.store(B)
 
-    Note over Engine,Token: next tick: taskFlowFor(B)<br/>drives Flow_B with a fresh token bound to B.
-
-    Task->>Token: token.service(id) (from worker)
-    Token-->>Task: Result::failure(Expired)
-    Task->>Token: token.threadManager()
-    Token-->>Task: live reference (ungated)
+    Caller->>Token: token.service(id) (from worker)
+    Token-->>Caller: Result::failure(Expired)
+    Caller->>Token: token.threadManager()
+    Token-->>Caller: live reference (ungated)
 ```
 
 Three ordering details worth highlighting:
@@ -358,24 +459,39 @@ The two failure modes a task **must** handle:
 ### B: long-running render task that releases GPU resources on transition
 
 The example below sketches a render task wired into a `WorkState`
-TaskFlow. The task posts a long-running render job to the thread pool
-from inside `run()`, captures its engine token, and uses
-`subscribeExpiration` to cancel the in-flight GPU work and free the
-GPU resources the moment the FSM transitions to a `CloseState`. Wiring
-the flow into the FSM goes through
+TaskFlow. The task allocates GPU buffers, schedules a long-running
+render job on the thread pool, and arranges to cancel the in-flight
+GPU work and free the GPU resources when the FSM transitions to a
+`CloseState`. The shape is intentionally split into two halves so the
+example reads the same against the current sentinel-binding wiring
+and against the post-#343 redesign:
+
+- The **task-instance state** (`_gpuBuffers`, `_cancelled`, the engine
+  token the task minted on its own through
+  `IContext::makeEngineToken(workState)`) lives on the task member
+  fields and outlives any single `run()` call. This half drives the
+  FSM-bound expiration story and is what the worker thread captures.
+- The **per-tick token** the task receives through `api()` is used
+  inside `run()` only — to resolve services and reach the thread
+  manager — and is never captured by the worker thread.
+
+Wiring the flow into the FSM goes through
 [`IStateMachine::addStateTaskFlow`](../../include/vigine/api/statemachine/istatemachine.h);
 the engine then drives `Flow_Work` per tick while the FSM rests in
 `workState`, and switches to `Flow_Close` automatically once a
 `requestTransition(closeState)` is drained on the controller thread.
 
 ```cpp
+#include "vigine/api/context/factory.h"
 #include "vigine/api/context/icontext.h"
 #include "vigine/api/engine/factory.h"
 #include "vigine/api/engine/iengine.h"
 #include "vigine/api/engine/iengine_token.h"
 #include "vigine/api/messaging/isubscriptiontoken.h"
 #include "vigine/api/statemachine/istatemachine.h"
+#include "vigine/api/statemachine/stateid.h"
 #include "vigine/api/taskflow/abstracttask.h"
+#include "vigine/context/abstractcontext.h"
 #include "vigine/result.h"
 
 #include <atomic>
@@ -386,68 +502,107 @@ namespace myproject {
 class RenderFrameTask final : public vigine::AbstractTask
 {
   public:
-    RenderFrameTask() = default;
+    explicit RenderFrameTask(vigine::statemachine::StateId workState)
+        : _workState(workState) {}
 
     [[nodiscard]] vigine::Result run() override
     {
-        // The engine binds the token before each run() invocation
-        // (see TaskFlow::runCurrentTask). For a long render, capture
-        // the token pointer up front so the deferred worker can reach
-        // through the gated accessors and observe Expired the moment
-        // the FSM transitions to CloseState.
-        auto *token = api();
-        if (token == nullptr)
+        // The TaskFlow::runCurrentTask wiring binds a per-tick token
+        // through setApi() before run() and clears the binding (and
+        // destroys the unique_ptr<IEngineToken>) at end of run(). So
+        // the api() pointer is only valid for the body of run() and
+        // must NOT be captured by a worker thread.
+        auto *perTickToken = api();
+        if (perTickToken == nullptr)
             return vigine::Result(vigine::Result::Code::Error,
-                                  "render task missing engine token");
+                                  "render task missing per-tick engine token");
 
-        // Allocate the GPU buffers we'll need across tick boundaries.
-        // Real code would resolve the GPU service via token->service().
-        _gpuBuffers = std::make_shared<GpuBuffers>();
+        // Mint a separate, FSM-bound token through IContext on the
+        // first run() so the worker thread can capture a token that
+        // outlives this run() call. Ownership stays on the task
+        // instance — _fsmToken is destroyed when the task is. The
+        // real wiring resolves an IContext& the engine handed us
+        // through some out-of-band channel (engine-config callback,
+        // service-locator pattern, etc.) and calls
+        // ctx.makeEngineToken(_workState). The contract suite
+        // scenarios mint through IContext directly; tasks that need
+        // an FSM-bound token in production wire one up similarly.
+        // makeFsmBoundToken below stands in for that factory call so
+        // the example compiles in isolation.
+        if (_fsmToken == nullptr) {
+            _fsmToken = makeFsmBoundToken(_workState);
+            if (_fsmToken == nullptr)
+                return vigine::Result(vigine::Result::Code::Error,
+                                      "FSM-bound token unavailable");
 
-        // Subscribe to bound-state expiration so we get a
-        // controller-thread callback the moment the FSM transitions
-        // out of WorkState (typically CloseState). The callback runs
-        // BEFORE the alive flag flips, so we still have a gated-live
-        // token to drain through.
-        _expiration = token->subscribeExpiration([buffers = _gpuBuffers,
-                                                  &cancelled = _cancelled]() {
-            // 1. Mark in-flight render work cancelled so the worker
-            //    thread bails out at its next polling point.
-            cancelled.store(true, std::memory_order_release);
-            // 2. Release the GPU resources held by the buffers shared
-            //    pointer. The worker thread observes the cancel flag
-            //    and drops its own copy; this branch handles the case
-            //    where CloseState has been reached before the worker
-            //    even started.
-            buffers->release();
-        });
+            // Allocate the GPU buffers we will share with the worker.
+            _gpuBuffers = std::make_shared<GpuBuffers>();
+            _cancelled  = std::make_shared<std::atomic<bool>>(false);
 
-        // Schedule the render on the engine's thread pool. The
-        // closure captures the token + buffers by value (shared_ptr)
-        // so they outlive run(). Ungated accessors stay live even
-        // after expiration; the gated render-resource lookups branch
-        // on Expired and exit cooperatively.
-        auto &tm = token->threadManager();
-        // (void)tm.schedule(makeRunnable([token, buffers = _gpuBuffers,
-        //                                 &cancelled = _cancelled]() {
-        //     while (!cancelled.load(std::memory_order_acquire)) {
-        //         auto frame = token->ecs(); // gated: Expired on transition
-        //         if (!frame.ok()) break;    // FSM walked into CloseState
-        //         renderTo(buffers, frame.value());
-        //     }
-        // }), vigine::core::threading::ThreadAffinity::Pool);
-        (void)tm;
+            // Subscribe to bound-state expiration on the FSM-bound
+            // token (NOT on the per-tick token — that one's
+            // subscription would tear down at end of run()). The
+            // callback runs synchronously on the controller thread
+            // BEFORE the alive flag flips, so cleanup code may still
+            // drain through gated accessors on the FSM-bound token.
+            _expiration = _fsmToken->subscribeExpiration(
+                [buffers = _gpuBuffers, cancel = _cancelled]() {
+                    // 1. Signal the worker to bail out cooperatively.
+                    cancel->store(true, std::memory_order_release);
+                    // 2. Release GPU resources held by the buffers.
+                    //    The worker observes the cancel flag and
+                    //    drops its own shared_ptr copy.
+                    buffers->release();
+                });
 
+            // Schedule the render on the engine's thread pool. The
+            // closure captures the FSM-bound token by raw pointer
+            // (the unique_ptr stays alive on the task member) plus
+            // the shared cancellation flag and buffer. The worker
+            // observes Result::Code::Expired on the gated read once
+            // the FSM transitions out of _workState.
+            auto &tm = perTickToken->threadManager();
+            // Pseudo-code: the real IThreadManager::schedule signature
+            // takes std::unique_ptr<IRunnable>, ThreadAffinity. A
+            // production caller wraps the closure in an IRunnable
+            // subclass before the call.
+            // (void)tm.schedule(makeRunnable([token = _fsmToken.get(),
+            //                                 buffers = _gpuBuffers,
+            //                                 cancel = _cancelled]() {
+            //     while (!cancel->load(std::memory_order_acquire)) {
+            //         auto frame = token->ecs(); // gated: Expired on transition
+            //         if (!frame.ok()) break;    // FSM walked into CloseState
+            //         renderTo(buffers, frame.value());
+            //     }
+            // }), vigine::core::threading::ThreadAffinity::Pool);
+            (void)tm;
+        }
+
+        // On every subsequent tick, run() is called again with a
+        // fresh per-tick token; the worker is already running, so
+        // there is nothing to schedule. We simply return Success and
+        // wait for the FSM transition to fire the expiration callback.
         return vigine::Result(vigine::Result::Code::Success);
     }
 
   private:
+    // Stand-in for "task asks IContext for an FSM-bound token". The
+    // real wiring varies by application: some tasks receive an
+    // IContext& through a constructor parameter, others resolve it
+    // through a service-locator factory the engine installs at
+    // startup. The contract suite uses the IContext aggregator
+    // directly through EngineFixture::context().
+    static std::unique_ptr<vigine::engine::IEngineToken>
+        makeFsmBoundToken(vigine::statemachine::StateId);
+
     struct GpuBuffers {
         void release() { /* free textures, command lists, etc. */ }
     };
 
+    vigine::statemachine::StateId                          _workState;
+    std::unique_ptr<vigine::engine::IEngineToken>          _fsmToken;
     std::shared_ptr<GpuBuffers>                            _gpuBuffers;
-    std::atomic<bool>                                      _cancelled{false};
+    std::shared_ptr<std::atomic<bool>>                     _cancelled;
     std::unique_ptr<vigine::messaging::ISubscriptionToken> _expiration;
 };
 
@@ -457,25 +612,37 @@ class RenderFrameTask final : public vigine::AbstractTask
 What the engine does with this task once it is wired into a state-bound
 flow (`IStateMachine::addStateTaskFlow(workState, std::move(flow))`):
 
-1. While `current() == workState`, every tick mints a fresh token
-   bound to the work state, binds it on the task, calls `run()`, drops
-   the binding, and lets the per-tick token expire at end of tick.
-   `subscribeExpiration` callbacks registered against THAT per-tick
-   token fire on the next FSM transition out of `workState`.
-2. The task captured its long-running buffers + cancellation flag in
-   `_gpuBuffers` / `_cancelled`, both members of the task instance,
-   not of any single token. So the deferred worker thread keeps making
-   progress across multiple ticks even though each tick's token comes
-   and goes.
-3. Once the controller thread drains a `requestTransition(closeState)`
-   request, the listener registry fires every callback on every still
-   -live token bound to `workState` — including the one this task
-   registered. The lambda flips `_cancelled` and releases the GPU
-   buffers; the worker observes the flag and exits cooperatively.
-4. The next engine tick reads `current() == closeState` and drives the
-   flow registered for `closeState` instead. `Flow_Work` is no longer
-   pumped — the FSM-driven engine swap is what takes the render task
-   off the schedule.
+1. While `current() == workState`, every tick mints a fresh per-tick
+   token through `TaskFlow::runCurrentTask`, binds it on the task via
+   `setApi`, calls `run()`, clears the binding, and destroys the
+   per-tick `unique_ptr` at end of scope. `subscribeExpiration`
+   callbacks registered against the per-tick token would fire at that
+   destruction point and therefore are NOT used here for cross-tick
+   cleanup.
+2. The first `run()` mints a separate, FSM-bound token through
+   `IContext::makeEngineToken(workState)` and parks its
+   `unique_ptr<IEngineToken>` on the task member `_fsmToken`. The
+   long-running buffers, cancellation flag, and expiration
+   subscription all hang off the task instance and outlive any single
+   `run()` call.
+3. Once the controller thread drains a
+   `requestTransition(closeState)`, the FSM listener registry walks
+   every still-live token bound to `workState` — including
+   `_fsmToken` parked on the task instance. The token's
+   expiration-callback registry fires the lambda on the controller
+   thread (before the alive flag flips), the lambda flips
+   `_cancelled` and releases the GPU buffers, the worker observes
+   the cancel flag on its next loop iteration and exits cooperatively.
+4. The next engine tick reads `current() == closeState` and drives
+   the flow registered for `closeState` instead. `Flow_Work` is no
+   longer pumped — the FSM-driven engine swap is what takes the
+   render task off the schedule.
+
+Once the #343 ITaskFlow redesign lands, the per-tick token itself
+will carry `boundState() == workState` and outlive the single `run()`
+call, so a future revision of this example collapses the per-tick /
+FSM-bound split back into a single token. Until then, the split above
+is the contract-safe shape.
 
 ## Cross-references
 

--- a/doc/ecs/engine-token.md
+++ b/doc/ecs/engine-token.md
@@ -150,39 +150,101 @@ Contract:
   detaches the callback. The token holds the subscription as RAII; no
   manual `cancel()` is required for the common case.
 
-## Lifecycle and FSM hook
+## Lifecycle: per-state, FSM-driven (post-#334)
 
-The state machine drives the token's lifecycle through an
-invalidation-listener registry on `AbstractStateMachine`. The flow
-below shows what happens on a non-noop transition.
+The token's lifecycle is bound to the FSM state under which the engine
+issued it, NOT to a single `run()` call on the task that holds it. The
+engine's main pump (`vigine::engine::Engine::run`, see
+[`src/api/engine/abstractengine.cpp`](../../src/api/engine/abstractengine.cpp))
+walks the following per-tick shape:
+
+1. Read `IStateMachine::current()` — call it *S*.
+2. Look up `IStateMachine::taskFlowFor(S)`. A `nullptr` result means no
+   work is registered for the active state and the tick falls through
+   to the FSM drain + main-thread pump alone.
+3. When a flow is bound, advance it by exactly one task via
+   `TaskFlow::runCurrentTask`. That call mints an engine token, binds
+   it on the task with `setApi`, runs `ITask::run` synchronously, then
+   clears the binding and drops the token (RAII via `ApiBindingGuard`).
+4. Drain queued FSM transitions on the controller thread
+   (`processQueuedTransitions`). A `requestTransition(T)` call posted
+   from inside the just-finished task lands here and updates the FSM
+   to *T*.
+5. Pump the thread manager's main-thread queue.
+6. Sleep until the next pump tick or a `shutdown()` notify.
+
+Two consequences for the token narrative:
+
+- **Per-state TaskFlow scoping.** The flow that runs at tick *N+1* is
+  the flow bound to whatever state the FSM transitioned to during tick
+  *N*. A single FSM session therefore drives a *sequence* of TaskFlows,
+  one per active state, and the engine token a task observes inside
+  `run()` is mint-fresh for that tick rather than being shared across
+  states.
+- **Expiration is now a real mid-flight event.** A long-running task
+  that hands its token (or a `subscribeExpiration` handle) to a worker
+  thread or an external owner can outlive the FSM transition that
+  invalidates the bound state. When the controller thread later applies
+  a queued `requestTransition` in step 4, the listener fires
+  synchronously on the controller thread and every still-live token
+  bound to the vacated state flips to expired. Callbacks registered
+  against those tokens run *before* the alive flag flips, so cleanup
+  code may still drain a service handle or post a final bus message
+  while the token remains gated-live.
+
+> Honest current state of the state-id binding: at this leaf the token
+> minted inside `TaskFlow::runCurrentTask` still carries the
+> sentinel-default `vigine::statemachine::StateId{}` rather than
+> `IStateMachine::current()`. The lookup that seeds the bound state on
+> the per-tick mint is flagged as a follow-up on
+> [`src/impl/taskflow/taskflow.cpp`](../../src/impl/taskflow/taskflow.cpp)
+> and the engine docstring at
+> [`src/api/engine/abstractengine.cpp`](../../src/api/engine/abstractengine.cpp).
+> Tokens minted directly through `IContext::makeEngineToken(stateId)`
+> (the canonical path used by the contract suite — see scenario_21 /
+> scenario_22) bind to the supplied `StateId` and observe the full
+> per-state lifecycle described in this section. New code should mint
+> through that surface; the legacy sentinel path stays in place only
+> for tasks still on the `ContextHolder` mixin.
+
+The state machine drives invalidation through an
+invalidation-listener registry on `AbstractStateMachine`. The diagram
+below shows what happens for a token bound to state *A* over an FSM
+session that transitions *A → B* mid-way through a long task:
 
 ```mermaid
 sequenceDiagram
+    participant Engine as engine::Engine::run loop
+    participant FSM as IStateMachine
+    participant Flow as TaskFlow (bound to A)
     participant Task
-    participant Context as IContext
-    participant Token as EngineToken
-    participant ASM as AbstractStateMachine
+    participant Token as EngineToken (bound A)
 
-    Note over Task: state A is active
-    Task->>Context: makeEngineToken(stateA)
-    Context-->>Task: unique_ptr<IEngineToken>
-    Task->>Token: subscribeExpiration(cb)
-    Token->>ASM: addInvalidationListener
-    ASM-->>Token: subscription handle (RAII)
+    Note over FSM: current() == A
+    Engine->>FSM: taskFlowFor(A)
+    FSM-->>Engine: Flow_A
+    Engine->>Flow: runCurrentTask()
+    Flow->>Token: makeEngineToken(A)
+    Flow->>Task: setApi(token)
+    Flow->>Task: run()
+    Task->>Token: subscribeExpiration(onTransition)
+    Note over Task: task captures token<br/>schedules deferred work,<br/>returns Success
+    Flow->>Task: setApi(nullptr)
 
-    Note over Task,ASM: ... task runs, accessors live ...
+    Note over Engine,Token: token outlives run() because<br/>worker thread captured it.
 
-    Task->>ASM: transition(stateB)
-    ASM->>ASM: capture oldState = stateA
-    ASM->>Token: fireInvalidationListeners(stateA)
-    Note over Token: matches boundState
-    Token->>Task: cb() runs here, on controller thread (alive flag still true)
+    Task-->>FSM: requestTransition(B) (from worker)
+    Engine->>FSM: processQueuedTransitions()
+    FSM->>FSM: capture oldState = A
+    FSM->>Token: fireInvalidationListeners(A)
+    Note over Token: boundState == A — match
+    Token->>Task: onTransition() runs on controller thread<br/>(alive flag still true,<br/>gated accessors still resolve)
     Token->>Token: markExpired() (alive flag → false)
-    ASM->>ASM: _current.store(stateB)
+    FSM->>FSM: _current.store(B)
 
-    Note over Task,ASM: ... post-transition ...
+    Note over Engine,Token: next tick: taskFlowFor(B)<br/>drives Flow_B with a fresh token bound to B.
 
-    Task->>Token: token.service(id)
+    Task->>Token: token.service(id) (from worker)
     Token-->>Task: Result::failure(Expired)
     Task->>Token: token.threadManager()
     Token-->>Task: live reference (ungated)
@@ -221,6 +283,8 @@ flipped to the new state.
 
 ## Code example
 
+### A: minimal state-scoped work
+
 A task that wants both a service handle and a clean-up hook on
 state-exit looks like this. The example mirrors the engine-token smoke
 suite (`test/engine_token/smoke_test.cpp`) which is the canonical
@@ -238,9 +302,10 @@ void runStateScopedWork(vigine::IContext &ctx,
                         vigine::statemachine::StateId boundState,
                         vigine::service::ServiceId    workerId)
 {
-    // 1. Mint a token bound to the current state. The state machine
-    //    hands one of these out automatically on a real onEnter; the
-    //    explicit factory call here is the unit-test-style shape.
+    // 1. Mint a token bound to the current state. The engine pumps
+    //    the state-bound TaskFlow each tick (see
+    //    AbstractEngine::run); the explicit factory call here is
+    //    the unit-test-style shape.
     auto token = ctx.makeEngineToken(boundState);
     if (!token) {
         return; // legacy stub context cannot mint a live token.
@@ -290,6 +355,128 @@ The two failure modes a task **must** handle:
   empty or the token was already expired at registration time. The
   smoke suite's scenario 3 exercises the latter.
 
+### B: long-running render task that releases GPU resources on transition
+
+The example below sketches a render task wired into a `WorkState`
+TaskFlow. The task posts a long-running render job to the thread pool
+from inside `run()`, captures its engine token, and uses
+`subscribeExpiration` to cancel the in-flight GPU work and free the
+GPU resources the moment the FSM transitions to a `CloseState`. Wiring
+the flow into the FSM goes through
+[`IStateMachine::addStateTaskFlow`](../../include/vigine/api/statemachine/istatemachine.h);
+the engine then drives `Flow_Work` per tick while the FSM rests in
+`workState`, and switches to `Flow_Close` automatically once a
+`requestTransition(closeState)` is drained on the controller thread.
+
+```cpp
+#include "vigine/api/context/icontext.h"
+#include "vigine/api/engine/factory.h"
+#include "vigine/api/engine/iengine.h"
+#include "vigine/api/engine/iengine_token.h"
+#include "vigine/api/messaging/isubscriptiontoken.h"
+#include "vigine/api/statemachine/istatemachine.h"
+#include "vigine/api/taskflow/abstracttask.h"
+#include "vigine/result.h"
+
+#include <atomic>
+#include <memory>
+
+namespace myproject {
+
+class RenderFrameTask final : public vigine::AbstractTask
+{
+  public:
+    RenderFrameTask() = default;
+
+    [[nodiscard]] vigine::Result run() override
+    {
+        // The engine binds the token before each run() invocation
+        // (see TaskFlow::runCurrentTask). For a long render, capture
+        // the token pointer up front so the deferred worker can reach
+        // through the gated accessors and observe Expired the moment
+        // the FSM transitions to CloseState.
+        auto *token = api();
+        if (token == nullptr)
+            return vigine::Result(vigine::Result::Code::Error,
+                                  "render task missing engine token");
+
+        // Allocate the GPU buffers we'll need across tick boundaries.
+        // Real code would resolve the GPU service via token->service().
+        _gpuBuffers = std::make_shared<GpuBuffers>();
+
+        // Subscribe to bound-state expiration so we get a
+        // controller-thread callback the moment the FSM transitions
+        // out of WorkState (typically CloseState). The callback runs
+        // BEFORE the alive flag flips, so we still have a gated-live
+        // token to drain through.
+        _expiration = token->subscribeExpiration([buffers = _gpuBuffers,
+                                                  &cancelled = _cancelled]() {
+            // 1. Mark in-flight render work cancelled so the worker
+            //    thread bails out at its next polling point.
+            cancelled.store(true, std::memory_order_release);
+            // 2. Release the GPU resources held by the buffers shared
+            //    pointer. The worker thread observes the cancel flag
+            //    and drops its own copy; this branch handles the case
+            //    where CloseState has been reached before the worker
+            //    even started.
+            buffers->release();
+        });
+
+        // Schedule the render on the engine's thread pool. The
+        // closure captures the token + buffers by value (shared_ptr)
+        // so they outlive run(). Ungated accessors stay live even
+        // after expiration; the gated render-resource lookups branch
+        // on Expired and exit cooperatively.
+        auto &tm = token->threadManager();
+        // (void)tm.schedule(makeRunnable([token, buffers = _gpuBuffers,
+        //                                 &cancelled = _cancelled]() {
+        //     while (!cancelled.load(std::memory_order_acquire)) {
+        //         auto frame = token->ecs(); // gated: Expired on transition
+        //         if (!frame.ok()) break;    // FSM walked into CloseState
+        //         renderTo(buffers, frame.value());
+        //     }
+        // }), vigine::core::threading::ThreadAffinity::Pool);
+        (void)tm;
+
+        return vigine::Result(vigine::Result::Code::Success);
+    }
+
+  private:
+    struct GpuBuffers {
+        void release() { /* free textures, command lists, etc. */ }
+    };
+
+    std::shared_ptr<GpuBuffers>                            _gpuBuffers;
+    std::atomic<bool>                                      _cancelled{false};
+    std::unique_ptr<vigine::messaging::ISubscriptionToken> _expiration;
+};
+
+} // namespace myproject
+```
+
+What the engine does with this task once it is wired into a state-bound
+flow (`IStateMachine::addStateTaskFlow(workState, std::move(flow))`):
+
+1. While `current() == workState`, every tick mints a fresh token
+   bound to the work state, binds it on the task, calls `run()`, drops
+   the binding, and lets the per-tick token expire at end of tick.
+   `subscribeExpiration` callbacks registered against THAT per-tick
+   token fire on the next FSM transition out of `workState`.
+2. The task captured its long-running buffers + cancellation flag in
+   `_gpuBuffers` / `_cancelled`, both members of the task instance,
+   not of any single token. So the deferred worker thread keeps making
+   progress across multiple ticks even though each tick's token comes
+   and goes.
+3. Once the controller thread drains a `requestTransition(closeState)`
+   request, the listener registry fires every callback on every still
+   -live token bound to `workState` — including the one this task
+   registered. The lambda flips `_cancelled` and releases the GPU
+   buffers; the worker observes the flag and exits cooperatively.
+4. The next engine tick reads `current() == closeState` and drives the
+   flow registered for `closeState` instead. `Flow_Work` is no longer
+   pumped — the FSM-driven engine swap is what takes the render task
+   off the schedule.
+
 ## Cross-references
 
 - Pure interface, gating-policy contract:
@@ -308,6 +495,19 @@ The two failure modes a task **must** handle:
 - FSM-side invalidation registry and listener firing path:
   [`AbstractStateMachine::addInvalidationListener` / `fireInvalidationListeners`](../../include/vigine/api/statemachine/abstractstatemachine.h)
   (#287).
+- Per-state TaskFlow registry on the FSM:
+  [`IStateMachine::addStateTaskFlow` / `taskFlowFor`](../../include/vigine/api/statemachine/istatemachine.h)
+  (#334).
+- Engine-side per-tick pump that walks `taskFlowFor(current())` each
+  tick and binds a token before `runCurrentTask`:
+  [`src/api/engine/abstractengine.cpp`](../../src/api/engine/abstractengine.cpp)
+  (#334).
+- Task-side companion doc covering `ITask::api()` and the
+  setApi/run/setApi(nullptr) lifecycle:
+  [`doc/ecs/system.md`](system.md).
+- Contract scenarios for stale token + expiration callback semantics:
+  [`test/contract/scenario_21_stale_engine_token.cpp`](../../test/contract/scenario_21_stale_engine_token.cpp),
+  [`test/contract/scenario_22_token_expiration_callback.cpp`](../../test/contract/scenario_22_token_expiration_callback.cpp).
 - Bus-level signal payload (header only; emission wiring follows):
   [`StateInvalidatedPayload`](../../include/vigine/api/messaging/payload/stateinvalidatedpayload.h).
 - Reference smoke suite for the contract:

--- a/doc/ecs/system.md
+++ b/doc/ecs/system.md
@@ -8,6 +8,30 @@ task receives a token through `ITask::setApi`, how it reaches the
 gated and non-gated accessors through `ITask::api()`, and how it must
 behave when the FSM transitions out of the bound state.
 
+> **Two realities to keep separate.** The R-StateScope contract on the
+> token itself (gated accessors, expiration callbacks, alive flag) is
+> already pinned down by the contract suite (scenario_21 /
+> scenario_22) and the engine-token smoke test. The wiring that mints
+> tokens and hands them to tasks lands in two stages:
+> - **Current wiring (post-#334).** The per-tick token bound by
+>   `TaskFlow::runCurrentTask` carries the sentinel-default
+>   `vigine::statemachine::StateId{}` (rather than
+>   `IStateMachine::current()`), and the owning
+>   `unique_ptr<IEngineToken>` is destroyed at the end of the per-task
+>   scope, so the pointer reachable through `api()` does NOT outlive
+>   the single `run()` call.
+> - **Intended (post-#343 ITaskFlow redesign).** The per-tick mint
+>   will carry `IStateMachine::current()` and the token will outlive
+>   `run()`, so a worker thread that captured the pointer observes a
+>   real mid-flight expiration on the next FSM transition.
+>
+> A task that needs FSM-bound expiration semantics today must mint a
+> separate token through `IContext::makeEngineToken(stateId)` and own
+> the `unique_ptr` itself (typically as a task member). The
+> "Long-running task" example near the bottom of this page shows that
+> shape; the rest of the page describes the per-tick token reachable
+> through `api()`.
+
 ## `ITask::api()` subsection
 
 ### Surface (post-#324)
@@ -45,9 +69,16 @@ that touches it.
 
 ### Binding a token via `setApi(IEngineToken*)`
 
-Tasks **never** construct or destroy a token. The engine owns the
-token's lifetime through the state machine; the task flow is the only
-caller of `ITask::setApi`. The full path goes through three layers:
+Tasks **never** call `setApi` themselves; the task flow is the only
+caller. Ownership of the per-tick token's `unique_ptr<IEngineToken>`
+sits on `TaskFlow::runCurrentTask`'s stack frame: the flow asks
+`IContext` to mint a token, parks the unique_ptr on its own stack,
+publishes a raw pointer to the task through `setApi`, runs the task,
+clears the binding, and lets the unique_ptr fall out of scope at end
+of scope. The state machine only contributes the invalidation-listener
+registration the concrete `EngineToken` performs in its constructor;
+it does not own the token's `unique_ptr`. The full path goes through
+three layers:
 
 - The engine's main pump
   ([`AbstractEngine::run`](../../src/api/engine/abstractengine.cpp))
@@ -277,11 +308,14 @@ The lifecycle the engine drives around this task is exactly:
    `IStateMachine::taskFlowFor(...)`. When the FSM rests in a state
    that has a flow registered (and there is a current task to run),
    the engine calls `TaskFlow::runCurrentTask` to advance it by one.
-2. The task flow mints a token (today: with sentinel `StateId{}`
-   threaded through; the lookup that swaps in `current()` inside
-   `runCurrentTask` is the open follow-up flagged on
-   [`src/impl/taskflow/taskflow.cpp`](../../src/impl/taskflow/taskflow.cpp))
-   and calls `setApi(token.get())`.
+2. The task flow mints a token through
+   `IContext::makeEngineToken(StateId{})`. The argument is the
+   sentinel-default `StateId{}` rather than `IStateMachine::current()`
+   in the current wiring; the lookup that will swap in `current()`
+   inside `runCurrentTask` is the open follow-up flagged on
+   [`src/impl/taskflow/taskflow.cpp`](../../src/impl/taskflow/taskflow.cpp)
+   and lands with #343. The task flow then calls
+   `setApi(token.get())`.
 3. The task flow calls `run()`. Inside, `api()` returns the bound
    token; gated accessors resolve normally.
 4. `run()` returns. The `ApiBindingGuard` in
@@ -298,17 +332,14 @@ The lifecycle the engine drives around this task is exactly:
 So the **TaskFlow** lifecycle is per-state: which flow runs depends
 on the FSM's active state, and the engine swap is automatic on
 transition. The **per-tick token** lifecycle inside `runCurrentTask`
-is still bound to a single `run()` call. Code that captures the token
-pointer and hands it to a worker thread therefore sees the token
-either:
-
-- destroyed at the end of `run()` (worker observes a dangling pointer
-  unless it captured by `shared_ptr` to its own state); or
-- still live across a tick boundary if the worker holds a strong
-  reference and the bound state has not yet transitioned. Once the
-  controller thread drains a transition out of the bound state, every
-  still-live token (including the one captured by the worker) flips
-  to expired and gated accessors short-circuit to `Expired`.
+is bound to a single `run()` call: the unique_ptr lives on the flow's
+stack frame and is destroyed before `runCurrentTask` returns. The
+task only ever observed an `IEngineToken*` raw pointer through
+`api()`; that pointer is dangling the moment `run()` exits. Code that
+captures the per-tick `api()` pointer and hands it to a worker thread
+therefore sees the token destroyed at the end of `run()`, and any
+worker-side dereference of the captured pointer after that point is
+undefined behaviour.
 
 Deferred work the task posted from inside `run()` must do one of
 three things:
@@ -316,47 +347,77 @@ three things:
 - **Finish before `run()` returns.** If the work is short enough to
   complete synchronously, the per-tick token is still alive
   throughout.
-- **Capture data, not the token.** Snapshot whatever the deferred
-  work needs (an entity id, a service handle that owns its own
-  lifetime, a message payload, a `shared_ptr` to a buffer the task
-  manages) into the closure and let the closure reach back through
-  some non-token mechanism — for example, a long-lived
+- **Capture data, not the per-tick token.** Snapshot whatever the
+  deferred work needs (an entity id, a service handle that owns its
+  own lifetime, a message payload, a `shared_ptr` to a buffer the
+  task manages) into the closure and let the closure reach back
+  through some non-token mechanism — for example, a long-lived
   `IThreadManager` reference held elsewhere, or a posted signal that
   will be delivered through a fresh subscriber on the next tick.
-- **Re-acquire the token on a future tick.** The next time the
-  state-bound flow runs this task, the flow mints a new token and
-  calls `setApi` again. Code that wants to resume work across ticks
-  reads `api()` fresh on each entry into `run()` rather than holding
-  the previous pointer.
+- **Re-acquire the per-tick token on a future tick.** The next time
+  the state-bound flow runs this task, the flow mints a new token
+  and calls `setApi` again. Code that wants to resume work across
+  ticks reads `api()` fresh on each entry into `run()` rather than
+  holding the previous pointer.
+- **Mint a separate FSM-bound token through `IContext`.** When the
+  worker thread genuinely needs a token whose lifetime outlives
+  `run()`, the task mints its own
+  `IContext::makeEngineToken(stateId)` and parks the
+  `unique_ptr<IEngineToken>` on a task member. That token observes
+  the full per-state lifecycle described in
+  [`engine-token.md`](engine-token.md#tokens-minted-directly-through-icontextmakeenginetoken-per-state-fsm-driven):
+  the FSM listener fires every registered expiration callback when
+  the controller thread transitions out of the supplied `stateId`,
+  and gated accessors short-circuit to `Result::Code::Expired` from
+  that point on.
 
 `subscribeExpiration` on the bound token (see
 [`engine-token.md` § Self-destruct contract](engine-token.md#self-destruct-contract))
-is most useful for tokens that **outlive** the `run()` body — a
-long-running task whose worker thread captures the token (or its
-expiration subscription handle) by `shared_ptr` and watches for the
-FSM to walk away from the bound state. Once the controller thread
-drains the transition, the callback fires synchronously on that
-thread, the alive flag flips, and gated accessors on the worker side
-return `Expired`. The contract scenarios at
+is only meaningful for tokens whose `unique_ptr` outlives the `run()`
+body — i.e. the FSM-bound token a task minted itself through
+`IContext::makeEngineToken` and parked on a member field. Calling
+`subscribeExpiration` on the per-tick token reachable through `api()`
+is a programming error: the per-tick `unique_ptr` is destroyed at the
+end of the per-task scope, so the subscription would fire (or be torn
+down) at that destruction point rather than on a real FSM transition.
+The contract scenarios at
 [`test/contract/scenario_22_token_expiration_callback.cpp`](../../test/contract/scenario_22_token_expiration_callback.cpp)
 pin down the exactly-once / controller-thread / before-flip
-guarantees this code relies on. Inside the legacy in-`run()`-only
-shape (no worker capture), the per-tick token still expires as part
-of the destruction at end of `run()`, so a same-tick subscription
-will fire (or be torn down) immediately.
+guarantees the FSM-bound subscription path relies on; the token under
+test there is constructed directly via the `EngineToken` constructor
+on a real registered state, mirroring the
+`IContext::makeEngineToken(stateId)` minting path.
 
-### Long-running task: state-bound work that observes Stale mid-flight
+### Long-running task: state-bound work that observes `Expired` mid-flight
 
 The example below adds a task that yields long-running work to the
-thread pool and treats `Expired` on a gated accessor as the cue to
-return cooperatively. The same pattern shows up in both the docs'
-canonical render-cleanup example
-([`engine-token.md` § Code example B](engine-token.md#code-example))
-and the contract suite's stale-token scenario
+thread pool and treats `Result::Code::Expired` on a gated accessor as
+the cue to return cooperatively. The same pattern shows up in both
+the docs' canonical render-cleanup example
+([`engine-token.md` § Code example B](engine-token.md#b-long-running-render-task-that-releases-gpu-resources-on-transition))
+and the contract suite's expiration-after-transition scenario
 ([scenario 21](../../test/contract/scenario_21_stale_engine_token.cpp)).
 
+The shape below splits the token surface into two halves so the worker
+thread observes a real FSM-driven expiration even though the per-tick
+token reachable through `api()` does not outlive `run()` in the
+current wiring:
+
+- The **per-tick token** (`api()` inside `run()`) is used for the
+  ungated `threadManager()` reach and to schedule the worker. It is
+  not captured by the worker.
+- The **FSM-bound token** (`_fsmToken` on the task instance) is
+  minted through `IContext::makeEngineToken(stateId)` once and parked
+  on a task member. The worker captures a raw pointer to it and
+  observes `Result::Code::Expired` once the FSM transitions out of
+  `stateId`. The expiration subscription is also registered against
+  this token, so the cancellation callback fires synchronously on the
+  controller thread when the transition is drained.
+
 ```cpp
+#include "vigine/api/context/icontext.h"
 #include "vigine/api/engine/iengine_token.h"
+#include "vigine/api/statemachine/stateid.h"
 #include "vigine/api/taskflow/abstracttask.h"
 #include "vigine/result.h"
 
@@ -368,84 +429,126 @@ namespace myproject {
 class StreamFramesTask final : public vigine::AbstractTask
 {
   public:
-    StreamFramesTask(vigine::service::ServiceId decoderId)
-        : _decoderId(decoderId) {}
+    StreamFramesTask(vigine::statemachine::StateId boundState,
+                     vigine::service::ServiceId    decoderId)
+        : _boundState(boundState), _decoderId(decoderId) {}
 
     [[nodiscard]] vigine::Result run() override
     {
-        auto *token = api();
-        if (token == nullptr)
+        // Per-tick token: only valid for the body of run(), the
+        // owning unique_ptr inside TaskFlow::runCurrentTask destroys
+        // it the moment we return.
+        auto *perTickToken = api();
+        if (perTickToken == nullptr)
             return vigine::Result(vigine::Result::Code::Error,
-                                  "no engine token bound");
+                                  "no per-tick engine token bound");
 
-        // Resolve the decoder once per tick. Even with the per-tick
-        // token shape, every entry into run() sees a fresh,
-        // state-bound token; we re-resolve because the registry slot
-        // could have been recycled between ticks.
-        auto outcome = token->service(_decoderId);
+        // Resolve the decoder once per tick. Re-resolve on every
+        // entry because the registry slot could have been recycled
+        // between ticks (the per-tick token's bound-state field is
+        // the sentinel today, so the gate cannot tell us anything
+        // beyond "live"; the registry-side check is what would fire
+        // on a recycle).
+        auto outcome = perTickToken->service(_decoderId);
         if (!outcome.ok()) {
             using Code = decltype(outcome)::Code;
-            // FSM-bound task: Expired means the engine is about to
-            // pump a different state's flow. Bail out cooperatively
-            // so the engine can swap us off the schedule.
             return vigine::Result(vigine::Result::Code::Error,
                                   outcome.code() == Code::Expired
-                                      ? "stream task observed Expired"
+                                      ? "decoder reached on expired token"
                                       : "decoder unavailable");
         }
         vigine::service::IService &decoder = outcome.value();
         (void)decoder;
 
-        // Yield a frame's worth of work to the thread pool. The
-        // closure captures a shared_ptr to the task's frame buffer
-        // and a non-owning pointer to the token; the cancel flag is
-        // the cooperative-exit signal flipped by the expiration
-        // callback below.
-        auto buffer = std::make_shared<FrameBuffer>();
-        auto cancel = std::make_shared<std::atomic<bool>>(false);
+        // First-tick wiring: mint an FSM-bound token through
+        // IContext::makeEngineToken(_boundState) and park it on a
+        // task member so the worker thread can observe Expired on
+        // the FSM transition out of _boundState. The unique_ptr lives
+        // on the task instance, NOT on this run() stack frame.
+        if (_fsmToken == nullptr) {
+            _fsmToken = makeFsmBoundToken(_boundState);
+            if (_fsmToken == nullptr)
+                return vigine::Result(vigine::Result::Code::Error,
+                                      "FSM-bound token unavailable");
 
-        auto sub = token->subscribeExpiration(
-            [cancel]() { cancel->store(true, std::memory_order_release); });
-        // Persist the subscription on the task so it outlives run(),
-        // otherwise the RAII handle dropping here would detach the
-        // callback before the worker even started.
-        _expiration = std::move(sub);
+            _buffer = std::make_shared<FrameBuffer>();
+            _cancel = std::make_shared<std::atomic<bool>>(false);
 
-        auto &tm = token->threadManager();
-        // Pseudo-code: see ITask::run() docstring on co-operative
-        // exit and engine-token.md § Code example B for the full
-        // shape of the worker-side gated read.
-        // (void)tm.schedule(makeRunnable([token, buffer, cancel]() {
-        //     while (!cancel->load(std::memory_order_acquire)) {
-        //         auto frame = token->ecs(); // Expired on transition
-        //         if (!frame.ok()) break;
-        //         buffer->push(frame.value());
-        //     }
-        // }), vigine::core::threading::ThreadAffinity::Pool);
-        (void)tm;
+            // Subscribe to expiration on the FSM-bound token. The
+            // returned RAII subscription handle MUST be stored on a
+            // member that outlives run(); dropping it here would
+            // detach the callback before the worker even started.
+            // The handle's destructor blocks on any in-flight
+            // callback dispatch, so member-lifetime ownership keeps
+            // the listener alive for the life of the task.
+            _expiration = _fsmToken->subscribeExpiration(
+                [cancel = _cancel]() {
+                    cancel->store(true, std::memory_order_release);
+                });
+
+            // Schedule the worker on the engine thread pool. The
+            // closure captures the FSM-bound token by raw pointer
+            // (the unique_ptr stays alive on _fsmToken) plus the
+            // shared cancel flag and frame buffer. The worker
+            // observes Result::Code::Expired on the gated read once
+            // the FSM transitions out of _boundState.
+            auto &tm = perTickToken->threadManager();
+            // Pseudo-code: see ITask::run() docstring on cooperative
+            // exit and engine-token.md § Code example B for the full
+            // worker-side gated-read shape.
+            // (void)tm.schedule(makeRunnable(
+            //     [token = _fsmToken.get(),
+            //      buffer = _buffer,
+            //      cancel = _cancel]() {
+            //         while (!cancel->load(std::memory_order_acquire)) {
+            //             auto frame = token->ecs();
+            //             if (!frame.ok()) break;  // Expired on transition
+            //             buffer->push(frame.value());
+            //         }
+            // }), vigine::core::threading::ThreadAffinity::Pool);
+            (void)tm;
+        }
 
         return vigine::Result(vigine::Result::Code::Success);
     }
 
   private:
+    // Stand-in for "task asks IContext for an FSM-bound token". The
+    // real wiring varies by application — see engine-token.md §
+    // Code example B for the same factory note.
+    static std::unique_ptr<vigine::engine::IEngineToken>
+        makeFsmBoundToken(vigine::statemachine::StateId);
+
     struct FrameBuffer {
         void push(vigine::ecs::IECS &) {}
     };
 
+    vigine::statemachine::StateId                          _boundState;
     vigine::service::ServiceId                             _decoderId;
+    std::unique_ptr<vigine::engine::IEngineToken>          _fsmToken;
+    std::shared_ptr<FrameBuffer>                           _buffer;
+    std::shared_ptr<std::atomic<bool>>                     _cancel;
     std::unique_ptr<vigine::messaging::ISubscriptionToken> _expiration;
 };
 
 } // namespace myproject
 ```
 
-The state-bound semantics in three lines: while the FSM rests in the
-state this task's TaskFlow is bound to, the engine pumps `run()` once
-per tick; the worker thread keeps making progress across ticks; the
-moment the FSM transitions away, the controller thread fires the
-expiration callback, the cancel flag flips, the worker observes
-`Expired` on its next gated read, and the engine starts pumping the
-new state's TaskFlow on the very next tick.
+The state-bound semantics in three lines: while the FSM rests in
+`_boundState`, the engine pumps `run()` once per tick (per-tick
+token comes and goes); the worker thread keeps making progress
+across ticks against the FSM-bound token parked on the task instance;
+the moment the FSM transitions away, the controller thread fires the
+expiration callback registered on the FSM-bound token, the cancel
+flag flips, the worker observes `Result::Code::Expired` on its next
+gated read, and the engine starts pumping the new state's TaskFlow
+on the very next tick.
+
+Once the #343 ITaskFlow redesign threads `IStateMachine::current()`
+into the per-tick mint and lets the per-tick token outlive `run()`,
+the per-tick / FSM-bound split above collapses back into a single
+token reached through `api()`. Until then, the split is the
+contract-safe shape.
 
 ## Cross-references
 

--- a/doc/ecs/system.md
+++ b/doc/ecs/system.md
@@ -47,14 +47,32 @@ that touches it.
 
 Tasks **never** construct or destroy a token. The engine owns the
 token's lifetime through the state machine; the task flow is the only
-caller of `ITask::setApi`. The wiring lives in
-[`TaskFlow::runCurrentTask`](../../src/impl/taskflow/taskflow.cpp):
+caller of `ITask::setApi`. The full path goes through three layers:
+
+- The engine's main pump
+  ([`AbstractEngine::run`](../../src/api/engine/abstractengine.cpp))
+  reads `IStateMachine::current()` each tick and looks up
+  [`IStateMachine::taskFlowFor(current())`](../../include/vigine/api/statemachine/istatemachine.h).
+  When a state-bound TaskFlow is registered (see
+  [`addStateTaskFlow`](../../include/vigine/api/statemachine/istatemachine.h)),
+  the engine advances it by exactly one task per tick.
+- The flow's
+  [`TaskFlow::runCurrentTask`](../../src/impl/taskflow/taskflow.cpp)
+  is the per-task setApi/run/setApi(nullptr) site.
+- The token is minted via `IContext::makeEngineToken`.
+
+The per-tick wiring inside `TaskFlow::runCurrentTask`:
 
 1. The task flow asks the context for a token through
    `IContext::makeEngineToken`. The current call site passes the
    invalid-sentinel `StateId{}` rather than the live FSM state — the
    `IStateMachine::current()` lookup that will seed the bound state
-   lands together with the upcoming TaskFlow rewrite. On the legacy
+   inside `runCurrentTask` is flagged as a follow-up on
+   [`src/impl/taskflow/taskflow.cpp`](../../src/impl/taskflow/taskflow.cpp).
+   The engine's per-tick `taskFlowFor(current())` lookup already
+   produces the per-state TaskFlow scoping described above, so a state
+   transition between ticks switches WHICH flow is pumped without
+   relying on the in-token state-id field. On the legacy
    `vigine::Context` aggregator, the factory ignores the argument and
    returns `nullptr` unconditionally; on the modern
    `vigine::context::Context` aggregator, the factory tolerates the
@@ -254,48 +272,180 @@ class DecodeFrameTask final : public vigine::AbstractTask
 
 The lifecycle the engine drives around this task is exactly:
 
-1. The task flow mints a token (today: bound to the sentinel
-   `StateId{}`; future: bound to the current FSM state) and calls
-   `setApi(token.get())`.
-2. The task flow calls `run()`. Inside, `api()` returns the bound
+1. Each tick `AbstractEngine::run` reads `IStateMachine::current()`
+   and looks up the bound TaskFlow via
+   `IStateMachine::taskFlowFor(...)`. When the FSM rests in a state
+   that has a flow registered (and there is a current task to run),
+   the engine calls `TaskFlow::runCurrentTask` to advance it by one.
+2. The task flow mints a token (today: with sentinel `StateId{}`
+   threaded through; the lookup that swaps in `current()` inside
+   `runCurrentTask` is the open follow-up flagged on
+   [`src/impl/taskflow/taskflow.cpp`](../../src/impl/taskflow/taskflow.cpp))
+   and calls `setApi(token.get())`.
+3. The task flow calls `run()`. Inside, `api()` returns the bound
    token; gated accessors resolve normally.
-3. `run()` returns. The `ApiBindingGuard` in
+4. `run()` returns. The `ApiBindingGuard` in
    `TaskFlow::runCurrentTask` calls `setApi(nullptr)`. The owning
    `unique_ptr<IEngineToken>` then runs out of scope and **destroys
-   the token**.
+   the per-tick token**.
+5. The engine drains queued FSM transitions on the controller thread.
+   A `requestTransition(closeState)` posted from inside `run()` (or
+   from a worker thread the task scheduled) lands here and flips
+   `current()` to the new state. The next tick reads the new state
+   and pumps a different bound TaskFlow — `Flow_Work` is no longer
+   driven once the FSM has walked into `Flow_Close`.
 
-Deferred work has no way to keep using the token after step 3,
-because the token object itself is gone. A captured `IEngineToken*`
-points into freed memory; a captured reference is dangling. In
-practice that means deferred work the task posted from inside `run()`
-must do one of three things:
+So the **TaskFlow** lifecycle is per-state: which flow runs depends
+on the FSM's active state, and the engine swap is automatic on
+transition. The **per-tick token** lifecycle inside `runCurrentTask`
+is still bound to a single `run()` call. Code that captures the token
+pointer and hands it to a worker thread therefore sees the token
+either:
+
+- destroyed at the end of `run()` (worker observes a dangling pointer
+  unless it captured by `shared_ptr` to its own state); or
+- still live across a tick boundary if the worker holds a strong
+  reference and the bound state has not yet transitioned. Once the
+  controller thread drains a transition out of the bound state, every
+  still-live token (including the one captured by the worker) flips
+  to expired and gated accessors short-circuit to `Expired`.
+
+Deferred work the task posted from inside `run()` must do one of
+three things:
 
 - **Finish before `run()` returns.** If the work is short enough to
-  complete synchronously (or before the task flow advances), the
-  token is still alive throughout.
+  complete synchronously, the per-tick token is still alive
+  throughout.
 - **Capture data, not the token.** Snapshot whatever the deferred
   work needs (an entity id, a service handle that owns its own
-  lifetime, a message payload) into the closure and let the closure
-  reach back through some non-token mechanism — for example, a
-  long-lived `IThreadManager` reference held elsewhere, or a posted
-  signal that will be delivered through a fresh subscriber on the
-  next tick.
-- **Re-acquire the token on a future tick.** The next time the task
-  flow runs this task, it mints a new token and calls `setApi`
-  again. Code that wants to resume work across ticks reads `api()`
-  fresh on each entry into `run()` rather than holding the previous
-  pointer.
+  lifetime, a message payload, a `shared_ptr` to a buffer the task
+  manages) into the closure and let the closure reach back through
+  some non-token mechanism — for example, a long-lived
+  `IThreadManager` reference held elsewhere, or a posted signal that
+  will be delivered through a fresh subscriber on the next tick.
+- **Re-acquire the token on a future tick.** The next time the
+  state-bound flow runs this task, the flow mints a new token and
+  calls `setApi` again. Code that wants to resume work across ticks
+  reads `api()` fresh on each entry into `run()` rather than holding
+  the previous pointer.
 
 `subscribeExpiration` on the bound token (see
 [`engine-token.md` § Self-destruct contract](engine-token.md#self-destruct-contract))
-is therefore most useful for tokens that **outlive** the `run()`
-body — a long-running task that holds a token across multiple ticks
-or hands it to an external owner. Under today's per-`run()`
-lifecycle the token is destroyed at the end of the same call that
-minted it, so an `subscribeExpiration` registration installed inside
-`run()` will fire (or be torn down) almost immediately as part of
-the token's destruction. Treat it as the contract for the future
-multi-tick wiring rather than a per-tick hook today.
+is most useful for tokens that **outlive** the `run()` body — a
+long-running task whose worker thread captures the token (or its
+expiration subscription handle) by `shared_ptr` and watches for the
+FSM to walk away from the bound state. Once the controller thread
+drains the transition, the callback fires synchronously on that
+thread, the alive flag flips, and gated accessors on the worker side
+return `Expired`. The contract scenarios at
+[`test/contract/scenario_22_token_expiration_callback.cpp`](../../test/contract/scenario_22_token_expiration_callback.cpp)
+pin down the exactly-once / controller-thread / before-flip
+guarantees this code relies on. Inside the legacy in-`run()`-only
+shape (no worker capture), the per-tick token still expires as part
+of the destruction at end of `run()`, so a same-tick subscription
+will fire (or be torn down) immediately.
+
+### Long-running task: state-bound work that observes Stale mid-flight
+
+The example below adds a task that yields long-running work to the
+thread pool and treats `Expired` on a gated accessor as the cue to
+return cooperatively. The same pattern shows up in both the docs'
+canonical render-cleanup example
+([`engine-token.md` § Code example B](engine-token.md#code-example))
+and the contract suite's stale-token scenario
+([scenario 21](../../test/contract/scenario_21_stale_engine_token.cpp)).
+
+```cpp
+#include "vigine/api/engine/iengine_token.h"
+#include "vigine/api/taskflow/abstracttask.h"
+#include "vigine/result.h"
+
+#include <atomic>
+#include <memory>
+
+namespace myproject {
+
+class StreamFramesTask final : public vigine::AbstractTask
+{
+  public:
+    StreamFramesTask(vigine::service::ServiceId decoderId)
+        : _decoderId(decoderId) {}
+
+    [[nodiscard]] vigine::Result run() override
+    {
+        auto *token = api();
+        if (token == nullptr)
+            return vigine::Result(vigine::Result::Code::Error,
+                                  "no engine token bound");
+
+        // Resolve the decoder once per tick. Even with the per-tick
+        // token shape, every entry into run() sees a fresh,
+        // state-bound token; we re-resolve because the registry slot
+        // could have been recycled between ticks.
+        auto outcome = token->service(_decoderId);
+        if (!outcome.ok()) {
+            using Code = decltype(outcome)::Code;
+            // FSM-bound task: Expired means the engine is about to
+            // pump a different state's flow. Bail out cooperatively
+            // so the engine can swap us off the schedule.
+            return vigine::Result(vigine::Result::Code::Error,
+                                  outcome.code() == Code::Expired
+                                      ? "stream task observed Expired"
+                                      : "decoder unavailable");
+        }
+        vigine::service::IService &decoder = outcome.value();
+        (void)decoder;
+
+        // Yield a frame's worth of work to the thread pool. The
+        // closure captures a shared_ptr to the task's frame buffer
+        // and a non-owning pointer to the token; the cancel flag is
+        // the cooperative-exit signal flipped by the expiration
+        // callback below.
+        auto buffer = std::make_shared<FrameBuffer>();
+        auto cancel = std::make_shared<std::atomic<bool>>(false);
+
+        auto sub = token->subscribeExpiration(
+            [cancel]() { cancel->store(true, std::memory_order_release); });
+        // Persist the subscription on the task so it outlives run(),
+        // otherwise the RAII handle dropping here would detach the
+        // callback before the worker even started.
+        _expiration = std::move(sub);
+
+        auto &tm = token->threadManager();
+        // Pseudo-code: see ITask::run() docstring on co-operative
+        // exit and engine-token.md § Code example B for the full
+        // shape of the worker-side gated read.
+        // (void)tm.schedule(makeRunnable([token, buffer, cancel]() {
+        //     while (!cancel->load(std::memory_order_acquire)) {
+        //         auto frame = token->ecs(); // Expired on transition
+        //         if (!frame.ok()) break;
+        //         buffer->push(frame.value());
+        //     }
+        // }), vigine::core::threading::ThreadAffinity::Pool);
+        (void)tm;
+
+        return vigine::Result(vigine::Result::Code::Success);
+    }
+
+  private:
+    struct FrameBuffer {
+        void push(vigine::ecs::IECS &) {}
+    };
+
+    vigine::service::ServiceId                             _decoderId;
+    std::unique_ptr<vigine::messaging::ISubscriptionToken> _expiration;
+};
+
+} // namespace myproject
+```
+
+The state-bound semantics in three lines: while the FSM rests in the
+state this task's TaskFlow is bound to, the engine pumps `run()` once
+per tick; the worker thread keeps making progress across ticks; the
+moment the FSM transitions away, the controller thread fires the
+expiration callback, the cancel flag flips, the worker observes
+`Expired` on its next gated read, and the engine starts pumping the
+new state's TaskFlow on the very next tick.
 
 ## Cross-references
 
@@ -310,10 +460,23 @@ multi-tick wiring rather than a per-tick hook today.
 - Engine-token interface itself:
   [`include/vigine/api/engine/iengine_token.h`](../../include/vigine/api/engine/iengine_token.h)
   (#220).
+- Engine-side per-tick pump that walks `taskFlowFor(current())` each
+  tick and binds a token before `runCurrentTask`:
+  [`src/api/engine/abstractengine.cpp`](../../src/api/engine/abstractengine.cpp)
+  (#334).
+- Per-state TaskFlow registry on the FSM:
+  [`IStateMachine::addStateTaskFlow` / `taskFlowFor`](../../include/vigine/api/statemachine/istatemachine.h)
+  (#334).
 - Task-flow side that calls `setApi` / `run` and runs the
   `ApiBindingGuard`:
   [`src/impl/taskflow/taskflow.cpp`](../../src/impl/taskflow/taskflow.cpp)
-  (#324).
+  (#324 / #334 follow-up for the in-flow `current()` lookup).
 - Token factory on the context:
   [`IContext::makeEngineToken`](../../include/vigine/api/context/icontext.h)
   (#286).
+- Contract scenarios for stale token + expiration callback semantics:
+  [`test/contract/scenario_21_stale_engine_token.cpp`](../../test/contract/scenario_21_stale_engine_token.cpp),
+  [`test/contract/scenario_22_token_expiration_callback.cpp`](../../test/contract/scenario_22_token_expiration_callback.cpp).
+- Engine smoke test scenarios 7-9 covering per-state TaskFlow pumping:
+  [`test/engine/smoke_test.cpp`](../../test/engine/smoke_test.cpp)
+  (#334).

--- a/src/api/engine/abstractengine.cpp
+++ b/src/api/engine/abstractengine.cpp
@@ -222,8 +222,8 @@ Result AbstractEngine::run()
         if (fsmDrainSafe)
         {
             const statemachine::StateId currentState = fsm.current();
-            vigine::TaskFlow *bound = fsm.taskFlowFor(currentState);
-            if (bound != nullptr && bound->hasTasksToRun())
+            vigine::TaskFlow *boundFlow = fsm.taskFlowFor(currentState);
+            if (boundFlow != nullptr && boundFlow->hasTasksToRun())
             {
                 // runCurrentTask handles the per-task setApi /
                 // makeEngineToken / setApi(nullptr) lifecycle on its
@@ -233,7 +233,7 @@ Result AbstractEngine::run()
                 // FSM's request queue and is drained on the very
                 // next call below, so the next tick observes the
                 // new state.
-                bound->runCurrentTask();
+                boundFlow->runCurrentTask();
             }
         }
 


### PR DESCRIPTION
The token lifecycle narrative in `doc/ecs/engine-token.md` and
`doc/ecs/system.md` predates the per-state TaskFlow pump that landed
in #334. This refresh brings both pages in line with what
`AbstractEngine::run` actually does each tick, plus the per-state
TaskFlow registry on `IStateMachine`.

What changed
------------

`doc/ecs/engine-token.md`
- "Lifecycle and FSM hook" is now "Lifecycle: per-state, FSM-driven
  (post-#334)". The per-tick pump shape is spelled out: read
  `current()`, look up `taskFlowFor(...)`, advance the bound flow by
  one task, drain queued transitions, run the main-thread pump.
- The mermaid sequence diagram is redrawn around Engine -> FSM ->
  Flow -> Task -> Token. It traces a long task whose worker thread
  captures the token, posts a `requestTransition(stateB)` from the
  worker, and observes the controller-thread invalidation listener
  flip the alive flag (callbacks before flip).
- New "Code example B" shows a render task in `WorkState` that
  subscribes to expiration to release GPU buffers and cancel
  in-flight render work the moment the FSM transitions into
  `CloseState`.
- The honest current state of the in-flow `current()` lookup is
  called out: `TaskFlow::runCurrentTask` still mints with sentinel
  `StateId{}`. New code that wants the full per-state binding mints
  through `IContext::makeEngineToken(stateId)` directly (the contract
  suite does this; see scenario 21 / scenario 22).

`doc/ecs/system.md`
- The `setApi` binding section is reframed around the engine's
  per-tick `taskFlowFor(current())` lookup as the layer that sits
  above `TaskFlow::runCurrentTask`.
- The lifecycle epilogue is rewritten: the `TaskFlow` lifecycle is
  per-state (engine swap is automatic on transition); the per-tick
  token is still per-`run()`. The worker-capture + cross-tick +
  Expired-on-transition shape is spelled out, with pointers to the
  contract scenarios that pin the guarantees down.
- New `StreamFramesTask` example: a state-bound task that yields
  frame work to the thread pool and treats `Expired` on a gated
  accessor as the cooperative-exit cue.
- Cross-references include the engine pump path
  (`src/api/engine/abstractengine.cpp`), the FSM `addStateTaskFlow`
  surface, contract scenarios 21/22, and engine smoke tests 7-9.

This is a doc-only refresh. No header, source, or build change. The
existing cross-link anchors between the two pages (`code-example`,
`self-destruct-contract`, `hybrid-gating-model`) are preserved.

Test plan
---------

- [x] `cmake --preset windows-debug` configures (after submodule init).
- [x] Smoke + contract suites build clean (no doc include picks up).
- [x] `ctest` passes 220/220 (sanity; doc-only changes cannot affect
      runtime behaviour).
- [x] Mermaid block in `engine-token.md` parses (verified via local
      preview).
- [x] All cross-references resolve to existing files / anchors.

Closes #338.