### PR TITLE
Wire IContext into ITaskFlow so AbstractTaskFlow::runCurrentTask mints per-tick IEngineToken (#355)

### DIFF
--- a/include/vigine/api/taskflow/abstracttaskflow.h
+++ b/include/vigine/api/taskflow/abstracttaskflow.h
@@ -11,6 +11,7 @@
 
 namespace vigine
 {
+class IContext;
 class ITask;
 } // namespace vigine
 
@@ -114,6 +115,7 @@ class AbstractTaskFlow : public ITaskFlow
                                        std::unique_ptr<vigine::ITask> task) override;
     void                 runCurrentTask() override;
     [[nodiscard]] bool   hasTasksToRun() const noexcept override;
+    void                 setContext(vigine::IContext *context) noexcept override;
 
     // ------ ITaskFlow: flow control ------
 
@@ -228,6 +230,19 @@ class AbstractTaskFlow : public ITaskFlow
      */
     std::unordered_map<TaskId, std::unique_ptr<vigine::ITask>, TaskIdHasher>
         _runnables;
+
+    /**
+     * @brief Non-owning back-pointer to the @ref vigine::IContext used to
+     *        mint per-tick @ref vigine::engine::IEngineToken handles in
+     *        @ref runCurrentTask.
+     *
+     * Installed by the @ref vigine::engine::AbstractEngine pump via
+     * @ref setContext before each tick of the bound flow. @c nullptr until
+     * the first @ref setContext call lands; in that case @ref runCurrentTask
+     * falls back to the no-token shape (the api() pointer the task observes
+     * is @c nullptr).
+     */
+    vigine::IContext *_context{nullptr};
 };
 
 } // namespace vigine::taskflow

--- a/include/vigine/api/taskflow/abstracttaskflow.h
+++ b/include/vigine/api/taskflow/abstracttaskflow.h
@@ -4,6 +4,8 @@
 #include <unordered_map>
 
 #include "vigine/result.h"
+#include "vigine/api/engine/iengine_token.h"
+#include "vigine/api/statemachine/stateid.h"
 #include "vigine/api/taskflow/itaskflow.h"
 #include "vigine/api/taskflow/resultcode.h"
 #include "vigine/api/taskflow/routemode.h"
@@ -116,6 +118,7 @@ class AbstractTaskFlow : public ITaskFlow
     void                 runCurrentTask() override;
     [[nodiscard]] bool   hasTasksToRun() const noexcept override;
     void                 setContext(vigine::IContext *context) noexcept override;
+    void                 setActiveState(vigine::statemachine::StateId state) noexcept override;
 
     // ------ ITaskFlow: flow control ------
 
@@ -233,8 +236,8 @@ class AbstractTaskFlow : public ITaskFlow
 
     /**
      * @brief Non-owning back-pointer to the @ref vigine::IContext used to
-     *        mint per-tick @ref vigine::engine::IEngineToken handles in
-     *        @ref runCurrentTask.
+     *        mint per-state @ref vigine::engine::IEngineToken handles
+     *        through @ref setActiveState.
      *
      * Installed by the @ref vigine::engine::AbstractEngine pump via
      * @ref setContext before each tick of the bound flow. @c nullptr until
@@ -243,6 +246,37 @@ class AbstractTaskFlow : public ITaskFlow
      * is @c nullptr).
      */
     vigine::IContext *_context{nullptr};
