### PR TITLE
Replace deprecated volatile loop in scenario_15 (#344)

### DIFF
--- a/test/contract/scenario_15_subscriber_serialization.cpp
+++ b/test/contract/scenario_15_subscriber_serialization.cpp
@@ -88,10 +88,12 @@ class SerialisationSubscriber final : public vigine::messaging::ISubscriber
         }
         // A small spin keeps the entry window wide enough that a racing
         // dispatcher would actually observe the in-flight state, without
-        // adding a real sleep that would slow the test down.
-        for (volatile int i = 0; i < 32; ++i)
+        // adding a real sleep that would slow the test down. The atomic
+        // counter prevents the optimiser from collapsing the loop.
+        std::atomic<int> spin{0};
+        for (int i = 0; i < 32; ++i)
         {
-            (void)i;
+            spin.fetch_add(1, std::memory_order_relaxed);
         }
         _hits.fetch_add(1, std::memory_order_acq_rel);
         _inFlight.fetch_sub(1, std::memory_order_acq_rel);


### PR DESCRIPTION
The contract test `scenario_15_subscriber_serialization.cpp` keeps a deliberate spin loop inside `SerialisationSubscriber::onMessage` so a racing dispatcher has time to observe the in-flight state and trip the reentry probe. The loop counter was a `volatile int`, which compiles cleanly under MSVC but trips `-Wdeprecated-volatile` on Clang and GCC starting at C++20. The new cross-platform CI matrix runs Clang/GCC with `-Wall -Wextra -Werror`, which would block this file from compiling.

Replace the volatile counter with a stack-local `std::atomic<int>` updated using `memory_order_relaxed`. The atomic is a real observable side-effect, so the optimiser must keep all 32 iterations -- the entry window stays the same length. The atomic carries no synchronisation order beyond itself, so the per-slot `deliverMutex` contract this scenario pins is unaffected.

Local verification:

- Clang 18 build with `-Wall -Wextra -Wpedantic -Werror -Wdeprecated-volatile`: clean.
- `ctest`: 223/223 pass, including `SubscriberSerialization.ConcurrentPublishersNeverReenterOnMessage` (8 publishers x 100 messages, zero reentry violations).

Single-file change. The `test/CMakeLists.txt` is left alone -- the sibling cleanup ticket owns that file.

Closes #344
