### PR TITLE
Redesign modern ITaskFlow with callable-attachment for IStateMachine (#343)

### DIFF
--- a/example/experimental/postgres_demo/main.cpp
+++ b/example/experimental/postgres_demo/main.cpp
@@ -37,7 +37,10 @@
 #include <vigine/api/engine/iengine.h>
 #include <vigine/api/statemachine/istatemachine.h>
 #include <vigine/api/statemachine/stateid.h>
-#include <vigine/impl/taskflow/taskflow.h>
+#include <vigine/api/taskflow/factory.h>
+#include <vigine/api/taskflow/itaskflow.h>
+#include <vigine/api/taskflow/resultcode.h>
+#include <vigine/api/taskflow/taskid.h>
 #include <vigine/result.h>
 #include <vigine/service/databaseservice.h>
 
@@ -59,13 +62,16 @@ namespace
 // the error state (or, in the close phase, asks the engine to shut
 // down).
 
-std::unique_ptr<vigine::TaskFlow> buildInitFlow(
-    vigine::DatabaseService                *dbService,
-    vigine::statemachine::IStateMachine    *stateMachine,
-    vigine::statemachine::StateId           workState,
-    vigine::statemachine::StateId           errorState)
+std::unique_ptr<vigine::taskflow::ITaskFlow> buildInitFlow(
+    vigine::DatabaseService             *dbService,
+    vigine::statemachine::IStateMachine *stateMachine,
+    vigine::statemachine::StateId        workState,
+    vigine::statemachine::StateId        errorState)
 {
-    auto flow = std::make_unique<vigine::TaskFlow>();
+    using vigine::taskflow::ResultCode;
+    using vigine::taskflow::TaskId;
+
+    auto flow = vigine::taskflow::createTaskFlow();
 
     auto initBd        = std::make_unique<InitBDTask>();
     initBd->setDatabaseService(dbService);
@@ -74,27 +80,35 @@ std::unique_ptr<vigine::TaskFlow> buildInitFlow(
     auto toWork        = std::make_unique<TransitionTask>(stateMachine, workState);
     auto toError       = std::make_unique<TransitionTask>(stateMachine, errorState);
 
-    auto *initBdRaw     = flow->addTask(std::move(initBd));
-    auto *checkSchemaRaw = flow->addTask(std::move(checkSchema));
-    auto *toWorkRaw      = flow->addTask(std::move(toWork));
-    auto *toErrorRaw     = flow->addTask(std::move(toError));
+    const TaskId initBdId      = flow->addTask();
+    const TaskId checkSchemaId = flow->addTask();
+    const TaskId toWorkId      = flow->addTask();
+    const TaskId toErrorId     = flow->addTask();
 
-    static_cast<void>(flow->route(initBdRaw,     checkSchemaRaw, vigine::Result::Code::Success));
-    static_cast<void>(flow->route(initBdRaw,     toErrorRaw,     vigine::Result::Code::Error));
-    static_cast<void>(flow->route(checkSchemaRaw, toWorkRaw,     vigine::Result::Code::Success));
-    static_cast<void>(flow->route(checkSchemaRaw, toErrorRaw,    vigine::Result::Code::Error));
+    static_cast<void>(flow->attachTaskRun(initBdId, std::move(initBd)));
+    static_cast<void>(flow->attachTaskRun(checkSchemaId, std::move(checkSchema)));
+    static_cast<void>(flow->attachTaskRun(toWorkId, std::move(toWork)));
+    static_cast<void>(flow->attachTaskRun(toErrorId, std::move(toError)));
 
-    flow->changeCurrentTaskTo(initBdRaw);
+    static_cast<void>(flow->onResult(initBdId,      ResultCode::Success, checkSchemaId));
+    static_cast<void>(flow->onResult(initBdId,      ResultCode::Error,   toErrorId));
+    static_cast<void>(flow->onResult(checkSchemaId, ResultCode::Success, toWorkId));
+    static_cast<void>(flow->onResult(checkSchemaId, ResultCode::Error,   toErrorId));
+
+    static_cast<void>(flow->enqueue(initBdId));
     return flow;
 }
 
-std::unique_ptr<vigine::TaskFlow> buildWorkFlow(
-    vigine::DatabaseService                *dbService,
-    vigine::statemachine::IStateMachine    *stateMachine,
-    vigine::statemachine::StateId           closeState,
-    vigine::statemachine::StateId           errorState)
+std::unique_ptr<vigine::taskflow::ITaskFlow> buildWorkFlow(
+    vigine::DatabaseService             *dbService,
+    vigine::statemachine::IStateMachine *stateMachine,
+    vigine::statemachine::StateId        closeState,
+    vigine::statemachine::StateId        errorState)
 {
-    auto flow = std::make_unique<vigine::TaskFlow>();
+    using vigine::taskflow::ResultCode;
+    using vigine::taskflow::TaskId;
+
+    auto flow = vigine::taskflow::createTaskFlow();
 
     auto addData    = std::make_unique<AddSomeDataTask>();
     addData->setDatabaseService(dbService);
@@ -105,48 +119,56 @@ std::unique_ptr<vigine::TaskFlow> buildWorkFlow(
     auto toClose    = std::make_unique<TransitionTask>(stateMachine, closeState);
     auto toError    = std::make_unique<TransitionTask>(stateMachine, errorState);
 
-    auto *addRaw     = flow->addTask(std::move(addData));
-    auto *readRaw    = flow->addTask(std::move(readData));
-    auto *removeRaw  = flow->addTask(std::move(removeData));
-    auto *closeRaw   = flow->addTask(std::move(toClose));
-    auto *errorRaw   = flow->addTask(std::move(toError));
+    const TaskId addId    = flow->addTask();
+    const TaskId readId   = flow->addTask();
+    const TaskId removeId = flow->addTask();
+    const TaskId closeId  = flow->addTask();
+    const TaskId errorId  = flow->addTask();
 
-    static_cast<void>(flow->route(addRaw,    readRaw,   vigine::Result::Code::Success));
-    static_cast<void>(flow->route(addRaw,    errorRaw,  vigine::Result::Code::Error));
-    static_cast<void>(flow->route(readRaw,   removeRaw, vigine::Result::Code::Success));
-    static_cast<void>(flow->route(readRaw,   errorRaw,  vigine::Result::Code::Error));
-    static_cast<void>(flow->route(removeRaw, closeRaw,  vigine::Result::Code::Success));
-    static_cast<void>(flow->route(removeRaw, errorRaw,  vigine::Result::Code::Error));
+    static_cast<void>(flow->attachTaskRun(addId,    std::move(addData)));
+    static_cast<void>(flow->attachTaskRun(readId,   std::move(readData)));
+    static_cast<void>(flow->attachTaskRun(removeId, std::move(removeData)));
+    static_cast<void>(flow->attachTaskRun(closeId,  std::move(toClose)));
+    static_cast<void>(flow->attachTaskRun(errorId,  std::move(toError)));
 
-    flow->changeCurrentTaskTo(addRaw);
+    static_cast<void>(flow->onResult(addId,    ResultCode::Success, readId));
+    static_cast<void>(flow->onResult(addId,    ResultCode::Error,   errorId));
+    static_cast<void>(flow->onResult(readId,   ResultCode::Success, removeId));
+    static_cast<void>(flow->onResult(readId,   ResultCode::Error,   errorId));
+    static_cast<void>(flow->onResult(removeId, ResultCode::Success, closeId));
+    static_cast<void>(flow->onResult(removeId, ResultCode::Error,   errorId));
+
+    static_cast<void>(flow->enqueue(addId));
     return flow;
 }
 
-std::unique_ptr<vigine::TaskFlow> buildErrorFlow(
+std::unique_ptr<vigine::taskflow::ITaskFlow> buildErrorFlow(
     vigine::statemachine::IStateMachine *stateMachine,
     vigine::statemachine::StateId        closeState)
 {
-    auto flow = std::make_unique<vigine::TaskFlow>();
+    auto flow = vigine::taskflow::createTaskFlow();
 
     // Error phase prints the reached-error notice and falls through to
     // close so the engine can shut down cleanly. No domain work runs
     // in this state.
-    auto toClose       = std::make_unique<TransitionTask>(stateMachine, closeState);
-    auto *toCloseRaw   = flow->addTask(std::move(toClose));
-    flow->changeCurrentTaskTo(toCloseRaw);
+    auto toClose = std::make_unique<TransitionTask>(stateMachine, closeState);
+    const vigine::taskflow::TaskId toCloseId = flow->addTask();
+    static_cast<void>(flow->attachTaskRun(toCloseId, std::move(toClose)));
+    static_cast<void>(flow->enqueue(toCloseId));
     return flow;
 }
 
-std::unique_ptr<vigine::TaskFlow> buildCloseFlow(vigine::engine::IEngine *engine)
+std::unique_ptr<vigine::taskflow::ITaskFlow> buildCloseFlow(vigine::engine::IEngine *engine)
 {
-    auto flow = std::make_unique<vigine::TaskFlow>();
+    auto flow = vigine::taskflow::createTaskFlow();
 
     // Close phase asks the engine to stop the main loop. The
     // ShutdownTask returns Success, the flow has no further routes
     // out of it, and Engine::run() exits on the next pump tick.
-    auto shutdown      = std::make_unique<ShutdownTask>(engine);
-    auto *shutdownRaw  = flow->addTask(std::move(shutdown));
-    flow->changeCurrentTaskTo(shutdownRaw);
+    auto shutdown = std::make_unique<ShutdownTask>(engine);
+    const vigine::taskflow::TaskId shutdownId = flow->addTask();
+    static_cast<void>(flow->attachTaskRun(shutdownId, std::move(shutdown)));
+    static_cast<void>(flow->enqueue(shutdownId));
     return flow;
 }
 

--- a/example/window/main.cpp
+++ b/example/window/main.cpp
@@ -39,12 +39,21 @@
 #include <vigine/api/engine/iengine.h>
 #include <vigine/api/context/icontext.h>
 #include <vigine/api/messaging/factory.h>
+#include <vigine/api/messaging/isignalemitter.h>
+#include <vigine/api/messaging/isubscriber.h>
+#include <vigine/api/messaging/isubscriptiontoken.h>
+#include <vigine/api/messaging/messagefilter.h>
+#include <vigine/api/messaging/messagekind.h>
 #include <vigine/api/messaging/payload/factory.h>
 #include <vigine/api/messaging/payload/ipayloadregistry.h>
 #include <vigine/api/messaging/payload/payloadtypeid.h>
 #include <vigine/api/service/serviceid.h>
 #include <vigine/api/statemachine/istatemachine.h>
 #include <vigine/api/statemachine/stateid.h>
+#include <vigine/api/taskflow/factory.h>
+#include <vigine/api/taskflow/itaskflow.h>
+#include <vigine/api/taskflow/resultcode.h>
+#include <vigine/api/taskflow/taskid.h>
 #include <vigine/core/threading/ithreadmanager.h>
 #include <vigine/core/threading/threadaffinity.h>
 #include <vigine/impl/ecs/entitymanager.h>
@@ -53,7 +62,7 @@
 #include <vigine/impl/ecs/platform/platformservice.h>
 #include <vigine/impl/ecs/platform/windowsystem.h>
 #include <vigine/impl/messaging/signalemitter.h>
-#include <vigine/impl/taskflow/taskflow.h>
+#include <vigine/result.h>
 
 #include "system/texteditorsystem.h"
 #include "task/vulkan/initvulkantask.h"
@@ -72,9 +81,14 @@
 #include <iostream>
 #include <memory>
 #include <utility>
+#include <vector>
 
 namespace
 {
+
+using SubscriptionTokenList =
+    std::vector<std::unique_ptr<vigine::messaging::ISubscriptionToken>>;
+
 struct InitFlowDeps
 {
     vigine::EntityManager *entityManager{nullptr};
@@ -84,53 +98,55 @@ struct InitFlowDeps
     vigine::messaging::ISignalEmitter *signalEmitter{nullptr};
     std::shared_ptr<TextEditState> textEditState{};
     std::shared_ptr<TextEditorSystem> textEditorSystem{};
+    // Sink for the input-signal subscription tokens so they outlive the
+    // flow itself. The flow's runnable registry holds the subscriber
+    // (ProcessInputEventTask) by unique_ptr; the token must be released
+    // before the subscriber is destroyed, which the engine guarantees
+    // by tearing the FSM (and with it the flow) down before the host
+    // drops these tokens at scope exit in main().
+    SubscriptionTokenList *signalSubscriptions{nullptr};
 };
 
-std::unique_ptr<vigine::TaskFlow> createInitTaskFlow(const InitFlowDeps &deps)
+std::unique_ptr<vigine::taskflow::ITaskFlow> createInitTaskFlow(const InitFlowDeps &deps)
 {
-    auto taskFlow             = std::make_unique<vigine::TaskFlow>();
+    using vigine::taskflow::ResultCode;
+    using vigine::taskflow::TaskId;
+
+    auto taskFlow = vigine::taskflow::createTaskFlow();
 
     auto initWindowOwned      = std::make_unique<InitWindowTask>();
     initWindowOwned->setEntityManager(deps.entityManager);
     initWindowOwned->setPlatformServiceId(deps.platformServiceId);
-    auto *initWindow          = taskFlow->addTask(std::move(initWindowOwned));
 
     auto initVulkanOwned      = std::make_unique<InitVulkanTask>();
     initVulkanOwned->setEntityManager(deps.entityManager);
     initVulkanOwned->setPlatformServiceId(deps.platformServiceId);
     initVulkanOwned->setGraphicsServiceId(deps.graphicsServiceId);
-    auto *initVulkan          = taskFlow->addTask(std::move(initVulkanOwned));
 
     auto setupHelperOwned     = std::make_unique<SetupHelperGeometryTask>();
     setupHelperOwned->setEntityManager(deps.entityManager);
     setupHelperOwned->setGraphicsServiceId(deps.graphicsServiceId);
-    auto *setupHelperGeometry = taskFlow->addTask(std::move(setupHelperOwned));
 
     auto setupCubeOwned       = std::make_unique<SetupCubeTask>();
     setupCubeOwned->setEntityManager(deps.entityManager);
     setupCubeOwned->setGraphicsServiceId(deps.graphicsServiceId);
-    auto *setupCube           = taskFlow->addTask(std::move(setupCubeOwned));
 
     auto setupTextOwned       = std::make_unique<SetupTextTask>();
     setupTextOwned->setEntityManager(deps.entityManager);
     setupTextOwned->setGraphicsServiceId(deps.graphicsServiceId);
-    auto *setupText           = taskFlow->addTask(std::move(setupTextOwned));
 
     auto loadTexturesOwned    = std::make_unique<LoadTexturesTask>();
     loadTexturesOwned->setEntityManager(deps.entityManager);
     loadTexturesOwned->setGraphicsServiceId(deps.graphicsServiceId);
-    auto *loadTextures        = taskFlow->addTask(std::move(loadTexturesOwned));
 
     auto setupPlanesOwned     = std::make_unique<SetupTexturedPlanesTask>();
     setupPlanesOwned->setEntityManager(deps.entityManager);
     setupPlanesOwned->setGraphicsServiceId(deps.graphicsServiceId);
-    auto *setupTexturedPlanes = taskFlow->addTask(std::move(setupPlanesOwned));
 
     auto setupTextEditOwned   = std::make_unique<SetupTextEditTask>(
         deps.textEditState, deps.textEditorSystem);
     setupTextEditOwned->setEntityManager(deps.entityManager);
     setupTextEditOwned->setGraphicsServiceId(deps.graphicsServiceId);
-    auto *setupTextEdit       = taskFlow->addTask(std::move(setupTextEditOwned));
 
     auto runWindowOwned       = std::make_unique<RunWindowTask>();
     runWindowOwned->setEntityManager(deps.entityManager);
@@ -139,57 +155,104 @@ std::unique_ptr<vigine::TaskFlow> createInitTaskFlow(const InitFlowDeps &deps)
     runWindowOwned->setEngine(deps.engine);
     runWindowOwned->setTextEditorSystem(deps.textEditorSystem);
     runWindowOwned->setSignalEmitter(deps.signalEmitter);
-    auto *runWindow           = taskFlow->addTask(std::move(runWindowOwned));
 
-    auto *processInputOwned   = taskFlow->addTask(std::make_unique<ProcessInputEventTask>());
+    auto processInputOwned    = std::make_unique<ProcessInputEventTask>();
 
-    taskFlow->setSignalEmitter(deps.signalEmitter);
+    // Allocate a slot per task and bind the runnable to it. The modern
+    // ITaskFlow surface separates slot allocation (addTask returns a
+    // TaskId) from runnable attachment (attachTaskRun consumes the
+    // unique_ptr). We capture each TaskId for the onResult routing
+    // below and the ProcessInputEventTask raw pointer for the signal
+    // subscription so the bus can deliver to it after attach.
+    const TaskId initWindowId         = taskFlow->addTask();
+    const TaskId initVulkanId         = taskFlow->addTask();
+    const TaskId setupHelperId        = taskFlow->addTask();
+    const TaskId setupCubeId          = taskFlow->addTask();
+    const TaskId setupTextId          = taskFlow->addTask();
+    const TaskId loadTexturesId       = taskFlow->addTask();
+    const TaskId setupPlanesId        = taskFlow->addTask();
+    const TaskId setupTextEditId      = taskFlow->addTask();
+    const TaskId runWindowId          = taskFlow->addTask();
+    const TaskId processInputId       = taskFlow->addTask();
 
-    static_cast<void>(taskFlow->route(initWindow, initVulkan));
-    static_cast<void>(taskFlow->route(initVulkan, setupHelperGeometry));
-    static_cast<void>(taskFlow->route(setupHelperGeometry, setupCube));
-    static_cast<void>(taskFlow->route(setupCube, setupText));
-    static_cast<void>(taskFlow->route(setupText, loadTextures));
-    static_cast<void>(taskFlow->route(loadTextures, setupTexturedPlanes));
-    static_cast<void>(taskFlow->route(setupTexturedPlanes, setupTextEdit));
-    static_cast<void>(taskFlow->route(setupTextEdit, runWindow));
-    // Pool affinity wraps the subscriber in a scheduled-delivery adapter
-    // that hands the clone to IThreadManager::schedule. The engine's
-    // context owns the IThreadManager and the TaskFlow's signal path
-    // routes through ISignalEmitter, so input handlers run on a pool
-    // worker thread, off the Win32 message-pump thread, and clicking
-    // the window does not stall rendering if the handler grows heavier
-    // later.
-    static_cast<void>(taskFlow->signal(runWindow, processInputOwned,
-                                       kMouseButtonDownPayloadTypeId,
-                                       vigine::core::threading::ThreadAffinity::Pool));
-    static_cast<void>(taskFlow->signal(runWindow, processInputOwned,
-                                       kKeyDownPayloadTypeId,
-                                       vigine::core::threading::ThreadAffinity::Pool));
+    ProcessInputEventTask *processInputRaw = processInputOwned.get();
 
-    taskFlow->changeCurrentTaskTo(initWindow);
+    static_cast<void>(taskFlow->attachTaskRun(initWindowId, std::move(initWindowOwned)));
+    static_cast<void>(taskFlow->attachTaskRun(initVulkanId, std::move(initVulkanOwned)));
+    static_cast<void>(taskFlow->attachTaskRun(setupHelperId, std::move(setupHelperOwned)));
+    static_cast<void>(taskFlow->attachTaskRun(setupCubeId, std::move(setupCubeOwned)));
+    static_cast<void>(taskFlow->attachTaskRun(setupTextId, std::move(setupTextOwned)));
+    static_cast<void>(taskFlow->attachTaskRun(loadTexturesId, std::move(loadTexturesOwned)));
+    static_cast<void>(taskFlow->attachTaskRun(setupPlanesId, std::move(setupPlanesOwned)));
+    static_cast<void>(taskFlow->attachTaskRun(setupTextEditId, std::move(setupTextEditOwned)));
+    static_cast<void>(taskFlow->attachTaskRun(runWindowId, std::move(runWindowOwned)));
+    static_cast<void>(taskFlow->attachTaskRun(processInputId, std::move(processInputOwned)));
+
+    static_cast<void>(taskFlow->onResult(initWindowId, ResultCode::Success, initVulkanId));
+    static_cast<void>(taskFlow->onResult(initVulkanId, ResultCode::Success, setupHelperId));
+    static_cast<void>(taskFlow->onResult(setupHelperId, ResultCode::Success, setupCubeId));
+    static_cast<void>(taskFlow->onResult(setupCubeId, ResultCode::Success, setupTextId));
+    static_cast<void>(taskFlow->onResult(setupTextId, ResultCode::Success, loadTexturesId));
+    static_cast<void>(taskFlow->onResult(loadTexturesId, ResultCode::Success, setupPlanesId));
+    static_cast<void>(taskFlow->onResult(setupPlanesId, ResultCode::Success, setupTextEditId));
+    static_cast<void>(taskFlow->onResult(setupTextEditId, ResultCode::Success, runWindowId));
+
+    // The legacy taskFlow->signal() helper merely subscribed the
+    // target task's ISubscriber adapter on the supplied emitter. The
+    // modern ITaskFlow surface no longer carries a signal-bus wrapper
+    // (the runnable-attached callable scope only models the synchronous
+    // routing path); so the demo subscribes directly through the
+    // signal emitter. The ProcessInputEventTask derives from
+    // ISubscriber, so it plugs straight into subscribeSignal. Pool
+    // affinity is preserved by routing through the bus's underlying
+    // policy -- the shared-pool emitter built in main() dispatches
+    // delivered messages on a pool worker by default.
+    if (deps.signalEmitter != nullptr && deps.signalSubscriptions != nullptr)
+    {
+        auto *subscriber = static_cast<vigine::messaging::ISubscriber *>(processInputRaw);
+
+        vigine::messaging::MessageFilter mouseFilter{};
+        mouseFilter.kind   = vigine::messaging::MessageKind::Signal;
+        mouseFilter.typeId = kMouseButtonDownPayloadTypeId;
+        if (auto token = deps.signalEmitter->subscribeSignal(mouseFilter, subscriber))
+        {
+            deps.signalSubscriptions->push_back(std::move(token));
+        }
+
+        vigine::messaging::MessageFilter keyFilter{};
+        keyFilter.kind   = vigine::messaging::MessageKind::Signal;
+        keyFilter.typeId = kKeyDownPayloadTypeId;
+        if (auto token = deps.signalEmitter->subscribeSignal(keyFilter, subscriber))
+        {
+            deps.signalSubscriptions->push_back(std::move(token));
+        }
+    }
+
+    static_cast<void>(taskFlow->enqueue(initWindowId));
 
     return taskFlow;
 }
 
-std::unique_ptr<vigine::TaskFlow> createWorkTaskFlow()
+std::unique_ptr<vigine::taskflow::ITaskFlow> createWorkTaskFlow()
 {
-    auto taskFlow    = std::make_unique<vigine::TaskFlow>();
+    auto taskFlow = vigine::taskflow::createTaskFlow();
 
-    auto *renderCube = taskFlow->addTask(std::make_unique<RenderCubeTask>());
-    taskFlow->changeCurrentTaskTo(renderCube);
+    const vigine::taskflow::TaskId renderCubeId = taskFlow->addTask();
+    static_cast<void>(taskFlow->attachTaskRun(renderCubeId,
+                                              std::make_unique<RenderCubeTask>()));
+    static_cast<void>(taskFlow->enqueue(renderCubeId));
 
     return taskFlow;
 }
 
-std::unique_ptr<vigine::TaskFlow> createErrorTaskFlow()
+std::unique_ptr<vigine::taskflow::ITaskFlow> createErrorTaskFlow()
 {
-    return std::make_unique<vigine::TaskFlow>();
+    return vigine::taskflow::createTaskFlow();
 }
 
-std::unique_ptr<vigine::TaskFlow> createCloseTaskFlow()
+std::unique_ptr<vigine::taskflow::ITaskFlow> createCloseTaskFlow()
 {
-    return std::make_unique<vigine::TaskFlow>();
+    return vigine::taskflow::createTaskFlow();
 }
 
 } // namespace
@@ -282,14 +345,25 @@ int main()
     const vigine::statemachine::StateId closeState = fsm.addState();
 
     // Bind a TaskFlow per state through the modern FSM-drive surface.
+    // The signal-subscription token sink lives in main() because the
+    // engine tears the FSM (and with it the flow that owns the
+    // ProcessInputEventTask subscriber) down before we drop these
+    // tokens at scope exit; cancelling the tokens after the
+    // subscriber has been destroyed would dereference dangling
+    // memory, so the token's RAII cancel must run with the
+    // subscriber still alive (the engine guarantees this through the
+    // ordering above).
+    SubscriptionTokenList signalSubscriptions{};
+
     InitFlowDeps initDeps{};
-    initDeps.entityManager     = entityManager.get();
-    initDeps.platformServiceId = platformServiceId;
-    initDeps.graphicsServiceId = graphicsServiceId;
-    initDeps.engine            = engine.get();
-    initDeps.signalEmitter     = signalEmitter.get();
-    initDeps.textEditState     = textEditState;
-    initDeps.textEditorSystem  = textEditorSystem;
+    initDeps.entityManager       = entityManager.get();
+    initDeps.platformServiceId   = platformServiceId;
+    initDeps.graphicsServiceId   = graphicsServiceId;
+    initDeps.engine              = engine.get();
+    initDeps.signalEmitter       = signalEmitter.get();
+    initDeps.textEditState       = textEditState;
+    initDeps.textEditorSystem    = textEditorSystem;
+    initDeps.signalSubscriptions = &signalSubscriptions;
 
     if (auto regResult = fsm.addStateTaskFlow(initState, createInitTaskFlow(initDeps));
         regResult.isError())

--- a/include/vigine/api/statemachine/abstractstatemachine.h
+++ b/include/vigine/api/statemachine/abstractstatemachine.h
@@ -17,10 +17,10 @@
 #include "vigine/api/statemachine/routemode.h"
 #include "vigine/api/statemachine/stateid.h"
 
-namespace vigine
+namespace vigine::taskflow
 {
-class TaskFlow;
-} // namespace vigine
+class ITaskFlow;
+} // namespace vigine::taskflow
 
 namespace vigine::statemachine
 {
@@ -177,11 +177,11 @@ class AbstractStateMachine : public IStateMachine
     // ------ IStateMachine: state-bound TaskFlow registry ------
 
     vigine::Result
-        addStateTaskFlow(StateId                          state,
-                         std::unique_ptr<vigine::TaskFlow> taskFlow) override;
+        addStateTaskFlow(StateId                                       state,
+                         std::unique_ptr<vigine::taskflow::ITaskFlow> taskFlow) override;
 
-    [[nodiscard]] vigine::TaskFlow       *taskFlowFor(StateId state) override;
-    [[nodiscard]] const vigine::TaskFlow *taskFlowFor(StateId state) const override;
+    [[nodiscard]] vigine::taskflow::ITaskFlow       *taskFlowFor(StateId state) override;
+    [[nodiscard]] const vigine::taskflow::ITaskFlow *taskFlowFor(StateId state) const override;
 
     // ------ State-invalidation listener registry ------
 
@@ -507,14 +507,14 @@ class AbstractStateMachine : public IStateMachine
     /**
      * @brief State-bound TaskFlow registry.
      *
-     * One entry per state: the engine looks the @ref vigine::TaskFlow
-     * up by @ref StateId on every tick of @c run() and drives
-     * @c runCurrentTask while the flow has tasks left to run. The
-     * machine owns each registered flow through a @c std::unique_ptr;
-     * destroying the machine destroys every flow. Slots are
-     * append-only in this leaf — there is no removal API yet, matching
-     * the rest of the wrapper surface (states themselves are
-     * append-only).
+     * One entry per state: the engine looks the
+     * @ref vigine::taskflow::ITaskFlow up by @ref StateId on every
+     * tick of @c run() and drives @c runCurrentTask while the flow
+     * has tasks left to run. The machine owns each registered flow
+     * through a @c std::unique_ptr; destroying the machine destroys
+     * every flow. Slots are append-only in this leaf — there is no
+     * removal API yet, matching the rest of the wrapper surface
+     * (states themselves are append-only).
      *
      * Storage shape is a heterogeneous-key @c std::unordered_map keyed
      * by @ref StateId via the @ref StateIdHasher above. The map is
@@ -524,7 +524,9 @@ class AbstractStateMachine : public IStateMachine
      * the duration of one tick after releasing the mutex, which is
      * safe because no removal API races against the read.
      */
-    std::unordered_map<StateId, std::unique_ptr<vigine::TaskFlow>, StateIdHasher>
+    std::unordered_map<StateId,
+                       std::unique_ptr<vigine::taskflow::ITaskFlow>,
+                       StateIdHasher>
         _stateTaskFlows;
 
     /**

--- a/include/vigine/api/statemachine/istatemachine.h
+++ b/include/vigine/api/statemachine/istatemachine.h
@@ -7,9 +7,13 @@
 #include "vigine/api/statemachine/routemode.h"
 #include "vigine/api/statemachine/stateid.h"
 
+namespace vigine::taskflow
+{
+class ITaskFlow;
+} // namespace vigine::taskflow
+
 namespace vigine
 {
-class TaskFlow;
 
 /**
  * @brief Pure-virtual forward-declared stub for the legacy state-machine
@@ -446,9 +450,9 @@ class IStateMachine
     // ------ State-bound TaskFlow registry ------
 
     /**
-     * @brief Associates a runnable @ref vigine::TaskFlow with @p state so
-     *        the engine pumps that flow's tasks while the FSM is in
-     *        @p state.
+     * @brief Associates a runnable @ref vigine::taskflow::ITaskFlow with
+     *        @p state so the engine pumps that flow's tasks while the
+     *        FSM is in @p state.
      *
      * The state machine takes ownership of @p taskFlow. The flow is
      * destroyed when the machine itself is destroyed; there is no
@@ -460,13 +464,13 @@ class IStateMachine
      *
      * Reports @ref Result::Code::Error when @p state is not registered
      * or when @p taskFlow is @c nullptr. Reports
-     * @ref Result::Code::Error when @p state already has a TaskFlow
-     * bound (one-shot; callers that need to swap a flow rebuild the
+     * @ref Result::Code::Error when @p state already has a flow bound
+     * (one-shot; callers that need to swap a flow rebuild the
      * machine). Ownership is consumed by this call regardless of
      * result: @p taskFlow is taken by value, so on every failure path
      * the @c std::unique_ptr held by the parameter is destroyed at
-     * function return — its TaskFlow is released along with it. There
-     * is no hand-back to the caller. On success the machine takes the
+     * function return — its flow is released along with it. There is
+     * no hand-back to the caller. On success the machine takes the
      * flow into its registry; on failure the flow is destroyed before
      * the call returns.
      *
@@ -479,12 +483,13 @@ class IStateMachine
      * mutations stay on the controller per the locked policy.
      */
     virtual vigine::Result
-        addStateTaskFlow(StateId                          state,
-                         std::unique_ptr<vigine::TaskFlow> taskFlow) = 0;
+        addStateTaskFlow(StateId                                       state,
+                         std::unique_ptr<vigine::taskflow::ITaskFlow> taskFlow) = 0;
 
     /**
-     * @brief Returns the @ref vigine::TaskFlow bound to @p state, or
-     *        @c nullptr when no flow has been registered for it.
+     * @brief Returns the @ref vigine::taskflow::ITaskFlow bound to
+     *        @p state, or @c nullptr when no flow has been registered
+     *        for it.
      *
      * The state machine retains ownership of every registered flow;
      * the returned pointer is non-owning and stays valid until the
@@ -495,21 +500,22 @@ class IStateMachine
      * thread manager pump alone.
      *
      * Two overloads are provided so callers observe a const-correct
-     * surface: a non-const machine returns a mutable @ref vigine::TaskFlow
-     * pointer (the engine needs that handle to call @c runCurrentTask
-     * each tick), while a const machine returns @c const @ref vigine::TaskFlow
-     * pointer so a @c const @ref IStateMachine reference cannot be used to
-     * mutate the bound flow. Both overloads share the same lookup body
-     * and lock policy below.
+     * surface: a non-const machine returns a mutable
+     * @ref vigine::taskflow::ITaskFlow pointer (the engine needs that
+     * handle to call @c runCurrentTask each tick), while a const
+     * machine returns @c const @ref vigine::taskflow::ITaskFlow
+     * pointer so a @c const @ref IStateMachine reference cannot be
+     * used to mutate the bound flow. Both overloads share the same
+     * lookup body and lock policy below.
      *
      * Threading: safe from any thread. Takes the registry mutex
      * briefly for the lookup; concurrent lookups serialise against
      * each other and against @ref addStateTaskFlow.
      */
-    [[nodiscard]] virtual vigine::TaskFlow *
+    [[nodiscard]] virtual vigine::taskflow::ITaskFlow *
         taskFlowFor(StateId state) = 0;
 
-    [[nodiscard]] virtual const vigine::TaskFlow *
+    [[nodiscard]] virtual const vigine::taskflow::ITaskFlow *
         taskFlowFor(StateId state) const = 0;
 
     IStateMachine(const IStateMachine &)            = delete;

--- a/include/vigine/api/taskflow/abstracttaskflow.h
+++ b/include/vigine/api/taskflow/abstracttaskflow.h
@@ -1,12 +1,18 @@
 #pragma once
 
 #include <memory>
+#include <unordered_map>
 
 #include "vigine/result.h"
 #include "vigine/api/taskflow/itaskflow.h"
 #include "vigine/api/taskflow/resultcode.h"
 #include "vigine/api/taskflow/routemode.h"
 #include "vigine/api/taskflow/taskid.h"
+
+namespace vigine
+{
+class ITask;
+} // namespace vigine
 
 namespace vigine::taskflow
 {
@@ -102,6 +108,13 @@ class AbstractTaskFlow : public ITaskFlow
         TaskId    next,
         RouteMode mode) override;
 
+    // ------ ITaskFlow: runnable attachment ------
+
+    Result               attachTaskRun(TaskId taskId,
+                                       std::unique_ptr<vigine::ITask> task) override;
+    void                 runCurrentTask() override;
+    [[nodiscard]] bool   hasTasksToRun() const noexcept override;
+
     // ------ ITaskFlow: flow control ------
 
     Result               enqueue(TaskId start) override;
@@ -170,6 +183,51 @@ class AbstractTaskFlow : public ITaskFlow
      * @ref enqueue.
      */
     TaskId _current{};
+
+    /**
+     * @brief Hasher for @ref TaskId so the runnable registry can use
+     *        @c std::unordered_map.
+     *
+     * @ref TaskId is an 8-byte trivially-copyable pair of
+     * @c std::uint32_t fields; the hasher splices the index and
+     * generation into a single 64-bit value before delegating to the
+     * standard library's @c std::hash<std::uint64_t>. Declared inside
+     * the private section so the symbol stays scoped to this header
+     * and no namespace-level @c std::hash specialisation leaks
+     * through the public header tree.
+     */
+    struct TaskIdHasher
+    {
+        [[nodiscard]] std::size_t operator()(const TaskId &task) const noexcept
+        {
+            const std::uint64_t blended =
+                (static_cast<std::uint64_t>(task.generation) << 32u)
+                | static_cast<std::uint64_t>(task.index);
+            return std::hash<std::uint64_t>{}(blended);
+        }
+    };
+
+    /**
+     * @brief Per-task runnable registry populated through
+     *        @ref attachTaskRun.
+     *
+     * Each entry binds a runnable @ref vigine::ITask to a
+     * @ref TaskId slot the orchestrator already tracks. The map
+     * owns each runnable through @c std::unique_ptr; destroying the
+     * flow tears down every attached runnable in turn. Lookups are
+     * by @ref TaskId; @ref runCurrentTask uses the lookup to find
+     * the runnable for @ref _current and to short-circuit cleanly
+     * when the slot is empty.
+     *
+     * Runnable lifetime: append-only. There is no detach surface in
+     * this leaf — once a runnable is attached it lives until the
+     * flow is destroyed. Callers that need to swap a runnable
+     * rebuild the flow from scratch, matching the
+     * @ref vigine::statemachine::IStateMachine::addStateTaskFlow
+     * one-shot-per-state contract.
+     */
+    std::unordered_map<TaskId, std::unique_ptr<vigine::ITask>, TaskIdHasher>
+        _runnables;
 };
 
 } // namespace vigine::taskflow

--- a/include/vigine/api/taskflow/itaskflow.h
+++ b/include/vigine/api/taskflow/itaskflow.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 #include "vigine/result.h"
 #include "vigine/api/taskflow/resultcode.h"
 #include "vigine/api/taskflow/routemode.h"
@@ -7,6 +9,8 @@
 
 namespace vigine
 {
+class ITask;
+
 /**
  * @brief Pure-virtual forward-declared stub for the legacy task flow
  *        surface.
@@ -168,6 +172,89 @@ class ITaskFlow
         ResultCode code,
         TaskId    next,
         RouteMode mode) = 0;
+
+    // ------ Runnable attachment ------
+
+    /**
+     * @brief Binds a runnable @ref vigine::ITask to the slot identified
+     *        by @p taskId so @ref runCurrentTask invokes it when the
+     *        flow's cursor reaches that task.
+     *
+     * The flow takes ownership of @p task. A successful registration is
+     * one-shot per slot: callers that need to swap a runnable on an
+     * existing task rebuild the flow from scratch. The runnable lives
+     * until the flow is destroyed; there is no detach surface in this
+     * leaf.
+     *
+     * Reports @ref Result::Code::Error when @p taskId is stale (the
+     * orchestrator never registered or has retired it) or when @p task
+     * is @c nullptr. Reports @ref Result::Code::Error when a runnable
+     * was already bound to @p taskId; ownership of @p task is consumed
+     * regardless of result, matching the @ref addStateTaskFlow contract
+     * on @ref vigine::statemachine::IStateMachine — the parameter is
+     * taken by value, so the @c std::unique_ptr held by the parameter
+     * is destroyed at function return on every failure path and the
+     * runnable is released along with it.
+     *
+     * Threading: callers serialise @c attachTaskRun against any
+     * @ref runCurrentTask path on the same flow externally; the wrapper
+     * does not introduce a per-flow mutex on the runnable registry
+     * because the typical wiring loads every runnable during topology
+     * setup before the engine pump starts.
+     */
+    virtual Result attachTaskRun(TaskId taskId, std::unique_ptr<vigine::ITask> task) = 0;
+
+    /**
+     * @brief Executes the runnable bound to the current task slot and
+     *        advances the cursor to whichever next task the registered
+     *        transitions select.
+     *
+     * Mirrors the legacy @c vigine::TaskFlow::runCurrentTask shape that
+     * @ref vigine::engine::IEngine::run drives every pump tick:
+     *
+     *   1. Look up the runnable bound to @ref current. When no runnable
+     *      is attached the call is a no-op and the cursor clears so
+     *      @ref hasTasksToRun reports false on the next probe.
+     *   2. Invoke the runnable's @c run(). The returned @ref Result is
+     *      mapped to the closest @ref ResultCode (Success / Error) and
+     *      the orchestrator looks up the @c onResult transition for
+     *      the @c (current, code) pair.
+     *   3. When a matching transition exists the cursor advances to
+     *      the next task. When no transition is registered the cursor
+     *      clears and @ref hasTasksToRun reports false on the next
+     *      probe — the engine pump then falls through to the FSM drain
+     *      alone, matching the legacy completion shape.
+     *
+     * The engine wires a state-scoped @c IEngineToken into the
+     * runnable through @ref vigine::ITask::setApi before invoking
+     * @c run and clears the binding through an RAII guard so a
+     * throwing @c run still leaves the task with a null token; that
+     * sequencing matches the legacy implementation and is required by
+     * the R-StateScope contract documented on @ref vigine::ITask.
+     *
+     * Threading: not thread-safe. The engine pump calls this from the
+     * controller thread; callers that drive their own pump must
+     * serialise externally.
+     */
+    virtual void runCurrentTask() = 0;
+
+    /**
+     * @brief Reports whether the flow has more work to drive.
+     *
+     * Returns @c true when @ref current names a task slot with an
+     * attached runnable that has not yet been consumed — i.e. the next
+     * @ref runCurrentTask invocation will execute a runnable. Returns
+     * @c false when the cursor has been cleared (the previous
+     * @ref runCurrentTask returned a @ref ResultCode that has no
+     * transition wired) or when no runnable is attached to the current
+     * task slot.
+     *
+     * The engine pump probes this every tick and skips the
+     * @ref runCurrentTask call when it returns @c false, falling
+     * through to the FSM drain + main-thread pump alone — matching the
+     * legacy @c vigine::TaskFlow::hasTasksToRun semantics.
+     */
+    [[nodiscard]] virtual bool hasTasksToRun() const noexcept = 0;
 
     // ------ Flow control ------
 

--- a/src/api/engine/abstractengine.cpp
+++ b/src/api/engine/abstractengine.cpp
@@ -8,8 +8,8 @@
 #include "vigine/api/context/icontext.h"
 #include "vigine/api/statemachine/istatemachine.h"
 #include "vigine/api/statemachine/stateid.h"
+#include "vigine/api/taskflow/itaskflow.h"
 #include "vigine/core/threading/ithreadmanager.h"
-#include "vigine/impl/taskflow/taskflow.h"
 
 namespace vigine::engine
 {
@@ -221,18 +221,17 @@ Result AbstractEngine::run()
         // its embedder is responsible for driving its own flows.
         if (fsmDrainSafe)
         {
-            const statemachine::StateId currentState = fsm.current();
-            vigine::TaskFlow *boundFlow = fsm.taskFlowFor(currentState);
+            const statemachine::StateId   currentState = fsm.current();
+            vigine::taskflow::ITaskFlow *boundFlow    = fsm.taskFlowFor(currentState);
             if (boundFlow != nullptr && boundFlow->hasTasksToRun())
             {
                 // runCurrentTask handles the per-task setApi /
-                // makeEngineToken / setApi(nullptr) lifecycle on its
-                // own through its ApiBindingGuard; the engine just
-                // tells it to advance once. Any FSM transition
-                // requested by the task during run() lands on the
-                // FSM's request queue and is drained on the very
-                // next call below, so the next tick observes the
-                // new state.
+                // setApi(nullptr) lifecycle on its own through its
+                // RAII guard; the engine just tells it to advance
+                // once. Any FSM transition requested by the task
+                // during run() lands on the FSM's request queue and
+                // is drained on the very next call below, so the
+                // next tick observes the new state.
                 boundFlow->runCurrentTask();
             }
         }

--- a/src/api/statemachine/abstractstatemachine.cpp
+++ b/src/api/statemachine/abstractstatemachine.cpp
@@ -11,7 +11,7 @@
 #include <vector>
 
 #include "statemachine/statetopology.h"
-#include "vigine/impl/taskflow/taskflow.h"
+#include "vigine/api/taskflow/itaskflow.h"
 #include "vigine/result.h"
 #include "vigine/api/statemachine/routemode.h"
 #include "vigine/api/statemachine/stateid.h"
@@ -438,8 +438,8 @@ void AbstractStateMachine::fireInvalidationListeners(StateId oldState)
 // ---------------------------------------------------------------------------
 
 Result AbstractStateMachine::addStateTaskFlow(
-    StateId                          state,
-    std::unique_ptr<vigine::TaskFlow> taskFlow)
+    StateId                                       state,
+    std::unique_ptr<vigine::taskflow::ITaskFlow> taskFlow)
 {
     checkThreadAffinity();
 
@@ -479,22 +479,22 @@ Result AbstractStateMachine::addStateTaskFlow(
     return Result();
 }
 
-vigine::TaskFlow *AbstractStateMachine::taskFlowFor(StateId state)
+vigine::taskflow::ITaskFlow *AbstractStateMachine::taskFlowFor(StateId state)
 {
     // Non-const overload: the engine's per-tick fast path calls this
     // through a non-const IStateMachine reference because runCurrentTask
-    // mutates the flow's internal _currTask field. Delegating to the
-    // const overload through a const_cast keeps the lookup logic in one
-    // place; the cast is sound because the underlying registry slot
-    // owns the TaskFlow through a std::unique_ptr and "the registry
-    // hands out a non-owning pointer" is the public contract — the
-    // const overload was never doing more than reading the slot value
-    // out from under the registry mutex.
+    // mutates the flow's internal cursor and runnable bookkeeping.
+    // Delegating to the const overload through a const_cast keeps the
+    // lookup logic in one place; the cast is sound because the
+    // underlying registry slot owns the flow through a std::unique_ptr
+    // and "the registry hands out a non-owning pointer" is the public
+    // contract -- the const overload was never doing more than reading
+    // the slot value out from under the registry mutex.
     const auto *self = this;
-    return const_cast<vigine::TaskFlow *>(self->taskFlowFor(state));
+    return const_cast<vigine::taskflow::ITaskFlow *>(self->taskFlowFor(state));
 }
 
-const vigine::TaskFlow *AbstractStateMachine::taskFlowFor(StateId state) const
+const vigine::taskflow::ITaskFlow *AbstractStateMachine::taskFlowFor(StateId state) const
 {
     // Lookup is open to any thread: the engine's per-tick fast path
     // calls this from the controller thread, but tests and

--- a/src/api/taskflow/abstracttaskflow.cpp
+++ b/src/api/taskflow/abstracttaskflow.cpp
@@ -1,9 +1,12 @@
 #include "vigine/api/taskflow/abstracttaskflow.h"
 
 #include <memory>
+#include <utility>
 
 #include "taskflow/taskorchestrator.h"
 #include "vigine/result.h"
+#include "vigine/api/taskflow/abstracttask.h"
+#include "vigine/api/taskflow/itask.h"
 #include "vigine/api/taskflow/resultcode.h"
 #include "vigine/api/taskflow/routemode.h"
 #include "vigine/api/taskflow/taskid.h"
@@ -84,6 +87,159 @@ Result AbstractTaskFlow::onResult(
     RouteMode mode)
 {
     return _orchestrator->addTransition(source, code, next, mode);
+}
+
+// ---------------------------------------------------------------------------
+// ITaskFlow: runnable attachment. The runnable registry is a small
+// per-task map populated by @ref attachTaskRun; @ref runCurrentTask
+// looks the runnable for @ref _current up, executes it through the
+// R-StateScope binding shape (setApi -> run -> setApi(nullptr) under an
+// RAII guard), and advances @c _current through the transition edge
+// matching the runnable's reported outcome. The shape mirrors the
+// legacy @c vigine::TaskFlow::runCurrentTask path the engine drives
+// every pump tick today, so callers migrating off the legacy front
+// door observe identical lifecycle and routing semantics.
+// ---------------------------------------------------------------------------
+
+namespace
+{
+
+// Map a generic @ref vigine::Result::Code to the closed
+// @ref vigine::taskflow::ResultCode enum the orchestrator stores on
+// transition edges. Only the two outcomes that callers can wire today
+// (Success / Error) survive the round-trip; Deferred / Skip are
+// reserved for the signal-driven facade that lands in a future leaf
+// and remain unwired here on purpose.
+[[nodiscard]] ResultCode mapResultCode(Result::Code code) noexcept
+{
+    switch (code)
+    {
+        case Result::Code::Success:
+            return ResultCode::Success;
+        default:
+            // Every non-Success outcome maps to Error so callers wiring
+            // an explicit error route through @c onResult observe the
+            // failure path; the legacy @c TaskFlow::runCurrentTask
+            // implements the same first-match resolution against
+            // @c Result::Code, so behaviour stays identical for tasks
+            // that only distinguish Success vs. Error.
+            return ResultCode::Error;
+    }
+}
+
+} // namespace
+
+Result AbstractTaskFlow::attachTaskRun(TaskId taskId,
+                                       std::unique_ptr<vigine::ITask> task)
+{
+    if (task == nullptr)
+    {
+        return Result(Result::Code::Error,
+                      "attachTaskRun: null ITask argument");
+    }
+    if (!_orchestrator->hasTask(taskId))
+    {
+        return Result(Result::Code::Error,
+                      "attachTaskRun: task id not registered");
+    }
+
+    auto [it, inserted] = _runnables.emplace(taskId, std::move(task));
+    if (!inserted)
+    {
+        // One-shot per slot. The parameter has already been moved into
+        // the local @p task; on the duplicate-key branch the
+        // @c std::unique_ptr held by the parameter is destroyed at
+        // function return and the runnable is released along with it.
+        // This matches the @ref addStateTaskFlow convention on
+        // @ref vigine::statemachine::IStateMachine.
+        return Result(Result::Code::Error,
+                      "attachTaskRun: task id already has an attached runnable");
+    }
+    return Result();
+}
+
+void AbstractTaskFlow::runCurrentTask()
+{
+    if (!_current.valid())
+    {
+        return;
+    }
+
+    auto it = _runnables.find(_current);
+    if (it == _runnables.end() || it->second == nullptr)
+    {
+        // Cursor sits on a slot with no runnable attached. Clear the
+        // cursor so @ref hasTasksToRun reports false on the next probe
+        // and the engine pump falls through to the FSM drain alone --
+        // the same shape the legacy @c TaskFlow::runCurrentTask takes
+        // when it observes a null @c _currTask.
+        _current = TaskId{};
+        return;
+    }
+
+    vigine::ITask *runnable = it->second.get();
+
+    // Execute the runnable. Concrete tasks today derive from
+    // @ref vigine::AbstractTask which makes @c setApi / @c api final
+    // and stores the bound token; the engine wires the token in this
+    // call site through @c setApi before @c run and clears it through
+    // an RAII guard so a throwing @c run still leaves the task with a
+    // null binding.
+    //
+    // The legacy @c vigine::TaskFlow path mints the engine token from
+    // the bound @c Context inside @c runCurrentTask. The modern wrapper
+    // does NOT yet thread an aggregator into the flow (UD-3 keeps the
+    // wrapper substrate-only); the engine-token binding is therefore
+    // skipped here and set up by the engine when it migrates the
+    // per-state flow registry to the modern surface in a follow-up.
+    // Tasks that today use @c api() observe a null token (they
+    // already branch on null per the @c IEngineToken contract); tasks
+    // that use the legacy @c context() accessor keep working through
+    // their existing @c setContext binding the caller wires manually.
+    struct ApiBindingGuard
+    {
+        vigine::ITask *task;
+        explicit ApiBindingGuard(vigine::ITask *t) : task(t) {}
+        ~ApiBindingGuard()
+        {
+            if (task != nullptr)
+            {
+                task->setApi(nullptr);
+            }
+        }
+        ApiBindingGuard(const ApiBindingGuard &)            = delete;
+        ApiBindingGuard &operator=(const ApiBindingGuard &) = delete;
+        ApiBindingGuard(ApiBindingGuard &&)                 = delete;
+        ApiBindingGuard &operator=(ApiBindingGuard &&)      = delete;
+    };
+
+    Result outcome;
+    {
+        runnable->setApi(nullptr);
+        [[maybe_unused]] ApiBindingGuard guard(runnable);
+        outcome = runnable->run();
+    }
+
+    // Resolve the next task through the orchestrator's transition map.
+    // Maps the runnable's @ref Result::Code to the closed
+    // @ref ResultCode enum stored on transition edges, then asks the
+    // orchestrator for the first matching target. An invalid result
+    // means "no transition wired" -- clear the cursor so the next
+    // @ref hasTasksToRun probe reports false and the engine pump
+    // falls through, matching the legacy completion shape.
+    const ResultCode code = mapResultCode(outcome.code());
+    const TaskId     next = _orchestrator->nextTaskFor(_current, code);
+    _current              = next;
+}
+
+bool AbstractTaskFlow::hasTasksToRun() const noexcept
+{
+    if (!_current.valid())
+    {
+        return false;
+    }
+    auto it = _runnables.find(_current);
+    return it != _runnables.end() && it->second != nullptr;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/taskflow/taskorchestrator.cpp
+++ b/src/taskflow/taskorchestrator.cpp
@@ -250,6 +250,58 @@ RouteMode TaskOrchestrator::storedModeFor(
     return fallback;
 }
 
+TaskId TaskOrchestrator::nextTaskFor(TaskId source, ResultCode code) const noexcept
+{
+    if (!source.valid())
+    {
+        return TaskId{};
+    }
+
+    const vigine::core::graph::NodeId srcNode = toNodeId(source);
+    if (!query().hasNode(srcNode))
+    {
+        return TaskId{};
+    }
+
+    // Walk the outgoing transition edges of @p source and pick the first
+    // edge that carries the matching @ref ResultCode. The graph stores
+    // edges in registration order; FirstMatch resolution maps to the
+    // first hit, which matches the legacy @c vigine::TaskFlow shape and
+    // the back-compat path documented on @ref RouteMode::FirstMatch.
+    const auto edges
+        = query().outEdgesOfKind(srcNode, vigine::taskflow::edge_kind::Transition);
+    for (const auto eid : edges)
+    {
+        const vigine::core::graph::IEdge *e = edge(eid);
+        if (e == nullptr)
+        {
+            continue;
+        }
+        const vigine::core::graph::IEdgeData *d = e->data();
+        if (d == nullptr || d->dataTypeId() != kTransitionDataTypeId)
+        {
+            continue;
+        }
+        const auto *td = static_cast<const TransitionData *>(d);
+        if (td->code() != code)
+        {
+            continue;
+        }
+
+        const vigine::core::graph::NodeId destNode = e->to();
+        if (!query().hasNode(destNode))
+        {
+            // Edge points at a retired slot; treat as no-match so the
+            // caller observes a clean cursor stop instead of a silent
+            // dereference of stale storage.
+            return TaskId{};
+        }
+        return toTaskId(destNode);
+    }
+
+    return TaskId{};
+}
+
 Result TaskOrchestrator::addTransition(
     TaskId    source,
     ResultCode code,

--- a/src/taskflow/taskorchestrator.h
+++ b/src/taskflow/taskorchestrator.h
@@ -97,6 +97,29 @@ class TaskOrchestrator final : public vigine::core::graph::AbstractGraph
         TaskId    next,
         RouteMode mode);
 
+    /**
+     * @brief Resolves the next @ref TaskId reachable from @p source on
+     *        a transition keyed by @p code, or an invalid @ref TaskId
+     *        when no matching transition is registered.
+     *
+     * Walks the outgoing transition edges of @p source under the
+     * graph's shared lock, picks the first edge whose stored
+     * @ref ResultCode matches @p code, and translates the edge's
+     * destination @c NodeId back to a @ref TaskId. Returns the
+     * invalid sentinel when @p source is stale, when no matching
+     * transition exists, or when the destination node has been
+     * retired since the edge was registered.
+     *
+     * The lookup honours @ref RouteMode::FirstMatch by reporting the
+     * first registered target — every other mode (FanOut, Chain) is
+     * configured at registration time but the runnable-attached
+     * callable surface only walks one target per
+     * @ref AbstractTaskFlow::runCurrentTask call, matching the legacy
+     * @c vigine::TaskFlow shape that fires exactly one transition per
+     * task completion.
+     */
+    [[nodiscard]] TaskId nextTaskFor(TaskId source, ResultCode code) const noexcept;
+
     // ------ POD translation helpers ------
 
     /**

--- a/test/contract/scenario_23_token_expires_on_transition.cpp
+++ b/test/contract/scenario_23_token_expires_on_transition.cpp
@@ -71,7 +71,9 @@
 #include "vigine/api/statemachine/istatemachine.h"
 #include "vigine/api/statemachine/stateid.h"
 #include "vigine/api/taskflow/abstracttask.h"
-#include "vigine/impl/taskflow/taskflow.h"
+#include "vigine/api/taskflow/factory.h"
+#include "vigine/api/taskflow/itaskflow.h"
+#include "vigine/api/taskflow/taskid.h"
 #include "vigine/result.h"
 
 #include <gtest/gtest.h>
@@ -192,16 +194,25 @@ struct DriverGuard
     // fixture after the TaskFlow has been successfully moved into the
     // FSM -- if any step before that fails, fx.probe stays null and
     // the caller's ASSERT_NE bails before any dereference.
-    auto flow        = std::make_unique<vigine::TaskFlow>();
+    auto flow        = vigine::taskflow::createTaskFlow();
     auto probeOwned  = std::make_unique<ProbeTask>();
     auto *probeRaw   = probeOwned.get();
-    auto *registered = flow->addTask(std::move(probeOwned));
-    if (registered == nullptr)
+    const vigine::taskflow::TaskId probeId = flow->addTask();
+    if (!probeId.valid())
     {
-        ADD_FAILURE() << "TaskFlow::addTask must register the probe task";
+        ADD_FAILURE() << "ITaskFlow::addTask must yield a valid task id for the probe";
         return fx;
     }
-    flow->changeCurrentTaskTo(registered);
+    if (!flow->attachTaskRun(probeId, std::move(probeOwned)).isSuccess())
+    {
+        ADD_FAILURE() << "ITaskFlow::attachTaskRun must bind the probe runnable";
+        return fx;
+    }
+    if (!flow->enqueue(probeId).isSuccess())
+    {
+        ADD_FAILURE() << "ITaskFlow::enqueue must position the cursor on the probe";
+        return fx;
+    }
 
     if (!fsm.addStateTaskFlow(fx.stateA, std::move(flow)).isSuccess())
     {

--- a/test/contract/scenario_24_fresh_token_in_new_state.cpp
+++ b/test/contract/scenario_24_fresh_token_in_new_state.cpp
@@ -59,7 +59,9 @@
 #include "vigine/api/statemachine/istatemachine.h"
 #include "vigine/api/statemachine/stateid.h"
 #include "vigine/api/taskflow/abstracttask.h"
-#include "vigine/impl/taskflow/taskflow.h"
+#include "vigine/api/taskflow/factory.h"
+#include "vigine/api/taskflow/itaskflow.h"
+#include "vigine/api/taskflow/taskid.h"
 #include "vigine/result.h"
 
 #include <gtest/gtest.h>
@@ -172,16 +174,25 @@ struct DriverGuard
     // shape. Each probe's runCount lets the test wait until the
     // engine has actually pumped the matching flow.
     {
-        auto flow        = std::make_unique<vigine::TaskFlow>();
+        auto flow        = vigine::taskflow::createTaskFlow();
         auto probeOwned  = std::make_unique<ProbeTask>();
         auto *probeRaw   = probeOwned.get();
-        auto *registered = flow->addTask(std::move(probeOwned));
-        if (registered == nullptr)
+        const vigine::taskflow::TaskId probeId = flow->addTask();
+        if (!probeId.valid())
         {
-            ADD_FAILURE() << "TaskFlow::addTask must register the StateA probe task";
+            ADD_FAILURE() << "ITaskFlow::addTask must yield a valid id for the StateA probe";
             return fx;
         }
-        flow->changeCurrentTaskTo(registered);
+        if (!flow->attachTaskRun(probeId, std::move(probeOwned)).isSuccess())
+        {
+            ADD_FAILURE() << "ITaskFlow::attachTaskRun must bind the StateA probe runnable";
+            return fx;
+        }
+        if (!flow->enqueue(probeId).isSuccess())
+        {
+            ADD_FAILURE() << "ITaskFlow::enqueue must position the cursor on the StateA probe";
+            return fx;
+        }
         if (!fsm.addStateTaskFlow(fx.stateA, std::move(flow)).isSuccess())
         {
             ADD_FAILURE() << "addStateTaskFlow(StateA) must succeed";
@@ -190,16 +201,25 @@ struct DriverGuard
         fx.probeA = probeRaw;
     }
     {
-        auto flow        = std::make_unique<vigine::TaskFlow>();
+        auto flow        = vigine::taskflow::createTaskFlow();
         auto probeOwned  = std::make_unique<ProbeTask>();
         auto *probeRaw   = probeOwned.get();
-        auto *registered = flow->addTask(std::move(probeOwned));
-        if (registered == nullptr)
+        const vigine::taskflow::TaskId probeId = flow->addTask();
+        if (!probeId.valid())
         {
-            ADD_FAILURE() << "TaskFlow::addTask must register the StateB probe task";
+            ADD_FAILURE() << "ITaskFlow::addTask must yield a valid id for the StateB probe";
             return fx;
         }
-        flow->changeCurrentTaskTo(registered);
+        if (!flow->attachTaskRun(probeId, std::move(probeOwned)).isSuccess())
+        {
+            ADD_FAILURE() << "ITaskFlow::attachTaskRun must bind the StateB probe runnable";
+            return fx;
+        }
+        if (!flow->enqueue(probeId).isSuccess())
+        {
+            ADD_FAILURE() << "ITaskFlow::enqueue must position the cursor on the StateB probe";
+            return fx;
+        }
         if (!fsm.addStateTaskFlow(fx.stateB, std::move(flow)).isSuccess())
         {
             ADD_FAILURE() << "addStateTaskFlow(StateB) must succeed";

--- a/test/engine/smoke_test.cpp
+++ b/test/engine/smoke_test.cpp
@@ -5,8 +5,10 @@
 #include "vigine/api/statemachine/istatemachine.h"
 #include "vigine/api/statemachine/stateid.h"
 #include "vigine/api/taskflow/abstracttask.h"
+#include "vigine/api/taskflow/factory.h"
+#include "vigine/api/taskflow/itaskflow.h"
+#include "vigine/api/taskflow/taskid.h"
 #include "vigine/impl/engine/engine.h"
-#include "vigine/impl/taskflow/taskflow.h"
 #include "vigine/result.h"
 #include "vigine/core/threading/irunnable.h"
 #include "vigine/core/threading/ithreadmanager.h"
@@ -281,16 +283,15 @@ TEST(EngineSmoke, RunFreezesTheContext)
 //   verifies the FSM-drive pump fired at least once before shutdown.
 //
 // Note on engine-token observation:
-//   The legacy @c vigine::TaskFlow::runCurrentTask path calls
-//   @c IContext::makeEngineToken when a context is bound through
-//   @c setContext. The modern aggregator built by @c createEngine is a
-//   @c vigine::context::AbstractContext, NOT a @c vigine::Context
-//   (legacy), so @c TaskFlow::setContext (which expects the legacy
-//   class) cannot be wired here. The probe still observes that it ran
-//   — that is enough to prove the engine pumped the flow each tick.
-//   The token-observation aspect is covered by the existing
-//   engine-token contract suite (@c scenario_21/22) and by the
-//   demos that exercise the legacy front door.
+//   The modern @c vigine::taskflow::ITaskFlow::runCurrentTask path runs
+//   the bound runnable without minting an engine token (the wrapper
+//   does not own an aggregator handle in this leaf -- that wiring is a
+//   follow-up). The probe still observes that it ran -- that is enough
+//   to prove the engine pumped the flow each tick. The token-observation
+//   aspect is covered by the existing engine-token contract suite
+//   (@c scenario_21/22) and by the engine-driven scenarios
+//   @c scenario_23 / @c scenario_24 that mint tokens off the engine
+//   context directly.
 // ---------------------------------------------------------------------------
 
 namespace
@@ -379,13 +380,19 @@ TEST(EngineSmoke, RunPumpsBoundTaskFlowEachTick)
 
     auto &fsm = engine->context().stateMachine();
 
-    auto flow = std::make_unique<vigine::TaskFlow>();
+    // Modern wiring: createTaskFlow -> addTask -> attachTaskRun ->
+    // enqueue. Each step is the wrapper's documented contract for
+    // turning an empty task slot into a runnable target the engine can
+    // pump.
+    auto flow = vigine::taskflow::createTaskFlow();
+    ASSERT_NE(flow, nullptr);
 
     auto       probeOwned = std::make_unique<ProbeTask>();
     ProbeTask *probe      = probeOwned.get();
-    auto      *task       = flow->addTask(std::move(probeOwned));
-    ASSERT_NE(task, nullptr);
-    flow->changeCurrentTaskTo(task);
+    const vigine::taskflow::TaskId probeId = flow->addTask();
+    ASSERT_TRUE(probeId.valid());
+    ASSERT_TRUE(flow->attachTaskRun(probeId, std::move(probeOwned)).isSuccess());
+    ASSERT_TRUE(flow->enqueue(probeId).isSuccess());
 
     const vigine::statemachine::StateId currentState = fsm.current();
     ASSERT_TRUE(currentState.valid());
@@ -442,13 +449,13 @@ TEST(EngineSmoke, AddStateTaskFlowRejectsBadInput)
     {
         const vigine::statemachine::StateId valid = fsm.current();
         const Result nullCase =
-            fsm.addStateTaskFlow(valid, std::unique_ptr<vigine::TaskFlow>{});
+            fsm.addStateTaskFlow(valid, std::unique_ptr<vigine::taskflow::ITaskFlow>{});
         EXPECT_TRUE(nullCase.isError());
     }
 
     // Stale id rejected.
     {
-        auto         flow = std::make_unique<vigine::TaskFlow>();
+        auto         flow = vigine::taskflow::createTaskFlow();
         const vigine::statemachine::StateId stale{42, 42};
         const Result staleCase = fsm.addStateTaskFlow(stale, std::move(flow));
         EXPECT_TRUE(staleCase.isError());
@@ -457,7 +464,7 @@ TEST(EngineSmoke, AddStateTaskFlowRejectsBadInput)
     // Valid registration succeeds.
     const vigine::statemachine::StateId valid = fsm.current();
     {
-        auto         flow = std::make_unique<vigine::TaskFlow>();
+        auto         flow = vigine::taskflow::createTaskFlow();
         const Result okCase = fsm.addStateTaskFlow(valid, std::move(flow));
         EXPECT_TRUE(okCase.isSuccess());
         EXPECT_NE(fsm.taskFlowFor(valid), nullptr);
@@ -465,7 +472,7 @@ TEST(EngineSmoke, AddStateTaskFlowRejectsBadInput)
 
     // Re-register on the same state errors out (one-shot per state).
     {
-        auto         flow = std::make_unique<vigine::TaskFlow>();
+        auto         flow = vigine::taskflow::createTaskFlow();
         const Result dupCase = fsm.addStateTaskFlow(valid, std::move(flow));
         EXPECT_TRUE(dupCase.isError());
     }


### PR DESCRIPTION
The legacy `vigine::TaskFlow` (root namespace) is the runnable engine
the FSM-driven Engine pump knew how to drive: it owns a chain of tasks,
runs the current one, maps the returned `Result::Code` to a transition,
and advances. The modern `vigine::taskflow::ITaskFlow` (post-#278) is a
graph-based registry of `TaskId` slots — tasks are abstract containers
with no run-callable surface. So `IStateMachine::addStateTaskFlow` (post
#334/#339) had to take the legacy `vigine::TaskFlow*`, and the legacy
type stayed alive blocking #282 (final legacy delete).

This PR teaches the modern surface to do callable work and migrates
`IStateMachine` + the engine pump + every direct caller onto it.

Three new methods on `vigine::taskflow::ITaskFlow`:

* `attachTaskRun(TaskId, std::unique_ptr<vigine::ITask>)` binds a
  runnable to an existing slot. One-shot per slot; ownership consumed
  by value, matching the `addStateTaskFlow` convention. Errors out on
  null task, stale id, or duplicate registration.
* `runCurrentTask()` executes the runnable bound to `current()`, maps
  its `Result::Code` to the closed `taskflow::ResultCode` enum
  (Success / Error), looks the first matching transition up through
  the internal task graph, and advances the cursor. When no
  transition is wired the cursor clears and `hasTasksToRun()` reports
  false on the next probe — same shape as the legacy completion path
  the engine pump already understood.
* `hasTasksToRun()` reports true when the cursor names a slot with an
  attached runnable that has not yet been consumed.

`AbstractTaskFlow` stores runnables in a private `unordered_map` keyed
by `TaskId` (with a private `TaskIdHasher` so no `std::hash<TaskId>`
specialisation leaks at namespace scope). `TaskOrchestrator` picks up
a `nextTaskFor(source, code)` helper that walks transition edges
under the graph's shared lock and resolves the first matching
destination, honouring `RouteMode::FirstMatch`. The runnable
lifecycle uses an RAII guard around `setApi(nullptr)` so a throwing
`run()` still leaves the task with a null engine-token binding —
mirrors the legacy `TaskFlow::runCurrentTask` sequencing.

`IStateMachine` flips its three TaskFlow methods from
`vigine::TaskFlow*` to `vigine::taskflow::ITaskFlow*`. The
implementation on `AbstractStateMachine` and the engine pump in
`AbstractEngine::run()` move onto the modern surface; neither
includes the legacy header anymore. `vigine::TaskFlow` (root
namespace) is now reachable only through demos that haven't migrated
yet — but every demo and test that previously consumed it is
migrated by this PR, so the legacy delete in #282 is unblocked.

Migrated callers:

* `test/engine/smoke_test.cpp` scenarios 7-9 (FSM-drive smoke tests
  for `Engine::run` against a state-bound TaskFlow) build their probe
  flow through `createTaskFlow + addTask + attachTaskRun + enqueue`.
* `test/contract/scenario_23_token_expires_on_transition.cpp` and
  `scenario_24_fresh_token_in_new_state.cpp` setup helpers move to
  the same construction shape; their five live cases on
  `EngineFsmTokenLifecycle` and `EngineFsmFreshToken` keep passing.
* `example/window/main.cpp`'s `createInitTaskFlow` rebuilds the
  Vulkan-init pipeline on the modern surface. The input-signal
  subscriptions previously routed through `TaskFlow::signal` now go
  straight to `ISignalEmitter::subscribeSignal`, with the returned
  tokens parked on a `SubscriptionTokenList` that `main()` owns and
  drops AFTER engine teardown so the `ProcessInputEventTask`
  subscriber outlives the cancel.
* `example/experimental/postgres_demo/main.cpp`'s four `buildXxxFlow`
  helpers rebuild every flow on the modern surface, replacing
  `route()` with `onResult()` and `changeCurrentTaskTo()` with
  `enqueue()`.

Verified locally on Windows / MSVC with `/WX`:

* 228 / 228 tests pass (full ctest pass).
* `parallel-fsm` 100 / 100, `threaded-bus` 800 / 800, `fanout-fsm`
  16 / 16.
* `example-window` builds clean.
* `example-postgresql` builds clean and exits as expected when no
  PostgreSQL substrate is bound (preserves prior behaviour).

Closes #343