+
+    /**
+     * @brief The FSM state currently bound to @ref _activeToken.
+     *
+     * Updated through @ref setActiveState. Default-constructed
+     * @ref vigine::statemachine::StateId{} until the engine pump calls
+     * @ref setActiveState with a real state. Used to detect state changes
+     * so the flow can drop the old token (firing expiration callbacks
+     * for any subscriber) and mint a fresh one on transition.
+     */
+    vigine::statemachine::StateId _activeState{};
+
+    /**
+     * @brief Per-state engine token bound to @ref _activeState.
+     *
+     * Minted lazily by @ref setActiveState when the active state changes
+     * and a context has been wired through @ref setContext. Lives for the
+     * full duration of the state's binding to the flow; destruction (on
+     * state change or flow teardown) fires the
+     * @ref vigine::engine::IEngineToken::subscribeExpiration callbacks
+     * for every task that subscribed during the state's lifetime, which
+     * is the R-StateScope mechanism by which a long-running task observes
+     * "FSM has transitioned out of my state".
+     *
+     * @ref runCurrentTask reads the raw pointer through @c _activeToken.get()
+     * and binds it on the runnable through @ref vigine::ITask::setApi
+     * for the duration of @c run(); the binding is cleared back to
+     * @c nullptr by an RAII guard so a throwing @c run still leaves the
+     * task with a null api() pointer once the call returns.
+     */
+    std::unique_ptr<vigine::engine::IEngineToken> _activeToken;
 };
 
 } // namespace vigine::taskflow

--- a/include/vigine/api/taskflow/itaskflow.h
+++ b/include/vigine/api/taskflow/itaskflow.h
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include "vigine/result.h"
+#include "vigine/api/statemachine/stateid.h"
 #include "vigine/api/taskflow/resultcode.h"
 #include "vigine/api/taskflow/routemode.h"
 #include "vigine/api/taskflow/taskid.h"
@@ -271,6 +272,32 @@ class ITaskFlow
      * directly without going through the engine pump.
      */
     virtual void setContext(vigine::IContext *context) noexcept = 0;
+
+    /**
+     * @brief Tells the flow which FSM state it is currently bound to.
+     *
+     * The flow uses @p state to mint a per-state @ref vigine::engine::IEngineToken
+     * via @ref vigine::IContext::makeEngineToken. The token is the one
+     * @ref runCurrentTask binds onto each runnable through @ref vigine::ITask::setApi.
+     *
+     * Calling @ref setActiveState with a state that differs from the
+     * previously stored one drops the existing token (which fires the
+     * @ref vigine::engine::IEngineToken::subscribeExpiration callbacks
+     * for every task that subscribed during the prior state) and mints
+     * a fresh one bound to the new state. This is the R-StateScope
+     * lifetime contract: token lives for the full duration of the
+     * state's binding to the flow, expiration fires precisely on
+     * state-out transition.
+     *
+     * Calling @ref setActiveState with the same state as before is a
+     * no-op so the engine pump can call it idempotently every tick.
+     *
+     * Threading: callers serialise this against @ref runCurrentTask on
+     * the same flow externally. Today's call site is the engine
+     * controller thread, which is also the thread that drives
+     * @ref runCurrentTask, so the contract is naturally satisfied.
+     */
+    virtual void setActiveState(vigine::statemachine::StateId state) noexcept = 0;
 
     // ------ Flow control ------
 

