### PR TITLE
Attach RenderComponent to entities in example/window setup tasks before bindEntity (#357)

### DIFF
--- a/example/window/task/vulkan/setupcubetask.cpp
+++ b/example/window/task/vulkan/setupcubetask.cpp
@@ -52,6 +52,7 @@ vigine::Result SetupCubeTask::run()
 
     _entityManager->addAlias(cubeEntity, "CubeEntity");
 
+    renderSystem->createComponents(cubeEntity);
     renderSystem->bindEntity(cubeEntity);
 
     auto *renderComponent = graphicsService->renderComponent();

--- a/example/window/task/vulkan/setuphelpergeometrytask.cpp
+++ b/example/window/task/vulkan/setuphelpergeometrytask.cpp
@@ -52,6 +52,7 @@ vigine::Result SetupHelperGeometryTask::run()
 
     _entityManager->addAlias(pyramidEntity, "PyramidEntity");
 
+    renderSystem->createComponents(pyramidEntity);
     renderSystem->bindEntity(pyramidEntity);
     auto *pyramidRC = graphicsService->renderComponent();
     if (!pyramidRC)
@@ -84,6 +85,7 @@ vigine::Result SetupHelperGeometryTask::run()
 
     _entityManager->addAlias(gridEntity, "GridEntity");
 
+    renderSystem->createComponents(gridEntity);
     renderSystem->bindEntity(gridEntity);
     auto *gridRC = graphicsService->renderComponent();
     if (!gridRC)
@@ -116,6 +118,7 @@ vigine::Result SetupHelperGeometryTask::run()
 
     _entityManager->addAlias(sunEntity, "SunEntity");
 
+    renderSystem->createComponents(sunEntity);
     renderSystem->bindEntity(sunEntity);
     auto *sunRC = graphicsService->renderComponent();
     if (!sunRC)

--- a/example/window/task/vulkan/setuptextedittask.cpp
+++ b/example/window/task/vulkan/setuptextedittask.cpp
@@ -100,6 +100,7 @@ vigine::Result SetupTextEditTask::run()
             return vigine::Result(vigine::Result::Code::Error, "Failed to create TextEditBgEntity");
 
         _entityManager->addAlias(bgEntity, "TextEditBgEntity");
+        renderSystem->createComponents(bgEntity);
         renderSystem->bindEntity(bgEntity);
 
         auto *rc = graphicsService->renderComponent();
@@ -138,6 +139,7 @@ vigine::Result SetupTextEditTask::run()
                                   "Failed to create TextEditScrollbarTrackEntity");
 
         _entityManager->addAlias(trackEntity, "TextEditScrollbarTrackEntity");
+        renderSystem->createComponents(trackEntity);
         renderSystem->bindEntity(trackEntity);
 
         auto *rc = graphicsService->renderComponent();
@@ -169,6 +171,7 @@ vigine::Result SetupTextEditTask::run()
                                   "Failed to create TextEditScrollbarThumbEntity");
 
         _entityManager->addAlias(thumbEntity, "TextEditScrollbarThumbEntity");
+        renderSystem->createComponents(thumbEntity);
         renderSystem->bindEntity(thumbEntity);
 
         rc = graphicsService->renderComponent();
@@ -202,6 +205,7 @@ vigine::Result SetupTextEditTask::run()
             return vigine::Result(vigine::Result::Code::Error, "Failed to create TextEditEntity");
 
         _entityManager->addAlias(textEntity, "TextEditEntity");
+        renderSystem->createComponents(textEntity);
         renderSystem->bindEntity(textEntity);
 
         auto *rc = graphicsService->renderComponent();
@@ -285,6 +289,7 @@ vigine::Result SetupTextEditTask::run()
                                       "Failed to create focus frame entity");
 
             _entityManager->addAlias(e, alias);
+            renderSystem->createComponents(e);
             renderSystem->bindEntity(e);
 
             auto *rc = graphicsService->renderComponent();

--- a/example/window/task/vulkan/setuptexttask.cpp
+++ b/example/window/task/vulkan/setuptexttask.cpp
@@ -79,6 +79,7 @@ vigine::Result SetupTextTask::run()
 
     _entityManager->addAlias(textEntity, "TextEntity");
 
+    renderSystem->createComponents(textEntity);
     renderSystem->bindEntity(textEntity);
 
     auto *renderComponent = graphicsService->renderComponent();

--- a/example/window/task/vulkan/setuptexturedplanestask.cpp
+++ b/example/window/task/vulkan/setuptexturedplanestask.cpp
@@ -108,6 +108,7 @@ vigine::Result SetupTexturedPlanesTask::run()
         }
 
         _entityManager->addAlias(planeEntity, config.entityName);
+        renderSystem->createComponents(planeEntity);
         renderSystem->bindEntity(planeEntity);
 
         auto *renderComponent = graphicsService->renderComponent();

--- a/example/window/task/window/runwindowtask.cpp
+++ b/example/window/task/window/runwindowtask.cpp
@@ -890,6 +890,7 @@ bool RunWindowTask::ensureMouseRayEntity()
         _entityManager->addAlias(_mouseRayEntity, "MouseRayEntity");
     }
 
+    _renderSystem->createComponents(_mouseRayEntity);
     _renderSystem->bindEntity(_mouseRayEntity);
     auto *rc = _renderSystem->boundRenderComponent();
     if (!rc)
@@ -934,6 +935,7 @@ bool RunWindowTask::ensureMouseClickSphereEntity()
         _entityManager->addAlias(_mouseClickSphereEntity, "MouseClickSphereEntity");
     }
 
+    _renderSystem->createComponents(_mouseClickSphereEntity);
     _renderSystem->bindEntity(_mouseClickSphereEntity);
     auto *rc = _renderSystem->boundRenderComponent();
     if (!rc)


### PR DESCRIPTION
Fixes the second example-window bug surfaced after #355 (PR #356) made api() actually work in tasks.

Background. Setup tasks created fresh entities via _entityManager->createEntity() and immediately called renderSystem->bindEntity(entity) without first attaching a RenderComponent. With no component in _entityComponents, _boundEntityComponent stayed nullptr, graphicsService->renderComponent() returned null, the task returned Result::Code::Error, and the engine pump cleared the cursor and idled in InitState — process running, no window. The bug was masked pre-#356 by the silent api()==nullptr early-return in the same tasks.

What landed. Inserted renderSystem->createComponents(entity) between createEntity and bindEntity in every example/window setup task that creates a fresh entity:

- example/window/task/vulkan/setuphelpergeometrytask.cpp — Pyramid, Grid, Sun.
- example/window/task/vulkan/setupcubetask.cpp — CubeEntity.
- example/window/task/vulkan/setuptexttask.cpp — TextEntity.
- example/window/task/vulkan/setuptexturedplanestask.cpp — plane entities (loop).
- example/window/task/vulkan/setuptextedittask.cpp — Bg, Track, Thumb, Text, focus-frame entities (loop).
- example/window/task/window/runwindowtask.cpp — ensureMouseRayEntity, ensureMouseClickSphereEntity helpers.

createComponents is idempotent (early-return when hasComponents already), so repeating the call on a re-bind is safe.

Verification (Windows MSVC, /W4 /WX, Debug):
- example-window now boots all init tasks, prints '[RunWindowTask] Showing window 1', and the cube + grid + textured planes window appears + accepts input (Mouse enter, Window focused, Window moved events firing).
- ctest 228/228 stays green.

Depends on #355 (PR #356) — without IContext wired into ITaskFlow, setup tasks never reach bindEntity (they bail early on api()==nullptr).

Closes #357.