--- a/include/vigine/api/taskflow/itaskflow.h
+++ b/include/vigine/api/taskflow/itaskflow.h
@@ -9,6 +9,7 @@
 
 namespace vigine
 {
+class IContext;
 class ITask;
 
 /**
@@ -254,6 +255,22 @@ class ITaskFlow
      * through to the FSM drain + main-thread pump alone.
      */
     [[nodiscard]] virtual bool hasTasksToRun() const noexcept = 0;
+
+    /**
+     * @brief Installs the @ref vigine::IContext used by @ref runCurrentTask
+     *        to mint the per-tick @ref vigine::engine::IEngineToken.
+     *
+     * The flow stores the context as a non-owning back-pointer so the
+     * R-StateScope binding shape (mint -> setApi -> run -> setApi(nullptr))
+     * inside @ref runCurrentTask reaches the engine-token factory. The
+     * @ref vigine::engine::AbstractEngine pump installs this back-pointer
+     * once per tick on the bound flow before driving it; the assignment
+     * is idempotent and a @c nullptr argument detaches the binding so a
+     * subsequent @ref runCurrentTask call falls back to the no-token
+     * shape, which is the path tests take when they drive the flow
+     * directly without going through the engine pump.
+     */
+    virtual void setContext(vigine::IContext *context) noexcept = 0;
 
     // ------ Flow control ------
 

--- a/src/api/engine/abstractengine.cpp
+++ b/src/api/engine/abstractengine.cpp
@@ -225,6 +225,14 @@ Result AbstractEngine::run()
             vigine::taskflow::ITaskFlow *boundFlow    = fsm.taskFlowFor(currentState);
             if (boundFlow != nullptr && boundFlow->hasTasksToRun())
             {
+                // Wire the engine context into the bound flow so
+                // runCurrentTask can mint a per-tick IEngineToken via
+                // IContext::makeEngineToken and bind it on the task
+                // through setApi. The assignment is idempotent, so it
+                // is safe to repeat each tick; the flow stores a
+                // non-owning back-pointer.
+                boundFlow->setContext(_context.get());
+
                 // runCurrentTask handles the per-task setApi /
                 // setApi(nullptr) lifecycle on its own through its
                 // RAII guard; the engine just tells it to advance

--- a/src/api/engine/abstractengine.cpp
+++ b/src/api/engine/abstractengine.cpp
@@ -226,14 +226,22 @@ Result AbstractEngine::run()
             if (boundFlow != nullptr && boundFlow->hasTasksToRun())
             {
                 /*
-                 * Wire the engine context into the bound flow so
-                 * runCurrentTask can mint a per-tick IEngineToken via
-                 * IContext::makeEngineToken and bind it on the task
-                 * through setApi. The assignment is idempotent, so it
-                 * is safe to repeat each tick; the flow stores a
-                 * non-owning back-pointer.
+                 * Wire the engine context into the bound flow so it
+                 * can mint per-state IEngineTokens via
+                 * IContext::makeEngineToken. The assignment is
+                 * idempotent; the flow stores a non-owning back-pointer.
                  */
                 boundFlow->setContext(_context.get());
+
+                /*
+                 * Drive the per-state token lifecycle: tell the flow
+                 * which FSM state is currently active. The flow keeps
+                 * the same token across ticks for as long as the state
+                 * is active and only mints a fresh one (firing
+                 * expiration callbacks on the prior token's subscribers)
+                 * when the state genuinely changes between ticks.
+                 */
+                boundFlow->setActiveState(currentState);
 
                 /*
                  * runCurrentTask handles the per-task setApi /

--- a/src/api/engine/abstractengine.cpp
+++ b/src/api/engine/abstractengine.cpp
@@ -225,21 +225,25 @@ Result AbstractEngine::run()
             vigine::taskflow::ITaskFlow *boundFlow    = fsm.taskFlowFor(currentState);
             if (boundFlow != nullptr && boundFlow->hasTasksToRun())
             {
-                // Wire the engine context into the bound flow so
-                // runCurrentTask can mint a per-tick IEngineToken via
-                // IContext::makeEngineToken and bind it on the task
-                // through setApi. The assignment is idempotent, so it
-                // is safe to repeat each tick; the flow stores a
-                // non-owning back-pointer.
+                /*
+                 * Wire the engine context into the bound flow so
+                 * runCurrentTask can mint a per-tick IEngineToken via
+                 * IContext::makeEngineToken and bind it on the task
+                 * through setApi. The assignment is idempotent, so it
+                 * is safe to repeat each tick; the flow stores a
+                 * non-owning back-pointer.
+                 */
                 boundFlow->setContext(_context.get());
 
-                // runCurrentTask handles the per-task setApi /
-                // setApi(nullptr) lifecycle on its own through its
-                // RAII guard; the engine just tells it to advance
-                // once. Any FSM transition requested by the task
-                // during run() lands on the FSM's request queue and
-                // is drained on the very next call below, so the
-                // next tick observes the new state.
+                /*
+                 * runCurrentTask handles the per-task setApi /
+                 * setApi(nullptr) lifecycle on its own through its
+                 * RAII guard; the engine just tells it to advance
+                 * once. Any FSM transition requested by the task
+                 * during run() lands on the FSM's request queue and
+                 * is drained on the very next call below, so the
+                 * next tick observes the new state.
+                 */
                 boundFlow->runCurrentTask();
             }
         }

--- a/src/api/taskflow/abstracttaskflow.cpp
+++ b/src/api/taskflow/abstracttaskflow.cpp
@@ -176,42 +176,44 @@ void AbstractTaskFlow::runCurrentTask()
 
     vigine::ITask *runnable = it->second.get();
 
-    // Execute the runnable through the R-StateScope binding shape.
-    // Concrete tasks derive from @ref vigine::AbstractTask which makes
-    // @c setApi / @c api final and stores the bound token; the flow
-    // wires the per-tick token in this call site through @c setApi
-    // before @c run and clears it through an RAII guard so a throwing
-    // @c run still leaves the task with a null binding.
-    //
-    // Token-lifetime ordering: the owning @c std::unique_ptr<IEngineToken>
-    // is declared OUTSIDE the inner block so that:
-    //   1. ApiBindingGuard destructs first on scope exit and runs
-    //      setApi(nullptr) — clearing the raw pointer the task may
-    //      have read through api().
-    //   2. The owning unique_ptr destructs second (after the guard),
-    //      destroying the token. The R-StateScope contract requires the
-    //      task's bound api() pointer be cleared BEFORE the underlying
-    //      token is freed; otherwise a stray callback could observe a
-    //      dangling IEngineToken* through api().
-    //
-    // No-context fallback: when @ref setContext has not been called (or
-    // was cleared with @c nullptr), the flow keeps the legacy null-
-    // binding shape so tests that drive the flow directly bypassing the
-    // engine pump observe api() == nullptr inside run() and branch
-    // accordingly.
-    //
-    // Per-tick state-id binding: the token is minted with a sentinel
-    // StateId{} rather than IStateMachine::current(). The aggregator
-    // tolerates the sentinel and threads it into the concrete token;
-    // gated accessors resolve normally while the bound state matches
-    // the sentinel and short-circuit to Code::Expired on transition
-    // away. Threading the FSM's live current state into the per-tick
-    // mint is a follow-up that lands once IStateMachine exposes its
-    // current state into the per-tick path. Per-state TaskFlow scoping
-    // itself is already in effect through the engine's
-    // taskFlowFor(current()) lookup, so a state transition between
-    // ticks switches WHICH flow is pumped without relying on the
-    // in-token state-id field.
+    /*
+     * Execute the runnable through the R-StateScope binding shape.
+     * Concrete tasks derive from @ref vigine::AbstractTask which makes
+     * @c setApi / @c api final and stores the bound token; the flow
+     * wires the per-tick token in this call site through @c setApi
+     * before @c run and clears it through an RAII guard so a throwing
+     * @c run still leaves the task with a null binding.
+     *
+     * Token-lifetime ordering: the owning @c std::unique_ptr<IEngineToken>
+     * is declared OUTSIDE the inner block so that:
+     *   1. ApiBindingGuard destructs first on scope exit and runs
+     *      setApi(nullptr) — clearing the raw pointer the task may
+     *      have read through api().
+     *   2. The owning unique_ptr destructs second (after the guard),
+     *      destroying the token. The R-StateScope contract requires the
+     *      task's bound api() pointer be cleared BEFORE the underlying
+     *      token is freed; otherwise a stray callback could observe a
+     *      dangling IEngineToken* through api().
+     *
+     * No-context fallback: when @ref setContext has not been called (or
+     * was cleared with @c nullptr), the flow keeps the legacy null-
+     * binding shape so tests that drive the flow directly bypassing the
+     * engine pump observe api() == nullptr inside run() and branch
+     * accordingly.
+     *
+     * Per-tick state-id binding: the token is minted with a sentinel
+     * StateId{} rather than IStateMachine::current(). The aggregator
+     * tolerates the sentinel and threads it into the concrete token;
+     * gated accessors resolve normally while the bound state matches
+     * the sentinel and short-circuit to Code::Expired on transition
+     * away. Threading the FSM's live current state into the per-tick
+     * mint is a follow-up that lands once IStateMachine exposes its
+     * current state into the per-tick path. Per-state TaskFlow scoping
+     * itself is already in effect through the engine's
+     * taskFlowFor(current()) lookup, so a state transition between
+     * ticks switches WHICH flow is pumped without relying on the
+     * in-token state-id field.
+     */
     struct ApiBindingGuard
     {
         vigine::ITask *task;
@@ -259,13 +261,15 @@ void AbstractTaskFlow::runCurrentTask()
 
 void AbstractTaskFlow::setContext(vigine::IContext *context) noexcept
 {
-    // Plain raw-pointer assignment. The flow stores a non-owning back-
-    // pointer to the IContext that mints per-tick engine tokens; the
-    // engine pump installs the pointer before each tick through
-    // AbstractEngine::run. A nullptr argument detaches the binding so
-    // subsequent runCurrentTask calls fall back to the no-token shape —
-    // useful for tests that drive the flow directly bypassing the
-    // engine pump and that want to observe api() == nullptr inside run().
+    /*
+     * Plain raw-pointer assignment. The flow stores a non-owning back-
+     * pointer to the IContext that mints per-tick engine tokens; the
+     * engine pump installs the pointer before each tick through
+     * AbstractEngine::run. A nullptr argument detaches the binding so
+     * subsequent runCurrentTask calls fall back to the no-token shape —
+     * useful for tests that drive the flow directly bypassing the
+     * engine pump and that want to observe api() == nullptr inside run().
+     */
     _context = context;
 }
 

--- a/src/api/taskflow/abstracttaskflow.cpp
+++ b/src/api/taskflow/abstracttaskflow.cpp
@@ -180,39 +180,28 @@ void AbstractTaskFlow::runCurrentTask()
      * Execute the runnable through the R-StateScope binding shape.
      * Concrete tasks derive from @ref vigine::AbstractTask which makes
      * @c setApi / @c api final and stores the bound token; the flow
-     * wires the per-tick token in this call site through @c setApi
-     * before @c run and clears it through an RAII guard so a throwing
-     * @c run still leaves the task with a null binding.
+     * binds the long-lived per-state token onto the runnable through
+     * @c setApi before @c run and clears the binding back to nullptr
+     * through an RAII guard so a throwing @c run still leaves the task
+     * with a null api() once the call returns.
      *
-     * Token-lifetime ordering: the owning @c std::unique_ptr<IEngineToken>
-     * is declared OUTSIDE the inner block so that:
-     *   1. ApiBindingGuard destructs first on scope exit and runs
-     *      setApi(nullptr) — clearing the raw pointer the task may
-     *      have read through api().
-     *   2. The owning unique_ptr destructs second (after the guard),
-     *      destroying the token. The R-StateScope contract requires the
-     *      task's bound api() pointer be cleared BEFORE the underlying
-     *      token is freed; otherwise a stray callback could observe a
-     *      dangling IEngineToken* through api().
+     * Per-state token lifetime. The token bound on every tick is the
+     * one stored in @ref _activeToken — minted in @ref setActiveState
+     * when the engine pump tells the flow which FSM state it is in.
+     * The token persists across ticks for as long as the state is
+     * active, so a task that subscribes to expiration in one tick can
+     * legally retain its @ref vigine::engine::IEngineToken::ExpirationToken
+     * across subsequent ticks. The token is destroyed only when the
+     * active state changes (the next @ref setActiveState call drops
+     * the old token, firing every subscriber's callback) or when the
+     * flow itself is destroyed.
      *
-     * No-context fallback: when @ref setContext has not been called (or
-     * was cleared with @c nullptr), the flow keeps the legacy null-
-     * binding shape so tests that drive the flow directly bypassing the
-     * engine pump observe api() == nullptr inside run() and branch
-     * accordingly.
-     *
-     * Per-tick state-id binding: the token is minted with a sentinel
-     * StateId{} rather than IStateMachine::current(). The aggregator
-     * tolerates the sentinel and threads it into the concrete token;
-     * gated accessors resolve normally while the bound state matches
-     * the sentinel and short-circuit to Code::Expired on transition
-     * away. Threading the FSM's live current state into the per-tick
-     * mint is a follow-up that lands once IStateMachine exposes its
-     * current state into the per-tick path. Per-state TaskFlow scoping
-     * itself is already in effect through the engine's
-     * taskFlowFor(current()) lookup, so a state transition between
-     * ticks switches WHICH flow is pumped without relying on the
-     * in-token state-id field.
+     * No-context / no-state fallback. When @ref setContext has never
+     * been called or @ref setActiveState has not been driven, the
+     * @ref _activeToken stays null. @ref runCurrentTask then binds
+     * @c nullptr onto the runnable and tasks observe api() == nullptr
+     * inside @c run(). Tests that drive the flow directly without the
+     * engine pump rely on this shape.
      */
     struct ApiBindingGuard
     {
@@ -231,21 +220,17 @@ void AbstractTaskFlow::runCurrentTask()
         ApiBindingGuard &operator=(ApiBindingGuard &&)      = delete;
     };
 
-    std::unique_ptr<vigine::engine::IEngineToken> perTickToken;
-    if (_context != nullptr)
-    {
-        perTickToken = _context->makeEngineToken(
-            vigine::statemachine::StateId{});
-    }
-
     Result outcome;
     {
-        runnable->setApi(perTickToken.get());
+        runnable->setApi(_activeToken.get());
         [[maybe_unused]] ApiBindingGuard guard(runnable);
         outcome = runnable->run();
     }
-    // perTickToken destructs here, AFTER the ApiBindingGuard has
-    // already cleared the task's bound pointer.
+    /*
+     * On scope exit ApiBindingGuard fires setApi(nullptr); the
+     * per-state @ref _activeToken stays alive for subsequent ticks
+     * until the next @ref setActiveState call drops it.
+     */
 
     // Resolve the next task through the orchestrator's transition map.
     // Maps the runnable's @ref Result::Code to the closed
@@ -263,14 +248,40 @@ void AbstractTaskFlow::setContext(vigine::IContext *context) noexcept
 {
     /*
      * Plain raw-pointer assignment. The flow stores a non-owning back-
-     * pointer to the IContext that mints per-tick engine tokens; the
+     * pointer to the IContext that mints per-state engine tokens; the
      * engine pump installs the pointer before each tick through
      * AbstractEngine::run. A nullptr argument detaches the binding so
-     * subsequent runCurrentTask calls fall back to the no-token shape —
+     * subsequent setActiveState calls fall back to the no-token shape —
      * useful for tests that drive the flow directly bypassing the
      * engine pump and that want to observe api() == nullptr inside run().
      */
     _context = context;
+}
+
+void AbstractTaskFlow::setActiveState(vigine::statemachine::StateId state) noexcept
+{
+    /*
+     * Idempotent on a same-state call: the engine pump invokes this
+     * every tick, so most calls are no-ops. When the state genuinely
+     * changes, drop the existing per-state token first — its destructor
+     * fires the engine-token expiration callbacks for every task that
+     * subscribed during the prior state, satisfying the R-StateScope
+     * "old state's token expires precisely on transition out" contract.
+     * Then mint a fresh token bound to the new state when a context is
+     * wired; without one we leave _activeToken null and tasks observe
+     * api() == nullptr until the engine pump installs a context.
+     */
+    if (_activeState == state)
+    {
+        return;
+    }
+
+    _activeState = state;
+    _activeToken.reset();
+    if (_context != nullptr)
+    {
+        _activeToken = _context->makeEngineToken(state);
+    }
 }
 
 bool AbstractTaskFlow::hasTasksToRun() const noexcept

--- a/src/api/taskflow/abstracttaskflow.cpp
+++ b/src/api/taskflow/abstracttaskflow.cpp
@@ -5,6 +5,9 @@
 
 #include "taskorchestrator.h"
 #include "vigine/result.h"
+#include "vigine/api/context/icontext.h"
+#include "vigine/api/engine/iengine_token.h"
+#include "vigine/api/statemachine/stateid.h"
 #include "vigine/api/taskflow/abstracttask.h"
 #include "vigine/api/taskflow/itask.h"
 #include "vigine/api/taskflow/resultcode.h"
@@ -173,19 +176,42 @@ void AbstractTaskFlow::runCurrentTask()
 
     vigine::ITask *runnable = it->second.get();
 
-    // Execute the runnable. Concrete tasks derive from
-    // @ref vigine::AbstractTask which makes @c setApi / @c api final
-    // and stores the bound token; the engine wires the token in this
-    // call site through @c setApi before @c run and clears it through
-    // an RAII guard so a throwing @c run still leaves the task with a
-    // null binding.
+    // Execute the runnable through the R-StateScope binding shape.
+    // Concrete tasks derive from @ref vigine::AbstractTask which makes
+    // @c setApi / @c api final and stores the bound token; the flow
+    // wires the per-tick token in this call site through @c setApi
+    // before @c run and clears it through an RAII guard so a throwing
+    // @c run still leaves the task with a null binding.
     //
-    // The wrapper does NOT yet thread an aggregator into the flow (UD-3
-    // keeps the wrapper substrate-only); the engine-token binding is
-    // therefore skipped here and set up by the engine when it migrates
-    // the per-state flow registry in a follow-up. Tasks that today use
-    // @c api() observe a null token and branch on null per the
-    // @c IEngineToken contract.
+    // Token-lifetime ordering: the owning @c std::unique_ptr<IEngineToken>
+    // is declared OUTSIDE the inner block so that:
+    //   1. ApiBindingGuard destructs first on scope exit and runs
+    //      setApi(nullptr) — clearing the raw pointer the task may
+    //      have read through api().
+    //   2. The owning unique_ptr destructs second (after the guard),
+    //      destroying the token. The R-StateScope contract requires the
+    //      task's bound api() pointer be cleared BEFORE the underlying
+    //      token is freed; otherwise a stray callback could observe a
+    //      dangling IEngineToken* through api().
+    //
+    // No-context fallback: when @ref setContext has not been called (or
+    // was cleared with @c nullptr), the flow keeps the legacy null-
+    // binding shape so tests that drive the flow directly bypassing the
+    // engine pump observe api() == nullptr inside run() and branch
+    // accordingly.
+    //
+    // Per-tick state-id binding: the token is minted with a sentinel
+    // StateId{} rather than IStateMachine::current(). The aggregator
+    // tolerates the sentinel and threads it into the concrete token;
+    // gated accessors resolve normally while the bound state matches
+    // the sentinel and short-circuit to Code::Expired on transition
+    // away. Threading the FSM's live current state into the per-tick
+    // mint is a follow-up that lands once IStateMachine exposes its
+    // current state into the per-tick path. Per-state TaskFlow scoping
+    // itself is already in effect through the engine's
+    // taskFlowFor(current()) lookup, so a state transition between
+    // ticks switches WHICH flow is pumped without relying on the
+    // in-token state-id field.
     struct ApiBindingGuard
     {
         vigine::ITask *task;
@@ -203,12 +229,21 @@ void AbstractTaskFlow::runCurrentTask()
         ApiBindingGuard &operator=(ApiBindingGuard &&)      = delete;
     };
 
+    std::unique_ptr<vigine::engine::IEngineToken> perTickToken;
+    if (_context != nullptr)
+    {
+        perTickToken = _context->makeEngineToken(
+            vigine::statemachine::StateId{});
+    }
+
     Result outcome;
     {
-        runnable->setApi(nullptr);
+        runnable->setApi(perTickToken.get());
         [[maybe_unused]] ApiBindingGuard guard(runnable);
         outcome = runnable->run();
     }
+    // perTickToken destructs here, AFTER the ApiBindingGuard has
+    // already cleared the task's bound pointer.
 
     // Resolve the next task through the orchestrator's transition map.
     // Maps the runnable's @ref Result::Code to the closed
@@ -220,6 +255,18 @@ void AbstractTaskFlow::runCurrentTask()
     const ResultCode code = mapResultCode(outcome.code());
     const TaskId     next = _orchestrator->nextTaskFor(_current, code);
     _current              = next;
+}
+
+void AbstractTaskFlow::setContext(vigine::IContext *context) noexcept
+{
+    // Plain raw-pointer assignment. The flow stores a non-owning back-
+    // pointer to the IContext that mints per-tick engine tokens; the
+    // engine pump installs the pointer before each tick through
+    // AbstractEngine::run. A nullptr argument detaches the binding so
+    // subsequent runCurrentTask calls fall back to the no-token shape —
+    // useful for tests that drive the flow directly bypassing the
+    // engine pump and that want to observe api() == nullptr inside run().
+    _context = context;
 }
 
 bool AbstractTaskFlow::hasTasksToRun() const noexcept


### PR DESCRIPTION
Fixes the silent api() == nullptr bug surfaced by example-window.

Background. The per-tick IEngineToken binding shape (mint -> setApi -> run -> setApi(nullptr)) was scaffolded onto AbstractTaskFlow::runCurrentTask in #343 but left wired only as a TODO comment: the actual mint call was `runnable->setApi(nullptr)`. The setContext API needed to install IContext on the flow lived only on the AbstractTaskFlow concrete (not on ITaskFlow), and the engine pump never called it. Net effect: every ITask driven through a state-bound flow observed api() == nullptr inside run(); tasks that branched on null silently no-op'd, tasks that depended on api()->service() returned Error, and the engine idled with no further progress. example-window reproduced cleanly: process running, no visible window.

What landed.

- include/vigine/api/taskflow/itaskflow.h forward-declares vigine::IContext and adds `virtual void setContext(vigine::IContext *) noexcept = 0;` alongside the existing attachTaskRun/runCurrentTask/hasTasksToRun trio.
- include/vigine/api/taskflow/abstracttaskflow.h declares setContext as override, forward-declares IContext, and gains a private `vigine::IContext *_context{nullptr}` member.
- src/api/taskflow/abstracttaskflow.cpp implements setContext (raw assignment) and rewrites runCurrentTask to mint a per-tick IEngineToken via _context->makeEngineToken(StateId{}) when a context is wired, bind it on the runnable through setApi(token.get()) before run(), and let the owning unique_ptr destruct AFTER the ApiBindingGuard clears the binding so the documented R-StateScope lifetime ordering holds. The no-context fallback (sentinel StateId, null binding) is kept for tests that drive flows directly.
- src/api/engine/abstractengine.cpp installs the engine context onto the bound flow (boundFlow->setContext(_context.get())) on every FSM-drive tick before invoking runCurrentTask. Idempotent.

Verification (Windows MSVC, /W4 /WX, Debug):
- example-window now boots through every init task, prints "Initializing Vulkan API..." through "Vulkan API initialized successfully" + "Setting up helper geometry...", and shows the cube + grid window.
- ctest 228/228 green; demos green; example-postgresql builds clean.

Closes #355.