### PR TITLE
Post-merge tail fixes for v0.1.0 release readiness (#359)

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -37,7 +37,7 @@ If a task description does not include the project folder layout, use this secti
 - `Result` is the shared execution result type for tasks and transitions.
 - `EntityManager` is the legacy entity owner used by examples that still walk the `Entity *` surface.
 - `Entity` is the base runtime entity type.
-- `AbstractTask` carries the bound `IEngineToken` pointer; concrete tasks reach engine subsystems through the token returned by `api()`.
+- `AbstractTask` carries the bound `IEngineToken` pointer; concrete tasks reach engine subsystems through the token returned by `apiToken()`.
 - `vigine::service::AbstractService` is the modern Level-1 service base; `vigine::ecs::AbstractSystem` is the modern system base that carries its `Entity *` binding by composition.
 
 ### Inheritance overview
@@ -107,7 +107,7 @@ If a task description does not include the project folder layout, use this secti
   the `subscribeExpiration` self-destruct contract, and the FSM-side
   invalidation listener firing path on `AbstractStateMachine`.
 - [Task system reference](ecs/system.md) — task-side companion to
-  `engine-token.md`. Documents the `ITask::setApi` / `ITask::api()`
+  `engine-token.md`. Documents the `ITask::setApiToken` / `ITask::apiToken()`
   surface, the gated vs non-gated accessor split as seen from inside a
   task body, and the `ApiBindingGuard` RAII pattern the task flow
   drives around every `run()` call.

--- a/doc/ecs/engine-token.md
+++ b/doc/ecs/engine-token.md
@@ -24,7 +24,7 @@ into the engine from inside a state hook.
 >   `TaskFlow::runCurrentTask` passes a sentinel-default
 >   `vigine::statemachine::StateId{}` and destroys the
 >   `unique_ptr<IEngineToken>` at the end of the per-task scope, so the
->   pointer the task observes through `api()` does **not** outlive the
+>   pointer the task observes through `apiToken()` does **not** outlive the
 >   single `run()` call and the bound-state field is the sentinel
 >   rather than `IStateMachine::current()`. Tokens minted directly
 >   through `IContext::makeEngineToken(stateId)` (the path the contract
@@ -220,7 +220,7 @@ walks the following per-tick shape:
 3. When a flow is bound, advance it by exactly one task via
    `TaskFlow::runCurrentTask`. That call mints an engine token through
    `IContext::makeEngineToken(StateId{})` (sentinel — see below),
-   binds it on the task with `setApi(token.get())`, runs `ITask::run`
+   binds it on the task with `setApiToken(token.get())`, runs `ITask::run`
    synchronously, clears the binding via the `ApiBindingGuard`
    destructor, and then destroys the owning `unique_ptr<IEngineToken>`
    at the end of the per-task scope.
@@ -242,14 +242,14 @@ today*:
   current state. The aggregator
   `vigine::context::Context::makeEngineToken` tolerates the sentinel
   and threads it into the concrete `EngineToken`. So a token observed
-  through `api()` inside `run()` today carries `boundState() ==
+  through `apiToken()` inside `run()` today carries `boundState() ==
   StateId{}` and matches no real FSM state when the listener walks the
   registry on a transition.
 - **The token does not outlive `run()`.** `runCurrentTask` keeps the
   `unique_ptr<IEngineToken>` on its own stack frame, calls
-  `setApi(nullptr)` through the RAII guard at end of scope, and then
+  `setApiToken(nullptr)` through the RAII guard at end of scope, and then
   the unique_ptr falls out of scope and destroys the token. The task
-  only ever observed a `IEngineToken*` through `ITask::api()`; that
+  only ever observed a `IEngineToken*` through `ITask::apiToken()`; that
   pointer is dangling the moment `runCurrentTask` returns. A worker
   thread that captured the pointer must therefore not dereference it
   after `run()` exits.
@@ -470,7 +470,7 @@ and against the post-#343 redesign:
   `IContext::makeEngineToken(workState)`) lives on the task member
   fields and outlives any single `run()` call. This half drives the
   FSM-bound expiration story and is what the worker thread captures.
-- The **per-tick token** the task receives through `api()` is used
+- The **per-tick token** the task receives through `apiToken()` is used
   inside `run()` only — to resolve services and reach the thread
   manager — and is never captured by the worker thread.
 
@@ -507,11 +507,11 @@ class RenderFrameTask final : public vigine::AbstractTask
     [[nodiscard]] vigine::Result run() override
     {
         // The TaskFlow::runCurrentTask wiring binds a per-tick token
-        // through setApi() before run() and clears the binding (and
+        // through setApiToken() before run() and clears the binding (and
         // destroys the unique_ptr<IEngineToken>) at end of run(). So
-        // the api() pointer is only valid for the body of run() and
+        // the apiToken() pointer is only valid for the body of run() and
         // must NOT be captured by a worker thread.
-        auto *perTickToken = api();
+        auto *perTickToken = apiToken();
         if (perTickToken == nullptr)
             return vigine::Result(vigine::Result::Code::Error,
                                   "render task missing per-tick engine token");
@@ -613,7 +613,7 @@ flow (`IStateMachine::addStateTaskFlow(workState, std::move(flow))`):
 
 1. While `current() == workState`, every tick mints a fresh per-tick
    token through `TaskFlow::runCurrentTask`, binds it on the task via
-   `setApi`, calls `run()`, clears the binding, and destroys the
+   `setApiToken`, calls `run()`, clears the binding, and destroys the
    per-tick `unique_ptr` at end of scope. `subscribeExpiration`
    callbacks registered against the per-tick token would fire at that
    destruction point and therefore are NOT used here for cross-tick
@@ -668,8 +668,8 @@ is the contract-safe shape.
   tick and binds a token before `runCurrentTask`:
   [`src/api/engine/abstractengine.cpp`](../../src/api/engine/abstractengine.cpp)
   (#334).
-- Task-side companion doc covering `ITask::api()` and the
-  setApi/run/setApi(nullptr) lifecycle:
+- Task-side companion doc covering `ITask::apiToken()` and the
+  setApiToken/run/setApiToken(nullptr) lifecycle:
   [`doc/ecs/system.md`](system.md).
 - Contract scenarios for stale token + expiration callback semantics:
   [`test/contract/scenario_21_stale_engine_token.cpp`](../../test/contract/scenario_21_stale_engine_token.cpp),

--- a/doc/ecs/system.md
+++ b/doc/ecs/system.md
@@ -4,8 +4,8 @@ This page is the task-side companion to
 [`engine-token.md`](engine-token.md). The engine-token doc explains
 *what* an `IEngineToken` is and *why* the gated / non-gated split
 exists; this page explains *how a task uses one*. Specifically, how a
-task receives a token through `ITask::setApi`, how it reaches the
-gated and non-gated accessors through `ITask::api()`, and how it must
+task receives a token through `ITask::setApiToken`, how it reaches the
+gated and non-gated accessors through `ITask::apiToken()`, and how it must
 behave when the FSM transitions out of the bound state.
 
 > **Two realities to keep separate.** The R-StateScope contract on the
@@ -18,7 +18,7 @@ behave when the FSM transitions out of the bound state.
 >   `vigine::statemachine::StateId{}` (rather than
 >   `IStateMachine::current()`), and the owning
 >   `unique_ptr<IEngineToken>` is destroyed at the end of the per-task
->   scope, so the pointer reachable through `api()` does NOT outlive
+>   scope, so the pointer reachable through `apiToken()` does NOT outlive
 >   the single `run()` call.
 > - **Intended (post-#343 ITaskFlow redesign).** The per-tick mint
 >   will carry `IStateMachine::current()` and the token will outlive
@@ -30,9 +30,9 @@ behave when the FSM transitions out of the bound state.
 > the `unique_ptr` itself (typically as a task member). The
 > "Long-running task" example near the bottom of this page shows that
 > shape; the rest of the page describes the per-tick token reachable
-> through `api()`.
+> through `apiToken()`.
 
-## `ITask::api()` subsection
+## `ITask::apiToken()` subsection
 
 ### Surface (post-#324)
 
@@ -48,10 +48,10 @@ class ITask
   public:
     // Bound by the task flow before every run() invocation.
     // Pass nullptr to clear the binding.
-    virtual void setApi(engine::IEngineToken *api) = 0;
+    virtual void setApiToken(engine::IEngineToken *api) = 0;
 
     // Returns the bound token, or nullptr when no token is bound.
-    [[nodiscard]] virtual engine::IEngineToken *api() = 0;
+    [[nodiscard]] virtual engine::IEngineToken *apiToken() = 0;
 
     // Canonical task entry point. Invoked once per scheduled tick.
     [[nodiscard]] virtual Result run() = 0;
@@ -62,18 +62,18 @@ class ITask
 
 Concrete tasks derive from
 [`AbstractTask`](../../include/vigine/api/taskflow/abstracttask.h),
-which implements `setApi` and `api` as `final` and leaves `run` pure
+which implements `setApiToken` and `api` as `final` and leaves `run` pure
 virtual. The token pointer lives on `AbstractTask::_api` (private,
-held by composition); `setApi` and `api` are the only public surface
+held by composition); `setApiToken` and `api` are the only public surface
 that touches it.
 
-### Binding a token via `setApi(IEngineToken*)`
+### Binding a token via `setApiToken(IEngineToken*)`
 
-Tasks **never** call `setApi` themselves; the task flow is the only
+Tasks **never** call `setApiToken` themselves; the task flow is the only
 caller. Ownership of the per-tick token's `unique_ptr<IEngineToken>`
 sits on `TaskFlow::runCurrentTask`'s stack frame: the flow asks
 `IContext` to mint a token, parks the unique_ptr on its own stack,
-publishes a raw pointer to the task through `setApi`, runs the task,
+publishes a raw pointer to the task through `setApiToken`, runs the task,
 clears the binding, and lets the unique_ptr fall out of scope at end
 of scope. The state machine only contributes the invalidation-listener
 registration the concrete `EngineToken` performs in its constructor;
@@ -89,7 +89,7 @@ three layers:
   the engine advances it by exactly one task per tick.
 - The flow's
   [`TaskFlow::runCurrentTask`](../../src/impl/taskflow/taskflow.cpp)
-  is the per-task setApi/run/setApi(nullptr) site.
+  is the per-task setApiToken/run/setApiToken(nullptr) site.
 - The token is minted via `IContext::makeEngineToken`.
 
 The per-tick wiring inside `TaskFlow::runCurrentTask`:
@@ -106,18 +106,18 @@ The per-tick wiring inside `TaskFlow::runCurrentTask`:
    relying on the in-token state-id field. The
    `vigine::context::Context` aggregator factory tolerates the
    sentinel and threads it into the concrete `EngineToken`.
-2. It calls the runnable's `setApi(token.get())` to publish that
+2. It calls the runnable's `setApiToken(token.get())` to publish that
    pointer to the task.
 3. It invokes the runnable's `run()` synchronously while the binding
    is live.
-4. An RAII `ApiBindingGuard` clears the binding (`setApi(nullptr)`)
+4. An RAII `ApiBindingGuard` clears the binding (`setApiToken(nullptr)`)
    when the scope exits — even if `run()` throws.
 5. The `unique_ptr<IEngineToken>` releases the token after the guard
    has run.
 
-The order matters. `setApi(nullptr)` must run **before** the `unique_ptr`
+The order matters. `setApiToken(nullptr)` must run **before** the `unique_ptr`
 releases the token, otherwise a stray callback on the task could
-observe a dangling `IEngineToken*` through `api()`. The guard pattern
+observe a dangling `IEngineToken*` through `apiToken()`. The guard pattern
 in `AbstractTaskFlow::runCurrentTask` is the canonical reference:
 
 ```cpp
@@ -127,14 +127,14 @@ struct ApiBindingGuard {
     explicit ApiBindingGuard(AbstractTask *t) : task(t) {}
     ~ApiBindingGuard() {
         if (task)
-            task->setApi(nullptr);
+            task->setApiToken(nullptr);
     }
     // copy / move deleted
 };
 
 Result currStatus;
 {
-    _currTask->setApi(token.get());
+    _currTask->setApiToken(token.get());
     [[maybe_unused]] ApiBindingGuard guard(_currTask);
     currStatus = _currTask->run();
 }
@@ -144,11 +144,11 @@ token.reset();
 A task author does not write this code. The author writes `run()`; the
 task flow drives the rest.
 
-### Gated vs non-gated accessors via `api()->...`
+### Gated vs non-gated accessors via `apiToken()->...`
 
 The token surface itself is documented in detail in
 [`engine-token.md`](engine-token.md#hybrid-gating-model). The summary
-below lists what a task reaches through `api()->...` and what each
+below lists what a task reaches through `apiToken()->...` and what each
 accessor returns.
 
 #### Gated accessors (return `Result<T>` / `Result<T&>`)
@@ -159,17 +159,17 @@ checks `isAlive()` first and short-circuits to
 
 | Accessor                            | Resource                          | Failure modes                                  |
 |-------------------------------------|-----------------------------------|------------------------------------------------|
-| `api()->service(ServiceId id)`      | `vigine::service::IService&`      | `Expired`, `NotFound`                          |
-| `api()->system(SystemId id)`        | `vigine::ecs::ISystem&`           | `Expired`, `Unavailable` (#197 follow-up wires the lookup) |
-| `api()->entityManager()`            | `vigine::IEntityManager&`         | `Expired`, `Unavailable` (#197 follow-up)      |
-| `api()->components()`               | `vigine::IComponentManager&`      | `Expired`, `Unavailable` (#197 follow-up)      |
-| `api()->ecs()`                      | `vigine::ecs::IECS&`              | `Expired` only                                 |
+| `apiToken()->service(ServiceId id)`      | `vigine::service::IService&`      | `Expired`, `NotFound`                          |
+| `apiToken()->system(SystemId id)`        | `vigine::ecs::ISystem&`           | `Expired`, `Unavailable` (#197 follow-up wires the lookup) |
+| `apiToken()->entityManager()`            | `vigine::IEntityManager&`         | `Expired`, `Unavailable` (#197 follow-up)      |
+| `apiToken()->components()`               | `vigine::IComponentManager&`      | `Expired`, `Unavailable` (#197 follow-up)      |
+| `apiToken()->ecs()`                      | `vigine::ecs::IECS&`              | `Expired` only                                 |
 
 Callers branch on `outcome.ok()` (or `outcome.code()`) and pull the
 live reference through `outcome.value()`:
 
 ```cpp
-auto outcome = api()->service(myServiceId);
+auto outcome = apiToken()->service(myServiceId);
 if (!outcome.ok())
     return Result(Result::Code::Error, "service unavailable");
 vigine::service::IService &svc = outcome.value();
@@ -185,39 +185,39 @@ non-null token pointer when you do it.**
 
 | Accessor                       | Resource                                              |
 |--------------------------------|-------------------------------------------------------|
-| `api()->threadManager()`       | `vigine::core::threading::IThreadManager&`            |
-| `api()->systemBus()`           | `vigine::messaging::IMessageBus&`                     |
-| `api()->signalEmitter()`       | `vigine::messaging::ISignalEmitter&`                  |
-| `api()->stateMachine()`        | `vigine::statemachine::IStateMachine&`                |
+| `apiToken()->threadManager()`       | `vigine::core::threading::IThreadManager&`            |
+| `apiToken()->systemBus()`           | `vigine::messaging::IMessageBus&`                     |
+| `apiToken()->signalEmitter()`       | `vigine::messaging::ISignalEmitter&`                  |
+| `apiToken()->stateMachine()`        | `vigine::statemachine::IStateMachine&`                |
 
-Inside the body of `run()` the engine guarantees `api()` is non-null
+Inside the body of `run()` the engine guarantees `apiToken()` is non-null
 on the modern context path, so you can call these accessors directly:
 
 ```cpp
-auto &tm = api()->threadManager(); // safe inside run()
+auto &tm = apiToken()->threadManager(); // safe inside run()
 ```
 
 Outside `run()` (for example from a deferred callback or an event
 handler that fires between ticks) the task flow has already cleared
-the binding via `setApi(nullptr)`, so `api()` returns `nullptr` even
+the binding via `setApiToken(nullptr)`, so `apiToken()` returns `nullptr` even
 for ungated reads. Null-check before dereferencing:
 
 ```cpp
-if (auto *token = api()) {
+if (auto *token = apiToken()) {
     auto &tm = token->threadManager();
     // ... use tm
 }
 ```
 
-### What happens when `api()` is called after the FSM transitions
+### What happens when `apiToken()` is called after the FSM transitions
 
 Two distinct cases:
 
-1. **`api()` itself returns `nullptr`.** Outside `run()` (for example
+1. **`apiToken()` itself returns `nullptr`.** Outside `run()` (for example
    from an event handler that fires between ticks) the task flow has
-   already cleared the binding via `setApi(nullptr)`. The task **must**
+   already cleared the binding via `setApiToken(nullptr)`. The task **must**
    null-check the return value before dereferencing.
-2. **`api()` returns a non-null pointer but the FSM has transitioned
+2. **`apiToken()` returns a non-null pointer but the FSM has transitioned
    away during `run()`.** The bound state was invalidated mid-tick.
    Gated accessors now report `engine::Result::Code::Expired` without
    touching the engine; non-gated accessors keep returning live
@@ -226,7 +226,7 @@ Two distinct cases:
 
 When the engine boots a `vigine::context::Context`, the token bound
 to your task is non-null and live for the duration of `run()`, so
-null checks on `api()` and `isAlive()` checks are not required for
+null checks on `apiToken()` and `isAlive()` checks are not required for
 the first access inside `run()`. They become required as soon as the
 task posts work that may run on a different thread or after a future
 state hop.
@@ -252,9 +252,9 @@ class DecodeFrameTask final : public vigine::AbstractTask
 
     [[nodiscard]] vigine::Result run() override
     {
-        // 1. The task flow already called setApi() before this run().
-        //    api() is non-null and bound to the current state.
-        auto *token = api();
+        // 1. The task flow already called setApiToken() before this run().
+        //    apiToken() is non-null and bound to the current state.
+        auto *token = apiToken();
         if (token == nullptr)
             return vigine::Result(vigine::Result::Code::Error,
                                   "no engine token bound");
@@ -308,11 +308,11 @@ The lifecycle the engine drives around this task is exactly:
    inside `runCurrentTask` is the open follow-up flagged on
    [`src/impl/taskflow/taskflow.cpp`](../../src/impl/taskflow/taskflow.cpp)
    and lands with #343. The task flow then calls
-   `setApi(token.get())`.
-3. The task flow calls `run()`. Inside, `api()` returns the bound
+   `setApiToken(token.get())`.
+3. The task flow calls `run()`. Inside, `apiToken()` returns the bound
    token; gated accessors resolve normally.
 4. `run()` returns. The `ApiBindingGuard` in
-   `TaskFlow::runCurrentTask` calls `setApi(nullptr)`. The owning
+   `TaskFlow::runCurrentTask` calls `setApiToken(nullptr)`. The owning
    `unique_ptr<IEngineToken>` then runs out of scope and **destroys
    the per-tick token**.
 5. The engine drains queued FSM transitions on the controller thread.
@@ -328,8 +328,8 @@ transition. The **per-tick token** lifecycle inside `runCurrentTask`
 is bound to a single `run()` call: the unique_ptr lives on the flow's
 stack frame and is destroyed before `runCurrentTask` returns. The
 task only ever observed an `IEngineToken*` raw pointer through
-`api()`; that pointer is dangling the moment `run()` exits. Code that
-captures the per-tick `api()` pointer and hands it to a worker thread
+`apiToken()`; that pointer is dangling the moment `run()` exits. Code that
+captures the per-tick `apiToken()` pointer and hands it to a worker thread
 therefore sees the token destroyed at the end of `run()`, and any
 worker-side dereference of the captured pointer after that point is
 undefined behaviour.
@@ -349,8 +349,8 @@ three things:
   will be delivered through a fresh subscriber on the next tick.
 - **Re-acquire the per-tick token on a future tick.** The next time
   the state-bound flow runs this task, the flow mints a new token
-  and calls `setApi` again. Code that wants to resume work across
-  ticks reads `api()` fresh on each entry into `run()` rather than
+  and calls `setApiToken` again. Code that wants to resume work across
+  ticks reads `apiToken()` fresh on each entry into `run()` rather than
   holding the previous pointer.
 - **Mint a separate FSM-bound token through `IContext`.** When the
   worker thread genuinely needs a token whose lifetime outlives
@@ -369,7 +369,7 @@ three things:
 is only meaningful for tokens whose `unique_ptr` outlives the `run()`
 body — i.e. the FSM-bound token a task minted itself through
 `IContext::makeEngineToken` and parked on a member field. Calling
-`subscribeExpiration` on the per-tick token reachable through `api()`
+`subscribeExpiration` on the per-tick token reachable through `apiToken()`
 is a programming error: the per-tick `unique_ptr` is destroyed at the
 end of the per-task scope, so the subscription would fire (or be torn
 down) at that destruction point rather than on a real FSM transition.
@@ -393,10 +393,10 @@ and the contract suite's expiration-after-transition scenario
 
 The shape below splits the token surface into two halves so the worker
 thread observes a real FSM-driven expiration even though the per-tick
-token reachable through `api()` does not outlive `run()` in the
+token reachable through `apiToken()` does not outlive `run()` in the
 current wiring:
 
-- The **per-tick token** (`api()` inside `run()`) is used for the
+- The **per-tick token** (`apiToken()` inside `run()`) is used for the
   ungated `threadManager()` reach and to schedule the worker. It is
   not captured by the worker.
 - The **FSM-bound token** (`_fsmToken` on the task instance) is
@@ -431,7 +431,7 @@ class StreamFramesTask final : public vigine::AbstractTask
         // Per-tick token: only valid for the body of run(), the
         // owning unique_ptr inside TaskFlow::runCurrentTask destroys
         // it the moment we return.
-        auto *perTickToken = api();
+        auto *perTickToken = apiToken();
         if (perTickToken == nullptr)
             return vigine::Result(vigine::Result::Code::Error,
                                   "no per-tick engine token bound");
@@ -540,7 +540,7 @@ on the very next tick.
 Once the #343 ITaskFlow redesign threads `IStateMachine::current()`
 into the per-tick mint and lets the per-tick token outlive `run()`,
 the per-tick / FSM-bound split above collapses back into a single
-token reached through `api()`. Until then, the split is the
+token reached through `apiToken()`. Until then, the split is the
 contract-safe shape.
 
 ## Cross-references
@@ -563,7 +563,7 @@ contract-safe shape.
 - Per-state TaskFlow registry on the FSM:
   [`IStateMachine::addStateTaskFlow` / `taskFlowFor`](../../include/vigine/api/statemachine/istatemachine.h)
   (#334).
-- Task-flow side that calls `setApi` / `run` and runs the
+- Task-flow side that calls `setApiToken` / `run` and runs the
   `ApiBindingGuard`:
   [`src/impl/taskflow/taskflow.cpp`](../../src/impl/taskflow/taskflow.cpp)
   (#324 / #334 follow-up for the in-flow `current()` lookup).

--- a/doc/sequence-engine-state.md
+++ b/doc/sequence-engine-state.md
@@ -16,10 +16,10 @@ loop per pump tick
   Engine->>TF: hasTasksToRun()
   alt has runnable
     Engine->>Ctx: makeEngineToken(boundState)
-    Engine->>Task: setApi(token)
+    Engine->>Task: setApiToken(token)
     Engine->>Task: run()
     Task-->>Engine: Result
-    Engine->>Task: setApi(nullptr)
+    Engine->>Task: setApiToken(nullptr)
     Engine->>TF: advance cursor by Result::Code
   end
   Engine->>FSM: select next state by transition outcome

--- a/example/experimental/postgres_demo/main.cpp
+++ b/example/experimental/postgres_demo/main.cpp
@@ -95,7 +95,7 @@ std::unique_ptr<vigine::taskflow::ITaskFlow> buildInitFlow(
     static_cast<void>(flow->onResult(checkSchemaId, ResultCode::Success, toWorkId));
     static_cast<void>(flow->onResult(checkSchemaId, ResultCode::Error,   toErrorId));
 
-    static_cast<void>(flow->enqueue(initBdId));
+    static_cast<void>(flow->setRoot(initBdId));
     return flow;
 }
 
@@ -138,7 +138,7 @@ std::unique_ptr<vigine::taskflow::ITaskFlow> buildWorkFlow(
     static_cast<void>(flow->onResult(removeId, ResultCode::Success, closeId));
     static_cast<void>(flow->onResult(removeId, ResultCode::Error,   errorId));
 
-    static_cast<void>(flow->enqueue(addId));
+    static_cast<void>(flow->setRoot(addId));
     return flow;
 }
 
@@ -154,7 +154,7 @@ std::unique_ptr<vigine::taskflow::ITaskFlow> buildErrorFlow(
     auto toClose = std::make_unique<TransitionTask>(stateMachine, closeState);
     const vigine::taskflow::TaskId toCloseId = flow->addTask();
     static_cast<void>(flow->attachTaskRun(toCloseId, std::move(toClose)));
-    static_cast<void>(flow->enqueue(toCloseId));
+    static_cast<void>(flow->setRoot(toCloseId));
     return flow;
 }
 
@@ -168,7 +168,7 @@ std::unique_ptr<vigine::taskflow::ITaskFlow> buildCloseFlow(vigine::engine::IEng
     auto shutdown = std::make_unique<ShutdownTask>(engine);
     const vigine::taskflow::TaskId shutdownId = flow->addTask();
     static_cast<void>(flow->attachTaskRun(shutdownId, std::move(shutdown)));
-    static_cast<void>(flow->enqueue(shutdownId));
+    static_cast<void>(flow->setRoot(shutdownId));
     return flow;
 }
 

--- a/example/experimental/postgres_demo/main.cpp
+++ b/example/experimental/postgres_demo/main.cpp
@@ -90,10 +90,10 @@ std::unique_ptr<vigine::taskflow::ITaskFlow> buildInitFlow(
     static_cast<void>(flow->attachTaskRun(toWorkId, std::move(toWork)));
     static_cast<void>(flow->attachTaskRun(toErrorId, std::move(toError)));
 
-    static_cast<void>(flow->route(initBdId,      ResultCode::Success, checkSchemaId));
-    static_cast<void>(flow->route(initBdId,      ResultCode::Error,   toErrorId));
-    static_cast<void>(flow->route(checkSchemaId, ResultCode::Success, toWorkId));
-    static_cast<void>(flow->route(checkSchemaId, ResultCode::Error,   toErrorId));
+    static_cast<void>(flow->route(initBdId,      checkSchemaId));
+    static_cast<void>(flow->route(initBdId,      toErrorId, ResultCode::Error));
+    static_cast<void>(flow->route(checkSchemaId, toWorkId));
+    static_cast<void>(flow->route(checkSchemaId, toErrorId, ResultCode::Error));
 
     static_cast<void>(flow->setRoot(initBdId));
     return flow;
@@ -131,12 +131,12 @@ std::unique_ptr<vigine::taskflow::ITaskFlow> buildWorkFlow(
     static_cast<void>(flow->attachTaskRun(closeId,  std::move(toClose)));
     static_cast<void>(flow->attachTaskRun(errorId,  std::move(toError)));
 
-    static_cast<void>(flow->route(addId,    ResultCode::Success, readId));
-    static_cast<void>(flow->route(addId,    ResultCode::Error,   errorId));
-    static_cast<void>(flow->route(readId,   ResultCode::Success, removeId));
-    static_cast<void>(flow->route(readId,   ResultCode::Error,   errorId));
-    static_cast<void>(flow->route(removeId, ResultCode::Success, closeId));
-    static_cast<void>(flow->route(removeId, ResultCode::Error,   errorId));
+    static_cast<void>(flow->route(addId,    readId));
+    static_cast<void>(flow->route(addId,    errorId,  ResultCode::Error));
+    static_cast<void>(flow->route(readId,   removeId));
+    static_cast<void>(flow->route(readId,   errorId,  ResultCode::Error));
+    static_cast<void>(flow->route(removeId, closeId));
+    static_cast<void>(flow->route(removeId, errorId,  ResultCode::Error));
 
     static_cast<void>(flow->setRoot(addId));
     return flow;

--- a/example/experimental/postgres_demo/main.cpp
+++ b/example/experimental/postgres_demo/main.cpp
@@ -90,10 +90,10 @@ std::unique_ptr<vigine::taskflow::ITaskFlow> buildInitFlow(
     static_cast<void>(flow->attachTaskRun(toWorkId, std::move(toWork)));
     static_cast<void>(flow->attachTaskRun(toErrorId, std::move(toError)));
 
-    static_cast<void>(flow->onResult(initBdId,      ResultCode::Success, checkSchemaId));
-    static_cast<void>(flow->onResult(initBdId,      ResultCode::Error,   toErrorId));
-    static_cast<void>(flow->onResult(checkSchemaId, ResultCode::Success, toWorkId));
-    static_cast<void>(flow->onResult(checkSchemaId, ResultCode::Error,   toErrorId));
+    static_cast<void>(flow->route(initBdId,      ResultCode::Success, checkSchemaId));
+    static_cast<void>(flow->route(initBdId,      ResultCode::Error,   toErrorId));
+    static_cast<void>(flow->route(checkSchemaId, ResultCode::Success, toWorkId));
+    static_cast<void>(flow->route(checkSchemaId, ResultCode::Error,   toErrorId));
 
     static_cast<void>(flow->setRoot(initBdId));
     return flow;
@@ -131,12 +131,12 @@ std::unique_ptr<vigine::taskflow::ITaskFlow> buildWorkFlow(
     static_cast<void>(flow->attachTaskRun(closeId,  std::move(toClose)));
     static_cast<void>(flow->attachTaskRun(errorId,  std::move(toError)));
 
-    static_cast<void>(flow->onResult(addId,    ResultCode::Success, readId));
-    static_cast<void>(flow->onResult(addId,    ResultCode::Error,   errorId));
-    static_cast<void>(flow->onResult(readId,   ResultCode::Success, removeId));
-    static_cast<void>(flow->onResult(readId,   ResultCode::Error,   errorId));
-    static_cast<void>(flow->onResult(removeId, ResultCode::Success, closeId));
-    static_cast<void>(flow->onResult(removeId, ResultCode::Error,   errorId));
+    static_cast<void>(flow->route(addId,    ResultCode::Success, readId));
+    static_cast<void>(flow->route(addId,    ResultCode::Error,   errorId));
+    static_cast<void>(flow->route(readId,   ResultCode::Success, removeId));
+    static_cast<void>(flow->route(readId,   ResultCode::Error,   errorId));
+    static_cast<void>(flow->route(removeId, ResultCode::Success, closeId));
+    static_cast<void>(flow->route(removeId, ResultCode::Error,   errorId));
 
     static_cast<void>(flow->setRoot(addId));
     return flow;

--- a/example/window/CMakeLists.txt
+++ b/example/window/CMakeLists.txt
@@ -38,6 +38,10 @@ set(EXAMPLE_WINDOW_TASK_SOURCES
 set(EXAMPLE_WINDOW_SYSTEM_SOURCES
     system/texteditorsystem.h system/texteditorsystem.cpp)
 
+set(EXAMPLE_WINDOW_SERVICE_SOURCES
+    services/wellknown.h
+    services/texteditorservice.h services/texteditorservice.cpp)
+
 # The legacy AbstractState-derived classes were retired when the
 # example migrated to the modern FSM-drive surface. State identity is
 # now a value handle (vigine::statemachine::StateId) allocated through
@@ -270,6 +274,7 @@ add_executable(${PROJECT_WINDOW_NAME}
     ${EXAMPLE_WINDOW_HANDLER_SOURCES}
     ${EXAMPLE_WINDOW_TASK_SOURCES}
     ${EXAMPLE_WINDOW_SYSTEM_SOURCES}
+    ${EXAMPLE_WINDOW_SERVICE_SOURCES}
     ${EXAMPLE_WINDOW_STATE_SOURCES})
 
 add_dependencies(${PROJECT_WINDOW_NAME} example_window_shaders)

--- a/example/window/CMakeLists.txt
+++ b/example/window/CMakeLists.txt
@@ -42,6 +42,9 @@ set(EXAMPLE_WINDOW_SERVICE_SOURCES
     services/wellknown.h
     services/texteditorservice.h services/texteditorservice.cpp)
 
+set(EXAMPLE_WINDOW_COMPONENT_SOURCES
+    component/texteditorcomponent.h)
+
 # The legacy AbstractState-derived classes were retired when the
 # example migrated to the modern FSM-drive surface. State identity is
 # now a value handle (vigine::statemachine::StateId) allocated through
@@ -275,6 +278,7 @@ add_executable(${PROJECT_WINDOW_NAME}
     ${EXAMPLE_WINDOW_TASK_SOURCES}
     ${EXAMPLE_WINDOW_SYSTEM_SOURCES}
     ${EXAMPLE_WINDOW_SERVICE_SOURCES}
+    ${EXAMPLE_WINDOW_COMPONENT_SOURCES}
     ${EXAMPLE_WINDOW_STATE_SOURCES})
 
 add_dependencies(${PROJECT_WINDOW_NAME} example_window_shaders)

--- a/example/window/component/texteditorcomponent.h
+++ b/example/window/component/texteditorcomponent.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <glm/vec3.hpp>
+
+namespace vigine
+{
+class Entity;
+} // namespace vigine
+
+/**
+ * @file texteditorcomponent.h
+ * @brief Single ECS component bundling every piece of editor-window
+ *        interaction state.
+ *
+ * The editor window does more than route keystrokes into the text
+ * buffer: it tracks which entity is focused, which entity is being
+ * dragged, where the last mouse click landed, whether Ctrl is held,
+ * whether a swapchain resize is pending, and so on. All of that
+ * state used to live on the @c RunWindowTask object as raw members;
+ * this component pulls it into a single ECS-shaped struct so the
+ * task itself can stay state-free and the @c TextEditorSystem can
+ * own / drive the state through its event-handler methods.
+ *
+ * Lifetime: the component is created by the editor-setup task and
+ * registered against an entity through @c TextEditorSystem::bindInteractionEntity.
+ * The system keeps a single live binding (the example wires it to
+ * the @c MainWindow entity) and queries it on every event call.
+ *
+ * Encapsulation: pure value aggregate. Public fields are the entire
+ * surface; the component exists to ferry data between the system's
+ * event handlers, not to enforce invariants. ENCAP EXEMPT in the
+ * style of @c vigine::service::ServiceId.
+ */
+// ENCAP EXEMPT: pure value aggregate
+struct TextEditorComponent
+{
+    // ---- Focus state ---------------------------------------------------
+    vigine::Entity *focusedEntity{nullptr};
+    glm::vec3       focusedOriginalScale{1.0f, 1.0f, 1.0f};
+    bool            hasFocusedOriginalScale{false};
+
+    // ---- Mouse-ray helper (visualises last clicked screen point) ------
+    vigine::Entity *mouseRayEntity{nullptr};
+    bool            mouseRayVisible{true};
+    bool            hasMouseRaySample{false};
+    int             lastMouseRayX{0};
+    int             lastMouseRayY{0};
+
+    // ---- Mouse-click-sphere helper ------------------------------------
+    vigine::Entity *mouseClickSphereEntity{nullptr};
+
+    // ---- Modifier / movement keys -------------------------------------
+    bool    ctrlHeld{false};
+    uint8_t movementKeyMask{0};
+
+    // ---- Object drag (one entity at a time) ---------------------------
+    bool             objectDragActive{false};
+    bool             objectDragEditorGroup{false};
+    vigine::Entity  *objectDragEntity{nullptr};
+    float            objectDragDistanceFromCamera{0.0f};
+    glm::vec3        objectDragGrabOffset{0.0f, 0.0f, 0.0f};
+
+    // ---- Resize tracking (debounced apply) -----------------------------
+    uint32_t                              pendingResizeWidth{0};
+    uint32_t                              pendingResizeHeight{0};
+    uint32_t                              appliedResizeWidth{0};
+    uint32_t                              appliedResizeHeight{0};
+    bool                                  resizePending{false};
+    std::chrono::steady_clock::time_point lastResizeEvent{};
+    std::chrono::steady_clock::time_point lastResizeApply{};
+};

--- a/example/window/main.cpp
+++ b/example/window/main.cpp
@@ -86,9 +86,6 @@
 namespace
 {
 
-using SubscriptionTokenList =
-    std::vector<std::unique_ptr<vigine::messaging::ISubscriptionToken>>;
-
 struct InitFlowDeps
 {
     vigine::EntityManager *entityManager{nullptr};
@@ -98,13 +95,6 @@ struct InitFlowDeps
     vigine::messaging::ISignalEmitter *signalEmitter{nullptr};
     std::shared_ptr<TextEditState> textEditState{};
     std::shared_ptr<TextEditorSystem> textEditorSystem{};
-    // Sink for the input-signal subscription tokens so they outlive the
-    // flow itself. The flow's runnable registry holds the subscriber
-    // (ProcessInputEventTask) by unique_ptr; the token must be released
-    // before the subscriber is destroyed, which the engine guarantees
-    // by tearing the FSM (and with it the flow) down before the host
-    // drops these tokens at scope exit in main().
-    SubscriptionTokenList *signalSubscriptions{nullptr};
 };
 
 std::unique_ptr<vigine::taskflow::ITaskFlow> createInitTaskFlow(const InitFlowDeps &deps)
@@ -197,36 +187,21 @@ std::unique_ptr<vigine::taskflow::ITaskFlow> createInitTaskFlow(const InitFlowDe
     static_cast<void>(taskFlow->onResult(setupPlanesId, ResultCode::Success, setupTextEditId));
     static_cast<void>(taskFlow->onResult(setupTextEditId, ResultCode::Success, runWindowId));
 
-    // The legacy taskFlow->signal() helper merely subscribed the
-    // target task's ISubscriber adapter on the supplied emitter. The
-    // modern ITaskFlow surface no longer carries a signal-bus wrapper
-    // (the runnable-attached callable scope only models the synchronous
-    // routing path); so the demo subscribes directly through the
-    // signal emitter. The ProcessInputEventTask derives from
-    // ISubscriber, so it plugs straight into subscribeSignal. Pool
-    // affinity is preserved by routing through the bus's underlying
-    // policy -- the shared-pool emitter built in main() dispatches
-    // delivered messages on a pool worker by default.
-    if (deps.signalEmitter != nullptr && deps.signalSubscriptions != nullptr)
-    {
-        auto *subscriber = static_cast<vigine::messaging::ISubscriber *>(processInputRaw);
+    // Wire the host-built signal emitter into the flow so taskFlow->signal
+    // can subscribe target tasks against it. The flow owns the resulting
+    // subscription tokens and unwinds them at destruction in reverse-
+    // registration order, before the underlying ProcessInputEventTask
+    // (registered above through attachTaskRun) is destroyed.
+    static_cast<void>(processInputRaw); // raw pointer no longer needed for direct subscribe
+    taskFlow->setSignalEmitter(deps.signalEmitter);
 
-        vigine::messaging::MessageFilter mouseFilter{};
-        mouseFilter.kind   = vigine::messaging::MessageKind::Signal;
-        mouseFilter.typeId = kMouseButtonDownPayloadTypeId;
-        if (auto token = deps.signalEmitter->subscribeSignal(mouseFilter, subscriber))
-        {
-            deps.signalSubscriptions->push_back(std::move(token));
-        }
-
-        vigine::messaging::MessageFilter keyFilter{};
-        keyFilter.kind   = vigine::messaging::MessageKind::Signal;
-        keyFilter.typeId = kKeyDownPayloadTypeId;
-        if (auto token = deps.signalEmitter->subscribeSignal(keyFilter, subscriber))
-        {
-            deps.signalSubscriptions->push_back(std::move(token));
-        }
-    }
+    using vigine::core::threading::ThreadAffinity;
+    static_cast<void>(taskFlow->signal(runWindowId, processInputId,
+                                       kMouseButtonDownPayloadTypeId,
+                                       ThreadAffinity::Pool));
+    static_cast<void>(taskFlow->signal(runWindowId, processInputId,
+                                       kKeyDownPayloadTypeId,
+                                       ThreadAffinity::Pool));
 
     static_cast<void>(taskFlow->enqueue(initWindowId));
 
@@ -347,13 +322,9 @@ int main()
     // Bind a TaskFlow per state through the modern FSM-drive surface.
     // The signal-subscription token sink lives in main() because the
     // engine tears the FSM (and with it the flow that owns the
-    // ProcessInputEventTask subscriber) down before we drop these
-    // tokens at scope exit; cancelling the tokens after the
-    // subscriber has been destroyed would dereference dangling
-    // memory, so the token's RAII cancel must run with the
-    // subscriber still alive (the engine guarantees this through the
-    // ordering above).
-    SubscriptionTokenList signalSubscriptions{};
+    // Subscription tokens issued by taskFlow->signal are now owned by
+    // the flow itself (declared after _runnables in AbstractTaskFlow so
+    // they unwind first); the host no longer needs an external sink.
 
     InitFlowDeps initDeps{};
     initDeps.entityManager       = entityManager.get();
@@ -363,7 +334,6 @@ int main()
     initDeps.signalEmitter       = signalEmitter.get();
     initDeps.textEditState       = textEditState;
     initDeps.textEditorSystem    = textEditorSystem;
-    initDeps.signalSubscriptions = &signalSubscriptions;
 
     if (auto regResult = fsm.addStateTaskFlow(initState, createInitTaskFlow(initDeps));
         regResult.isError())

--- a/example/window/main.cpp
+++ b/example/window/main.cpp
@@ -104,79 +104,65 @@ std::unique_ptr<vigine::taskflow::ITaskFlow> createInitTaskFlow(const InitFlowDe
 
     auto taskFlow = vigine::taskflow::createTaskFlow();
 
-    auto initWindowOwned      = std::make_unique<InitWindowTask>();
+    // Construct + configure each runnable, then hand it to the flow
+    // through the single-call addTask(unique_ptr) overload that
+    // allocates the slot and binds the runnable atomically. The flow
+    // owns each runnable from this point on; the caller only retains
+    // the returned TaskId for use in the onResult routing and the
+    // taskFlow->signal subscription wiring below.
+
+    auto initWindowOwned = std::make_unique<InitWindowTask>();
     initWindowOwned->setEntityManager(deps.entityManager);
     initWindowOwned->setPlatformServiceId(deps.platformServiceId);
+    const TaskId initWindowId = taskFlow->addTask(std::move(initWindowOwned));
 
-    auto initVulkanOwned      = std::make_unique<InitVulkanTask>();
+    auto initVulkanOwned = std::make_unique<InitVulkanTask>();
     initVulkanOwned->setEntityManager(deps.entityManager);
     initVulkanOwned->setPlatformServiceId(deps.platformServiceId);
     initVulkanOwned->setGraphicsServiceId(deps.graphicsServiceId);
+    const TaskId initVulkanId = taskFlow->addTask(std::move(initVulkanOwned));
 
-    auto setupHelperOwned     = std::make_unique<SetupHelperGeometryTask>();
+    auto setupHelperOwned = std::make_unique<SetupHelperGeometryTask>();
     setupHelperOwned->setEntityManager(deps.entityManager);
     setupHelperOwned->setGraphicsServiceId(deps.graphicsServiceId);
+    const TaskId setupHelperId = taskFlow->addTask(std::move(setupHelperOwned));
 
-    auto setupCubeOwned       = std::make_unique<SetupCubeTask>();
+    auto setupCubeOwned = std::make_unique<SetupCubeTask>();
     setupCubeOwned->setEntityManager(deps.entityManager);
     setupCubeOwned->setGraphicsServiceId(deps.graphicsServiceId);
+    const TaskId setupCubeId = taskFlow->addTask(std::move(setupCubeOwned));
 
-    auto setupTextOwned       = std::make_unique<SetupTextTask>();
+    auto setupTextOwned = std::make_unique<SetupTextTask>();
     setupTextOwned->setEntityManager(deps.entityManager);
     setupTextOwned->setGraphicsServiceId(deps.graphicsServiceId);
+    const TaskId setupTextId = taskFlow->addTask(std::move(setupTextOwned));
 
-    auto loadTexturesOwned    = std::make_unique<LoadTexturesTask>();
+    auto loadTexturesOwned = std::make_unique<LoadTexturesTask>();
     loadTexturesOwned->setEntityManager(deps.entityManager);
     loadTexturesOwned->setGraphicsServiceId(deps.graphicsServiceId);
+    const TaskId loadTexturesId = taskFlow->addTask(std::move(loadTexturesOwned));
 
-    auto setupPlanesOwned     = std::make_unique<SetupTexturedPlanesTask>();
+    auto setupPlanesOwned = std::make_unique<SetupTexturedPlanesTask>();
     setupPlanesOwned->setEntityManager(deps.entityManager);
     setupPlanesOwned->setGraphicsServiceId(deps.graphicsServiceId);
+    const TaskId setupPlanesId = taskFlow->addTask(std::move(setupPlanesOwned));
 
-    auto setupTextEditOwned   = std::make_unique<SetupTextEditTask>(
-        deps.textEditState, deps.textEditorSystem);
+    auto setupTextEditOwned =
+        std::make_unique<SetupTextEditTask>(deps.textEditState, deps.textEditorSystem);
     setupTextEditOwned->setEntityManager(deps.entityManager);
     setupTextEditOwned->setGraphicsServiceId(deps.graphicsServiceId);
+    const TaskId setupTextEditId = taskFlow->addTask(std::move(setupTextEditOwned));
 
-    auto runWindowOwned       = std::make_unique<RunWindowTask>();
+    auto runWindowOwned = std::make_unique<RunWindowTask>();
     runWindowOwned->setEntityManager(deps.entityManager);
     runWindowOwned->setPlatformServiceId(deps.platformServiceId);
     runWindowOwned->setGraphicsServiceId(deps.graphicsServiceId);
     runWindowOwned->setEngine(deps.engine);
     runWindowOwned->setTextEditorSystem(deps.textEditorSystem);
     runWindowOwned->setSignalEmitter(deps.signalEmitter);
+    const TaskId runWindowId = taskFlow->addTask(std::move(runWindowOwned));
 
-    auto processInputOwned    = std::make_unique<ProcessInputEventTask>();
-
-    // Allocate a slot per task and bind the runnable to it. The modern
-    // ITaskFlow surface separates slot allocation (addTask returns a
-    // TaskId) from runnable attachment (attachTaskRun consumes the
-    // unique_ptr). We capture each TaskId for the onResult routing
-    // below and the ProcessInputEventTask raw pointer for the signal
-    // subscription so the bus can deliver to it after attach.
-    const TaskId initWindowId         = taskFlow->addTask();
-    const TaskId initVulkanId         = taskFlow->addTask();
-    const TaskId setupHelperId        = taskFlow->addTask();
-    const TaskId setupCubeId          = taskFlow->addTask();
-    const TaskId setupTextId          = taskFlow->addTask();
-    const TaskId loadTexturesId       = taskFlow->addTask();
-    const TaskId setupPlanesId        = taskFlow->addTask();
-    const TaskId setupTextEditId      = taskFlow->addTask();
-    const TaskId runWindowId          = taskFlow->addTask();
-    const TaskId processInputId       = taskFlow->addTask();
-
-    ProcessInputEventTask *processInputRaw = processInputOwned.get();
-
-    static_cast<void>(taskFlow->attachTaskRun(initWindowId, std::move(initWindowOwned)));
-    static_cast<void>(taskFlow->attachTaskRun(initVulkanId, std::move(initVulkanOwned)));
-    static_cast<void>(taskFlow->attachTaskRun(setupHelperId, std::move(setupHelperOwned)));
-    static_cast<void>(taskFlow->attachTaskRun(setupCubeId, std::move(setupCubeOwned)));
-    static_cast<void>(taskFlow->attachTaskRun(setupTextId, std::move(setupTextOwned)));
-    static_cast<void>(taskFlow->attachTaskRun(loadTexturesId, std::move(loadTexturesOwned)));
-    static_cast<void>(taskFlow->attachTaskRun(setupPlanesId, std::move(setupPlanesOwned)));
-    static_cast<void>(taskFlow->attachTaskRun(setupTextEditId, std::move(setupTextEditOwned)));
-    static_cast<void>(taskFlow->attachTaskRun(runWindowId, std::move(runWindowOwned)));
-    static_cast<void>(taskFlow->attachTaskRun(processInputId, std::move(processInputOwned)));
+    const TaskId processInputId = taskFlow->addTask(std::make_unique<ProcessInputEventTask>());
 
     static_cast<void>(taskFlow->onResult(initWindowId, ResultCode::Success, initVulkanId));
     static_cast<void>(taskFlow->onResult(initVulkanId, ResultCode::Success, setupHelperId));
@@ -191,8 +177,7 @@ std::unique_ptr<vigine::taskflow::ITaskFlow> createInitTaskFlow(const InitFlowDe
     // can subscribe target tasks against it. The flow owns the resulting
     // subscription tokens and unwinds them at destruction in reverse-
     // registration order, before the underlying ProcessInputEventTask
-    // (registered above through attachTaskRun) is destroyed.
-    static_cast<void>(processInputRaw); // raw pointer no longer needed for direct subscribe
+    // (registered above through addTask) is destroyed.
     taskFlow->setSignalEmitter(deps.signalEmitter);
 
     using vigine::core::threading::ThreadAffinity;
@@ -203,7 +188,7 @@ std::unique_ptr<vigine::taskflow::ITaskFlow> createInitTaskFlow(const InitFlowDe
                                        kKeyDownPayloadTypeId,
                                        ThreadAffinity::Pool));
 
-    static_cast<void>(taskFlow->enqueue(initWindowId));
+    static_cast<void>(taskFlow->setRoot(initWindowId));
 
     return taskFlow;
 }
@@ -212,10 +197,9 @@ std::unique_ptr<vigine::taskflow::ITaskFlow> createWorkTaskFlow()
 {
     auto taskFlow = vigine::taskflow::createTaskFlow();
 
-    const vigine::taskflow::TaskId renderCubeId = taskFlow->addTask();
-    static_cast<void>(taskFlow->attachTaskRun(renderCubeId,
-                                              std::make_unique<RenderCubeTask>()));
-    static_cast<void>(taskFlow->enqueue(renderCubeId));
+    const vigine::taskflow::TaskId renderCubeId =
+        taskFlow->addTask(std::make_unique<RenderCubeTask>());
+    static_cast<void>(taskFlow->setRoot(renderCubeId));
 
     return taskFlow;
 }

--- a/example/window/main.cpp
+++ b/example/window/main.cpp
@@ -78,14 +78,14 @@ std::unique_ptr<vigine::taskflow::ITaskFlow> createInitTaskFlow()
     const TaskId runWindowId     = taskFlow->addTask(std::make_unique<RunWindowTask>());
     const TaskId processInputId  = taskFlow->addTask(std::make_unique<ProcessInputEventTask>());
 
-    static_cast<void>(taskFlow->onResult(initWindowId, ResultCode::Success, initVulkanId));
-    static_cast<void>(taskFlow->onResult(initVulkanId, ResultCode::Success, setupHelperId));
-    static_cast<void>(taskFlow->onResult(setupHelperId, ResultCode::Success, setupCubeId));
-    static_cast<void>(taskFlow->onResult(setupCubeId, ResultCode::Success, setupTextId));
-    static_cast<void>(taskFlow->onResult(setupTextId, ResultCode::Success, loadTexturesId));
-    static_cast<void>(taskFlow->onResult(loadTexturesId, ResultCode::Success, setupPlanesId));
-    static_cast<void>(taskFlow->onResult(setupPlanesId, ResultCode::Success, setupTextEditId));
-    static_cast<void>(taskFlow->onResult(setupTextEditId, ResultCode::Success, runWindowId));
+    static_cast<void>(taskFlow->route(initWindowId, ResultCode::Success, initVulkanId));
+    static_cast<void>(taskFlow->route(initVulkanId, ResultCode::Success, setupHelperId));
+    static_cast<void>(taskFlow->route(setupHelperId, ResultCode::Success, setupCubeId));
+    static_cast<void>(taskFlow->route(setupCubeId, ResultCode::Success, setupTextId));
+    static_cast<void>(taskFlow->route(setupTextId, ResultCode::Success, loadTexturesId));
+    static_cast<void>(taskFlow->route(loadTexturesId, ResultCode::Success, setupPlanesId));
+    static_cast<void>(taskFlow->route(setupPlanesId, ResultCode::Success, setupTextEditId));
+    static_cast<void>(taskFlow->route(setupTextEditId, ResultCode::Success, runWindowId));
 
     using vigine::core::threading::ThreadAffinity;
     static_cast<void>(taskFlow->signal(runWindowId, processInputId,

--- a/example/window/main.cpp
+++ b/example/window/main.cpp
@@ -78,14 +78,14 @@ std::unique_ptr<vigine::taskflow::ITaskFlow> createInitTaskFlow()
     const TaskId runWindowId     = taskFlow->addTask(std::make_unique<RunWindowTask>());
     const TaskId processInputId  = taskFlow->addTask(std::make_unique<ProcessInputEventTask>());
 
-    static_cast<void>(taskFlow->route(initWindowId, ResultCode::Success, initVulkanId));
-    static_cast<void>(taskFlow->route(initVulkanId, ResultCode::Success, setupHelperId));
-    static_cast<void>(taskFlow->route(setupHelperId, ResultCode::Success, setupCubeId));
-    static_cast<void>(taskFlow->route(setupCubeId, ResultCode::Success, setupTextId));
-    static_cast<void>(taskFlow->route(setupTextId, ResultCode::Success, loadTexturesId));
-    static_cast<void>(taskFlow->route(loadTexturesId, ResultCode::Success, setupPlanesId));
-    static_cast<void>(taskFlow->route(setupPlanesId, ResultCode::Success, setupTextEditId));
-    static_cast<void>(taskFlow->route(setupTextEditId, ResultCode::Success, runWindowId));
+    static_cast<void>(taskFlow->route(initWindowId,    initVulkanId));
+    static_cast<void>(taskFlow->route(initVulkanId,    setupHelperId));
+    static_cast<void>(taskFlow->route(setupHelperId,   setupCubeId));
+    static_cast<void>(taskFlow->route(setupCubeId,     setupTextId));
+    static_cast<void>(taskFlow->route(setupTextId,     loadTexturesId));
+    static_cast<void>(taskFlow->route(loadTexturesId,  setupPlanesId));
+    static_cast<void>(taskFlow->route(setupPlanesId,   setupTextEditId));
+    static_cast<void>(taskFlow->route(setupTextEditId, runWindowId));
 
     using vigine::core::threading::ThreadAffinity;
     static_cast<void>(taskFlow->signal(runWindowId, processInputId,

--- a/example/window/main.cpp
+++ b/example/window/main.cpp
@@ -1,70 +1,41 @@
 // example-window
 //
-// Drives the modern FSM-pumped engine through a four-state machine
-// (Init -> Work -> Close, with Error as the failure off-ramp). Each state
-// owns a TaskFlow registered through @c IStateMachine::addStateTaskFlow;
-// the engine pump advances the active state's flow one task per tick and
-// drains queued FSM transitions on the controller thread.
+// Demonstrates the modern FSM-pumped engine where IContext is the
+// self-sufficient task execution environment. The engine builds every
+// default (entity manager, signal emitter, platform / graphics services)
+// during context construction so a host program only has to:
+//   1. createEngine() to spin up the context aggregator + the lifecycle
+//      primitives;
+//   2. Register any application-scope services (the example registers
+//      its TextEditorService under example::services::wellknown::textEditor);
+//   3. Allocate FSM states and bind a TaskFlow per state — the tasks
+//      themselves resolve every dependency through @c apiToken() in
+//      their run() method, so no setters are threaded through the wiring
+//      path.
 //
-// Modern wiring overview:
-//   1. Build the engine via @c vigine::engine::createEngine. The engine
-//      owns the @c IContext aggregator (thread manager + system bus +
-//      Level-1 wrappers).
-//   2. Build the legacy @c EntityManager + the platform / graphics
-//      subsystems (RenderSystem, WindowSystem). The legacy substrate
-//      stays here because the modern @c IECS handle still uses
-//      EntityId-typed entries while the rendering pipeline below expects
-//      legacy @c Entity* handles.
-//   3. Build the platform / graphics services on the modern
-//      @c vigine::service::AbstractService base, attach their underlying
-//      systems through @c setRenderSystem / @c setWindowSystem, and
-//      register them on the engine context. The aggregator stamps a
-//      generational @c ServiceId on each registration; the example
-//      captures the stamped ids on the wrappers and hands them to every
-//      task that needs the service.
-//   4. Build the user-bus signal emitter against the engine-owned thread
-//      manager so input events fan out off the platform message-pump
-//      thread.
-//   5. Allocate four FSM states, build a TaskFlow per state (init flow
-//      drives the Vulkan boot path + window pump; work flow ticks the
-//      cube; close / error flows are no-ops), and register each via
-//      @c addStateTaskFlow.
-//   6. Wire transitions, install one state-bound TaskFlow per state, set
-//      the initial state, and call @c IEngine::run.
+// Applications that need different concrete platform / graphics
+// implementations replace the engine defaults via
+// IContext::registerService(myService, vigine::service::wellknown::*);
+// the unique_ptr / shared_ptr slot's RAII chain destroys the prior
+// occupant in place.
 
-#include "texteditstate.h"
-
+#include <vigine/api/context/icontext.h>
 #include <vigine/api/engine/engineconfig.h>
 #include <vigine/api/engine/factory.h>
 #include <vigine/api/engine/iengine.h>
-#include <vigine/api/context/icontext.h>
-#include <vigine/api/messaging/factory.h>
-#include <vigine/api/messaging/isignalemitter.h>
-#include <vigine/api/messaging/isubscriber.h>
-#include <vigine/api/messaging/isubscriptiontoken.h>
-#include <vigine/api/messaging/messagefilter.h>
-#include <vigine/api/messaging/messagekind.h>
 #include <vigine/api/messaging/payload/factory.h>
 #include <vigine/api/messaging/payload/ipayloadregistry.h>
 #include <vigine/api/messaging/payload/payloadtypeid.h>
-#include <vigine/api/service/serviceid.h>
 #include <vigine/api/statemachine/istatemachine.h>
 #include <vigine/api/statemachine/stateid.h>
 #include <vigine/api/taskflow/factory.h>
 #include <vigine/api/taskflow/itaskflow.h>
 #include <vigine/api/taskflow/resultcode.h>
 #include <vigine/api/taskflow/taskid.h>
-#include <vigine/core/threading/ithreadmanager.h>
-#include <vigine/core/threading/threadaffinity.h>
-#include <vigine/impl/ecs/entitymanager.h>
-#include <vigine/impl/ecs/graphics/graphicsservice.h>
-#include <vigine/impl/ecs/graphics/rendersystem.h>
-#include <vigine/impl/ecs/platform/platformservice.h>
-#include <vigine/impl/ecs/platform/windowsystem.h>
-#include <vigine/impl/messaging/signalemitter.h>
 #include <vigine/result.h>
 
-#include "system/texteditorsystem.h"
+#include "services/texteditorservice.h"
+#include "services/wellknown.h"
 #include "task/vulkan/initvulkantask.h"
 #include "task/vulkan/loadtexturestask.h"
 #include "task/vulkan/rendercubetask.h"
@@ -81,88 +52,31 @@
 #include <iostream>
 #include <memory>
 #include <utility>
-#include <vector>
 
 namespace
 {
 
-struct InitFlowDeps
-{
-    vigine::EntityManager *entityManager{nullptr};
-    vigine::service::ServiceId platformServiceId{};
-    vigine::service::ServiceId graphicsServiceId{};
-    vigine::engine::IEngine *engine{nullptr};
-    vigine::messaging::ISignalEmitter *signalEmitter{nullptr};
-    std::shared_ptr<TextEditState> textEditState{};
-    std::shared_ptr<TextEditorSystem> textEditorSystem{};
-};
-
-std::unique_ptr<vigine::taskflow::ITaskFlow> createInitTaskFlow(const InitFlowDeps &deps)
+std::unique_ptr<vigine::taskflow::ITaskFlow> createInitTaskFlow()
 {
     using vigine::taskflow::ResultCode;
     using vigine::taskflow::TaskId;
 
     auto taskFlow = vigine::taskflow::createTaskFlow();
 
-    // Construct + configure each runnable, then hand it to the flow
-    // through the single-call addTask(unique_ptr) overload that
-    // allocates the slot and binds the runnable atomically. The flow
-    // owns each runnable from this point on; the caller only retains
-    // the returned TaskId for use in the onResult routing and the
-    // taskFlow->signal subscription wiring below.
-
-    auto initWindowOwned = std::make_unique<InitWindowTask>();
-    initWindowOwned->setEntityManager(deps.entityManager);
-    initWindowOwned->setPlatformServiceId(deps.platformServiceId);
-    const TaskId initWindowId = taskFlow->addTask(std::move(initWindowOwned));
-
-    auto initVulkanOwned = std::make_unique<InitVulkanTask>();
-    initVulkanOwned->setEntityManager(deps.entityManager);
-    initVulkanOwned->setPlatformServiceId(deps.platformServiceId);
-    initVulkanOwned->setGraphicsServiceId(deps.graphicsServiceId);
-    const TaskId initVulkanId = taskFlow->addTask(std::move(initVulkanOwned));
-
-    auto setupHelperOwned = std::make_unique<SetupHelperGeometryTask>();
-    setupHelperOwned->setEntityManager(deps.entityManager);
-    setupHelperOwned->setGraphicsServiceId(deps.graphicsServiceId);
-    const TaskId setupHelperId = taskFlow->addTask(std::move(setupHelperOwned));
-
-    auto setupCubeOwned = std::make_unique<SetupCubeTask>();
-    setupCubeOwned->setEntityManager(deps.entityManager);
-    setupCubeOwned->setGraphicsServiceId(deps.graphicsServiceId);
-    const TaskId setupCubeId = taskFlow->addTask(std::move(setupCubeOwned));
-
-    auto setupTextOwned = std::make_unique<SetupTextTask>();
-    setupTextOwned->setEntityManager(deps.entityManager);
-    setupTextOwned->setGraphicsServiceId(deps.graphicsServiceId);
-    const TaskId setupTextId = taskFlow->addTask(std::move(setupTextOwned));
-
-    auto loadTexturesOwned = std::make_unique<LoadTexturesTask>();
-    loadTexturesOwned->setEntityManager(deps.entityManager);
-    loadTexturesOwned->setGraphicsServiceId(deps.graphicsServiceId);
-    const TaskId loadTexturesId = taskFlow->addTask(std::move(loadTexturesOwned));
-
-    auto setupPlanesOwned = std::make_unique<SetupTexturedPlanesTask>();
-    setupPlanesOwned->setEntityManager(deps.entityManager);
-    setupPlanesOwned->setGraphicsServiceId(deps.graphicsServiceId);
-    const TaskId setupPlanesId = taskFlow->addTask(std::move(setupPlanesOwned));
-
-    auto setupTextEditOwned =
-        std::make_unique<SetupTextEditTask>(deps.textEditState, deps.textEditorSystem);
-    setupTextEditOwned->setEntityManager(deps.entityManager);
-    setupTextEditOwned->setGraphicsServiceId(deps.graphicsServiceId);
-    const TaskId setupTextEditId = taskFlow->addTask(std::move(setupTextEditOwned));
-
-    auto runWindowOwned = std::make_unique<RunWindowTask>();
-    runWindowOwned->setEntityManager(deps.entityManager);
-    runWindowOwned->setPlatformServiceId(deps.platformServiceId);
-    runWindowOwned->setGraphicsServiceId(deps.graphicsServiceId);
-    runWindowOwned->setEngine(deps.engine);
-    runWindowOwned->setTextEditorSystem(deps.textEditorSystem);
-    runWindowOwned->setSignalEmitter(deps.signalEmitter);
-    const TaskId runWindowId = taskFlow->addTask(std::move(runWindowOwned));
-
-    const TaskId processInputId = taskFlow->addTask(std::make_unique<ProcessInputEventTask>());
+    // Each runnable resolves every dependency through its own apiToken()
+    // inside run(); no setters are threaded through here. The flow
+    // therefore receives default-constructed unique_ptrs and only owns
+    // the runnables thereafter.
+    const TaskId initWindowId    = taskFlow->addTask(std::make_unique<InitWindowTask>());
+    const TaskId initVulkanId    = taskFlow->addTask(std::make_unique<InitVulkanTask>());
+    const TaskId setupHelperId   = taskFlow->addTask(std::make_unique<SetupHelperGeometryTask>());
+    const TaskId setupCubeId     = taskFlow->addTask(std::make_unique<SetupCubeTask>());
+    const TaskId setupTextId     = taskFlow->addTask(std::make_unique<SetupTextTask>());
+    const TaskId loadTexturesId  = taskFlow->addTask(std::make_unique<LoadTexturesTask>());
+    const TaskId setupPlanesId   = taskFlow->addTask(std::make_unique<SetupTexturedPlanesTask>());
+    const TaskId setupTextEditId = taskFlow->addTask(std::make_unique<SetupTextEditTask>());
+    const TaskId runWindowId     = taskFlow->addTask(std::make_unique<RunWindowTask>());
+    const TaskId processInputId  = taskFlow->addTask(std::make_unique<ProcessInputEventTask>());
 
     static_cast<void>(taskFlow->onResult(initWindowId, ResultCode::Success, initVulkanId));
     static_cast<void>(taskFlow->onResult(initVulkanId, ResultCode::Success, setupHelperId));
@@ -172,13 +86,6 @@ std::unique_ptr<vigine::taskflow::ITaskFlow> createInitTaskFlow(const InitFlowDe
     static_cast<void>(taskFlow->onResult(loadTexturesId, ResultCode::Success, setupPlanesId));
     static_cast<void>(taskFlow->onResult(setupPlanesId, ResultCode::Success, setupTextEditId));
     static_cast<void>(taskFlow->onResult(setupTextEditId, ResultCode::Success, runWindowId));
-
-    // Wire the host-built signal emitter into the flow so taskFlow->signal
-    // can subscribe target tasks against it. The flow owns the resulting
-    // subscription tokens and unwinds them at destruction in reverse-
-    // registration order, before the underlying ProcessInputEventTask
-    // (registered above through addTask) is destroyed.
-    taskFlow->setSignalEmitter(deps.signalEmitter);
 
     using vigine::core::threading::ThreadAffinity;
     static_cast<void>(taskFlow->signal(runWindowId, processInputId,
@@ -218,9 +125,6 @@ std::unique_ptr<vigine::taskflow::ITaskFlow> createCloseTaskFlow()
 
 int main()
 {
-    // Modern engine. Owns the IContext aggregator with thread manager,
-    // system bus, IECS / IStateMachine / ITaskFlow Level-1 wrappers, and
-    // the service registry.
     auto engine = vigine::engine::createEngine();
     if (!engine)
     {
@@ -228,69 +132,33 @@ int main()
         return 1;
     }
 
-    auto &context  = engine->context();
-    auto &fsm      = context.stateMachine();
+    auto &context = engine->context();
+    auto &fsm     = context.stateMachine();
 
-    // Legacy substrate the rendering / window pipeline still needs
-    // (RenderSystem + WindowSystem keep using @c Entity* handles).
-    auto entityManager = std::make_unique<vigine::EntityManager>();
-    auto windowSystem  = std::make_unique<vigine::ecs::platform::WindowSystem>("MainWindow");
-    auto renderSystem  = std::make_unique<vigine::ecs::graphics::RenderSystem>("MainRender");
-
-    // Modern services. Each derives from
-    // @c vigine::service::AbstractService and exposes its underlying
-    // legacy system through a setter; the example wires the systems in
-    // before registration so the stamped ServiceId is the only handle
-    // tasks need to reach the wrappers.
-    auto platformService =
-        std::make_shared<vigine::ecs::platform::PlatformService>(vigine::Name("MainPlatform"));
-    platformService->setWindowSystem(windowSystem.get());
-
-    auto graphicsService =
-        std::make_shared<vigine::ecs::graphics::GraphicsService>(vigine::Name("MainGraphics"));
-    graphicsService->setRenderSystem(renderSystem.get());
-
-    if (auto regResult = context.registerService(platformService); regResult.isError())
+    // Application-scope service registration. The engine already has
+    // defaults for platform / graphics services + entity manager +
+    // signal emitter; the example only needs to add its own text
+    // editor service under an app-side well-known id.
+    if (auto regResult = context.registerService(
+            std::make_shared<TextEditorService>(),
+            example::services::wellknown::textEditor);
+        regResult.isError())
     {
-        std::cerr << "[example-window] failed to register PlatformService: "
+        std::cerr << "[example-window] failed to register TextEditorService: "
                   << regResult.message() << std::endl;
         return 1;
     }
-    if (auto regResult = context.registerService(graphicsService); regResult.isError())
-    {
-        std::cerr << "[example-window] failed to register GraphicsService: "
-                  << regResult.message() << std::endl;
-        return 1;
-    }
-
-    const vigine::service::ServiceId platformServiceId = platformService->id();
-    const vigine::service::ServiceId graphicsServiceId = graphicsService->id();
 
     // Payload registry for the user-range payload ids used by the
     // window input pipeline. Engine-bundled ranges (Control, System,
     // SystemExt, Reserved) are pre-registered by the factory.
-    auto payloadRegistry  = vigine::payload::createPayloadRegistry();
+    auto payloadRegistry = vigine::payload::createPayloadRegistry();
     static_cast<void>(payloadRegistry->registerRange(
         kMouseButtonDownPayloadTypeId, kMouseButtonDownPayloadTypeId,
         "example-window.mouse"));
     static_cast<void>(payloadRegistry->registerRange(
         kKeyDownPayloadTypeId, kKeyDownPayloadTypeId,
         "example-window.key"));
-
-    // Shared-pool signal emitter so dispatch lands on a pool worker, off
-    // the Win32 message-pump thread. Built against the engine-owned
-    // thread manager so the bus shares one worker pool across the whole
-    // example.
-    auto signalEmitter = vigine::messaging::createSignalEmitter(
-        context.threadManager(), vigine::messaging::sharedBusConfig());
-    if (!signalEmitter)
-    {
-        std::cerr << "[example-window] createSignalEmitter returned null" << std::endl;
-        return 1;
-    }
-
-    auto textEditState    = std::make_shared<TextEditState>();
-    auto textEditorSystem = std::make_shared<TextEditorSystem>(textEditState);
 
     // FSM states: Init -> Work -> Close, Error as the failure off-ramp.
     // Reuse the FSM's auto-provisioned default state as InitState so
@@ -303,23 +171,7 @@ int main()
     const vigine::statemachine::StateId errorState = fsm.addState();
     const vigine::statemachine::StateId closeState = fsm.addState();
 
-    // Bind a TaskFlow per state through the modern FSM-drive surface.
-    // The signal-subscription token sink lives in main() because the
-    // engine tears the FSM (and with it the flow that owns the
-    // Subscription tokens issued by taskFlow->signal are now owned by
-    // the flow itself (declared after _runnables in AbstractTaskFlow so
-    // they unwind first); the host no longer needs an external sink.
-
-    InitFlowDeps initDeps{};
-    initDeps.entityManager       = entityManager.get();
-    initDeps.platformServiceId   = platformServiceId;
-    initDeps.graphicsServiceId   = graphicsServiceId;
-    initDeps.engine              = engine.get();
-    initDeps.signalEmitter       = signalEmitter.get();
-    initDeps.textEditState       = textEditState;
-    initDeps.textEditorSystem    = textEditorSystem;
-
-    if (auto regResult = fsm.addStateTaskFlow(initState, createInitTaskFlow(initDeps));
+    if (auto regResult = fsm.addStateTaskFlow(initState, createInitTaskFlow());
         regResult.isError())
     {
         std::cerr << "[example-window] addStateTaskFlow(init) failed: "

--- a/example/window/services/texteditorservice.cpp
+++ b/example/window/services/texteditorservice.cpp
@@ -25,21 +25,11 @@ void TextEditorService::ensureWired(vigine::IContext &context)
     if (_wired)
         return;
 
-    // EntityManager comes from the engine-default slot; the concrete
-    // is the legacy @c vigine::EntityManager so the dynamic_cast is
-    // expected to succeed for the default path. A future override
-    // installed via @c IContext::setEntityManager that supplies a
-    // non-EntityManager implementation will fail this cast and leave
-    // the wired flag clear; the service's own getters still hand back
-    // live handles so the example can still read state, but the
-    // @c TextEditorSystem stays unbound until the override matches
-    // the legacy concrete.
     auto *entityManager = dynamic_cast<vigine::EntityManager *>(&context.entityManager());
     if (entityManager == nullptr)
         return;
 
-    auto graphicsService =
-        context.service(vigine::service::wellknown::graphicsService);
+    auto graphicsService = context.service(vigine::service::wellknown::graphicsService);
     if (!graphicsService)
         return;
 
@@ -56,6 +46,11 @@ void TextEditorService::ensureWired(vigine::IContext &context)
     _wired = true;
 }
 
+void TextEditorService::bindInteractionEntity(vigine::Entity *entity)
+{
+    static_cast<void>(_system->bindInteractionEntity(entity));
+}
+
 std::shared_ptr<TextEditState> TextEditorService::state() const noexcept
 {
     return _state;
@@ -64,4 +59,51 @@ std::shared_ptr<TextEditState> TextEditorService::state() const noexcept
 std::shared_ptr<TextEditorSystem> TextEditorService::textEditorSystem() const noexcept
 {
     return _system;
+}
+
+// ---- Window-event router (forwards to TextEditorSystem::route*) ----------
+
+void TextEditorService::onMouseButtonDown(vigine::ecs::platform::MouseButton button, int x, int y)
+{
+    _system->routeMouseButtonDown(button, x, y);
+}
+
+void TextEditorService::onMouseButtonUp(vigine::ecs::platform::MouseButton button, int x, int y)
+{
+    _system->routeMouseButtonUp(button, x, y);
+}
+
+void TextEditorService::onMouseMove(int x, int y)
+{
+    _system->routeMouseMove(x, y);
+}
+
+void TextEditorService::onMouseWheel(int delta, int x, int y)
+{
+    _system->routeMouseWheel(delta, x, y);
+}
+
+void TextEditorService::onKeyDown(const vigine::ecs::platform::KeyEvent &event)
+{
+    _system->routeKeyDown(event);
+}
+
+void TextEditorService::onKeyUp(const vigine::ecs::platform::KeyEvent &event)
+{
+    _system->routeKeyUp(event);
+}
+
+void TextEditorService::onChar(const vigine::ecs::platform::TextEvent &event)
+{
+    _system->routeChar(event);
+}
+
+void TextEditorService::onWindowResized(int width, int height)
+{
+    _system->routeWindowResized(width, height);
+}
+
+void TextEditorService::onFrame()
+{
+    _system->onFrame();
 }

--- a/example/window/services/texteditorservice.cpp
+++ b/example/window/services/texteditorservice.cpp
@@ -61,7 +61,7 @@ std::shared_ptr<TextEditState> TextEditorService::state() const noexcept
     return _state;
 }
 
-std::shared_ptr<TextEditorSystem> TextEditorService::system() const noexcept
+std::shared_ptr<TextEditorSystem> TextEditorService::textEditorSystem() const noexcept
 {
     return _system;
 }

--- a/example/window/services/texteditorservice.cpp
+++ b/example/window/services/texteditorservice.cpp
@@ -1,0 +1,67 @@
+#include "texteditorservice.h"
+
+#include <vigine/api/context/icontext.h>
+#include <vigine/api/ecs/ientitymanager.h>
+#include <vigine/api/service/iservice.h>
+#include <vigine/api/service/wellknown.h>
+#include <vigine/impl/ecs/entitymanager.h>
+#include <vigine/impl/ecs/graphics/graphicsservice.h>
+#include <vigine/impl/ecs/graphics/rendersystem.h>
+
+#include "../system/texteditorsystem.h"
+#include "../texteditstate.h"
+
+TextEditorService::TextEditorService()
+    : vigine::service::AbstractService()
+    , _state{std::make_shared<TextEditState>()}
+    , _system{std::make_shared<TextEditorSystem>(_state)}
+{
+}
+
+TextEditorService::~TextEditorService() = default;
+
+void TextEditorService::ensureWired(vigine::IContext &context)
+{
+    if (_wired)
+        return;
+
+    // EntityManager comes from the engine-default slot; the concrete
+    // is the legacy @c vigine::EntityManager so the dynamic_cast is
+    // expected to succeed for the default path. A future override
+    // installed via @c IContext::setEntityManager that supplies a
+    // non-EntityManager implementation will fail this cast and leave
+    // the wired flag clear; the service's own getters still hand back
+    // live handles so the example can still read state, but the
+    // @c TextEditorSystem stays unbound until the override matches
+    // the legacy concrete.
+    auto *entityManager = dynamic_cast<vigine::EntityManager *>(&context.entityManager());
+    if (entityManager == nullptr)
+        return;
+
+    auto graphicsService =
+        context.service(vigine::service::wellknown::graphicsService);
+    if (!graphicsService)
+        return;
+
+    auto *graphics =
+        dynamic_cast<vigine::ecs::graphics::GraphicsService *>(graphicsService.get());
+    if (graphics == nullptr)
+        return;
+
+    auto *renderSystem = graphics->renderSystem();
+    if (renderSystem == nullptr)
+        return;
+
+    _system->bind(entityManager, graphics, renderSystem);
+    _wired = true;
+}
+
+std::shared_ptr<TextEditState> TextEditorService::state() const noexcept
+{
+    return _state;
+}
+
+std::shared_ptr<TextEditorSystem> TextEditorService::system() const noexcept
+{
+    return _system;
+}

--- a/example/window/services/texteditorservice.h
+++ b/example/window/services/texteditorservice.h
@@ -1,11 +1,13 @@
 #pragma once
 
+#include <vigine/api/ecs/platform/iwindoweventhandler.h>
 #include <vigine/api/service/abstractservice.h>
 
 #include <memory>
 
 namespace vigine
 {
+class Entity;
 class IContext;
 } // namespace vigine
 
@@ -14,13 +16,17 @@ class TextEditorSystem;
 
 /**
  * @brief App-scope service that owns the example's text-editor state
- *        and system pair.
+ *        and system pair AND fronts every window-event hook the editor
+ *        window needs.
  *
- * @ref TextEditorService wraps @c TextEditState and @c TextEditorSystem
- * (the example's UTF-8 buffer + input router) into a single
- * @ref vigine::service::IService so every editor-touching task
+ * The service wraps @c TextEditState and @c TextEditorSystem (the
+ * example's UTF-8 buffer + input router) so every editor-touching task
  * resolves them through @c apiToken()->service(...) instead of through
- * a chain of setters threaded through the task wiring.
+ * a chain of setters threaded through the task wiring. The window
+ * event router methods (@ref onMouseButtonDown, @ref onMouseMove,
+ * @ref onKeyDown, ...) forward verbatim to the underlying
+ * @c TextEditorSystem so @c RunWindowTask can stay state-free and
+ * push every callback through this facade.
  *
  * Registration:
  * @code
@@ -34,14 +40,13 @@ class TextEditorSystem;
  *   if (!svc.ok()) return Error("text editor service unavailable");
  *   auto* tes = dynamic_cast<TextEditorService*>(&svc.value());
  *   tes->ensureWired(apiToken()->engine().context());
- *   auto editorSystem = tes->textEditorSystem();
+ *   tes->onMouseMove(x, y);  // → routed to TextEditorSystem::routeMouseMove
  * @endcode
  *
- * Wiring: the underlying @c TextEditorSystem needs a one-time
- * binding to the engine's entity manager + graphics service /
- * render system. @ref ensureWired performs that binding the first
- * time it is called and is idempotent on every subsequent call so
- * tasks can invoke it unconditionally without bookkeeping.
+ * Wiring: the underlying @c TextEditorSystem needs a one-time binding
+ * to the engine's entity manager + graphics service / render system.
+ * @ref ensureWired performs that binding the first time it is called
+ * and is idempotent so callers can invoke it unconditionally.
  *
  * Ownership: the service owns the @c TextEditState and
  * @c TextEditorSystem instances through @c std::shared_ptr so callers
@@ -59,18 +64,43 @@ class TextEditorService final : public vigine::service::AbstractService
      * @brief Idempotent one-shot wiring of the underlying
      *        @c TextEditorSystem to the engine's entity manager and
      *        graphics service / render system.
-     *
-     * The first call performs the lookup through @p context and
-     * binds the system. Subsequent calls are no-ops. A bind failure
-     * (entity manager has unexpected type, graphics service is
-     * unavailable, render system pointer is null) leaves the wired
-     * flag clear so a later call retries; the contract is "best
-     * effort, idempotent on success".
      */
     void ensureWired(vigine::IContext &context);
 
+    /**
+     * @brief Registers a fresh @ref TextEditorComponent against
+     *        @p entity through @c TextEditorSystem::bindInteractionEntity.
+     *
+     * The example calls this once from @c SetupTextEditTask for the
+     * @c MainWindow entity right after the editor visuals are built;
+     * subsequent calls re-bind (or refresh) the component for the
+     * given entity. Forwarded verbatim so callers do not need to
+     * reach into the system.
+     */
+    void bindInteractionEntity(vigine::Entity *entity);
+
     [[nodiscard]] std::shared_ptr<TextEditState>    state() const noexcept;
     [[nodiscard]] std::shared_ptr<TextEditorSystem> textEditorSystem() const noexcept;
+
+    // ---- Window-event router (forwards to TextEditorSystem::route*) ----
+
+    void onMouseButtonDown(vigine::ecs::platform::MouseButton button, int x, int y);
+    void onMouseButtonUp(vigine::ecs::platform::MouseButton button, int x, int y);
+    void onMouseMove(int x, int y);
+    void onMouseWheel(int delta, int x, int y);
+    void onKeyDown(const vigine::ecs::platform::KeyEvent &event);
+    void onKeyUp(const vigine::ecs::platform::KeyEvent &event);
+    void onChar(const vigine::ecs::platform::TextEvent &event);
+    void onWindowResized(int width, int height);
+
+    /**
+     * @brief Per-frame editor tick.
+     *
+     * Forwards to @c TextEditorSystem::onFrame which drives the cursor
+     * blink, applies any pending swapchain resize debounced by 80 ms,
+     * and rebuilds the editor mesh when the buffer is dirty.
+     */
+    void onFrame();
 
   private:
     std::shared_ptr<TextEditState>    _state;

--- a/example/window/services/texteditorservice.h
+++ b/example/window/services/texteditorservice.h
@@ -34,7 +34,7 @@ class TextEditorSystem;
  *   if (!svc.ok()) return Error("text editor service unavailable");
  *   auto* tes = dynamic_cast<TextEditorService*>(&svc.value());
  *   tes->ensureWired(apiToken()->engine().context());
- *   auto editorSystem = tes->system();
+ *   auto editorSystem = tes->textEditorSystem();
  * @endcode
  *
  * Wiring: the underlying @c TextEditorSystem needs a one-time
@@ -70,7 +70,7 @@ class TextEditorService final : public vigine::service::AbstractService
     void ensureWired(vigine::IContext &context);
 
     [[nodiscard]] std::shared_ptr<TextEditState>    state() const noexcept;
-    [[nodiscard]] std::shared_ptr<TextEditorSystem> system() const noexcept;
+    [[nodiscard]] std::shared_ptr<TextEditorSystem> textEditorSystem() const noexcept;
 
   private:
     std::shared_ptr<TextEditState>    _state;

--- a/example/window/services/texteditorservice.h
+++ b/example/window/services/texteditorservice.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <vigine/api/service/abstractservice.h>
+
+#include <memory>
+
+namespace vigine
+{
+class IContext;
+} // namespace vigine
+
+struct TextEditState;
+class TextEditorSystem;
+
+/**
+ * @brief App-scope service that owns the example's text-editor state
+ *        and system pair.
+ *
+ * @ref TextEditorService wraps @c TextEditState and @c TextEditorSystem
+ * (the example's UTF-8 buffer + input router) into a single
+ * @ref vigine::service::IService so every editor-touching task
+ * resolves them through @c apiToken()->service(...) instead of through
+ * a chain of setters threaded through the task wiring.
+ *
+ * Registration:
+ * @code
+ *   context.registerService(std::make_shared<TextEditorService>(),
+ *                           example::services::wellknown::textEditor);
+ * @endcode
+ *
+ * Resolution from a task:
+ * @code
+ *   auto svc = apiToken()->service(example::services::wellknown::textEditor);
+ *   if (!svc.ok()) return Error("text editor service unavailable");
+ *   auto* tes = dynamic_cast<TextEditorService*>(&svc.value());
+ *   tes->ensureWired(apiToken()->engine().context());
+ *   auto editorSystem = tes->system();
+ * @endcode
+ *
+ * Wiring: the underlying @c TextEditorSystem needs a one-time
+ * binding to the engine's entity manager + graphics service /
+ * render system. @ref ensureWired performs that binding the first
+ * time it is called and is idempotent on every subsequent call so
+ * tasks can invoke it unconditionally without bookkeeping.
+ *
+ * Ownership: the service owns the @c TextEditState and
+ * @c TextEditorSystem instances through @c std::shared_ptr so callers
+ * that want to keep a handle past the service's own lifetime may copy
+ * the pointer aside. Both objects live for the service's lifetime
+ * inside the registry.
+ */
+class TextEditorService final : public vigine::service::AbstractService
+{
+  public:
+    TextEditorService();
+    ~TextEditorService() override;
+
+    /**
+     * @brief Idempotent one-shot wiring of the underlying
+     *        @c TextEditorSystem to the engine's entity manager and
+     *        graphics service / render system.
+     *
+     * The first call performs the lookup through @p context and
+     * binds the system. Subsequent calls are no-ops. A bind failure
+     * (entity manager has unexpected type, graphics service is
+     * unavailable, render system pointer is null) leaves the wired
+     * flag clear so a later call retries; the contract is "best
+     * effort, idempotent on success".
+     */
+    void ensureWired(vigine::IContext &context);
+
+    [[nodiscard]] std::shared_ptr<TextEditState>    state() const noexcept;
+    [[nodiscard]] std::shared_ptr<TextEditorSystem> system() const noexcept;
+
+  private:
+    std::shared_ptr<TextEditState>    _state;
+    std::shared_ptr<TextEditorSystem> _system;
+    bool                              _wired{false};
+};

--- a/example/window/services/wellknown.h
+++ b/example/window/services/wellknown.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <vigine/api/service/serviceid.h>
+
+namespace example::services::wellknown
+{
+/**
+ * @file wellknown.h
+ * @brief Application-scope well-known service ids for the
+ *        example-window app.
+ *
+ * Application well-known ids live in the @c index >= 16 range so they
+ * never overlap the engine-reserved range
+ * (@c vigine::service::wellknown::* uses @c index in [1..15]).
+ * Applications declare their own ids here and register matching
+ * services through @c IContext::registerService(svc, knownId); tasks
+ * resolve them through @c apiToken()->service(...) the same way they
+ * resolve engine-scope services.
+ */
+
+/**
+ * @brief Well-known id for the example's @c TextEditorService.
+ *
+ * Bound to the @c TextEditorService implementation that wraps the
+ * @c TextEditState + @c TextEditorSystem pair the example's editor
+ * tasks consume. The service is registered once in @c main and
+ * resolved by every editor-touching task through this constant.
+ */
+inline constexpr vigine::service::ServiceId textEditor{16, 1};
+
+} // namespace example::services::wellknown

--- a/example/window/system/texteditorsystem.cpp
+++ b/example/window/system/texteditorsystem.cpp
@@ -1,12 +1,23 @@
 #include "texteditorsystem.h"
 
+#include <vigine/impl/ecs/entity.h>
 #include <vigine/impl/ecs/entitymanager.h>
+#include <vigine/impl/ecs/graphics/meshcomponent.h>
 #include <vigine/impl/ecs/graphics/rendercomponent.h>
 #include <vigine/impl/ecs/graphics/rendersystem.h>
+#include <vigine/impl/ecs/graphics/shadercomponent.h>
+#include <vigine/impl/ecs/graphics/transformcomponent.h>
 #include <vigine/impl/ecs/graphics/graphicsservice.h>
 
 #include <algorithm>
 #include <cmath>
+#include <cstring>
+#include <glm/glm.hpp>
+#include <glm/gtx/quaternion.hpp>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
 
 namespace
 {
@@ -62,6 +73,13 @@ void TextEditorSystem::refreshEditorLayout()
 
 void TextEditorSystem::onFrame()
 {
+    // Apply any pending swapchain resize first so the render pass that
+    // follows this tick draws against the new size. Debounced 80 ms to
+    // avoid thrashing the swapchain while the user actively drags the
+    // window edge.
+    if (auto *i = interaction())
+        applyPendingResizeIfPaused(*i);
+
     if (!_state)
         return;
 
@@ -623,3 +641,827 @@ std::size_t TextEditorSystem::nextUtf8Pos(const std::string &text, std::size_t p
 }
 
 bool TextEditorSystem::isContinuationByte(unsigned char byte) { return (byte & 0xC0u) == 0x80u; }
+
+// ===========================================================================
+//  Window-interaction surface
+//
+//  The block below absorbs the focus / object-drag / mouse-ray / Ctrl /
+//  movement-key / debounced-resize logic @c RunWindowTask used to carry
+//  directly on its own object. The state lives on the bound
+//  @ref TextEditorComponent record; the @c route* methods are the entry
+//  points the @c TextEditorService facade forwards from
+//  @c RunWindowTask's event router.
+// ===========================================================================
+
+namespace
+{
+constexpr unsigned int kKeyW               = 'W';
+constexpr unsigned int kKeyA               = 'A';
+constexpr unsigned int kKeyS               = 'S';
+constexpr unsigned int kKeyD               = 'D';
+constexpr unsigned int kKeyQ               = 'Q';
+constexpr unsigned int kKeyE               = 'E';
+constexpr unsigned int kKeyShift           = 0x10;
+constexpr unsigned int kKeyLeftShift       = 0xA0;
+constexpr unsigned int kKeyRightShift      = 0xA1;
+constexpr unsigned int kKeyControl         = 0x11;
+constexpr unsigned int kKeyLeftControl     = 0xA2;
+constexpr unsigned int kKeyRightControl    = 0xA3;
+constexpr unsigned int kKeyAlt             = 0x12;
+constexpr unsigned int kKeyLeftAlt         = 0xA4;
+constexpr unsigned int kKeyRightAlt        = 0xA5;
+constexpr unsigned int kKeyRayToggle       = 'R';
+constexpr unsigned int kKeyBillboardToggle = 'B';
+constexpr unsigned int kKeyEscape          = 0x1B;
+
+#ifdef _WIN32
+std::string utf8FromWide(const wchar_t *wide)
+{
+    if (!wide)
+        return {};
+
+    const int needed = WideCharToMultiByte(CP_UTF8, 0, wide, -1, nullptr, 0, nullptr, nullptr);
+    if (needed <= 1)
+        return {};
+
+    std::string result(static_cast<size_t>(needed - 1), '\0');
+    static_cast<void>(
+        WideCharToMultiByte(CP_UTF8, 0, wide, -1, result.data(), needed, nullptr, nullptr));
+    return result;
+}
+
+std::wstring wideFromUtf8(const std::string &utf8)
+{
+    if (utf8.empty())
+        return {};
+
+    const int needed = MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, nullptr, 0);
+    if (needed <= 1)
+        return {};
+
+    std::wstring result(static_cast<size_t>(needed - 1), L'\0');
+    static_cast<void>(MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, result.data(), needed));
+    return result;
+}
+#endif
+} // namespace
+
+TextEditorComponent &
+TextEditorSystem::bindInteractionEntity(vigine::Entity *entity)
+{
+    return _interactions[entity];
+}
+
+TextEditorComponent *TextEditorSystem::interaction(vigine::Entity *entity)
+{
+    auto it = _interactions.find(entity);
+    return it != _interactions.end() ? &it->second : nullptr;
+}
+
+const TextEditorComponent *
+TextEditorSystem::interaction(const vigine::Entity *entity) const
+{
+    auto it = _interactions.find(const_cast<vigine::Entity *>(entity));
+    return it != _interactions.end() ? &it->second : nullptr;
+}
+
+TextEditorComponent *TextEditorSystem::interaction()
+{
+    return _interactions.empty() ? nullptr : &_interactions.begin()->second;
+}
+
+const TextEditorComponent *TextEditorSystem::interaction() const
+{
+    return _interactions.empty() ? nullptr : &_interactions.begin()->second;
+}
+
+vigine::Entity *TextEditorSystem::focusedEntity() const
+{
+    if (auto *i = interaction())
+        return i->focusedEntity;
+    return nullptr;
+}
+
+uint8_t TextEditorSystem::movementKeyMask() const
+{
+    if (auto *i = interaction())
+        return i->movementKeyMask;
+    return 0u;
+}
+
+// ---- Window-event router methods -----------------------------------------
+
+void TextEditorSystem::routeMouseButtonDown(vigine::ecs::platform::MouseButton button,
+                                            int x, int y)
+{
+    auto *i = interaction();
+    if (!i)
+        return;
+
+    if (button == vigine::ecs::platform::MouseButton::Left)
+    {
+        vigine::Entity *picked =
+            _renderSystem ? _renderSystem->pickFirstIntersectedEntity(x, y) : nullptr;
+
+        i->lastMouseRayX     = x;
+        i->lastMouseRayY     = y;
+        i->hasMouseRaySample = true;
+
+        const bool pickedTextEditor = isEditorEntity(picked);
+
+        // Freeze click marker first, then build ray from the same click point.
+        updateMouseClickSphereVisualization(*i, x, y);
+        updateMouseRayVisualization(*i, x, y);
+
+        bool consumedByScrollbar = false;
+        if (pickedTextEditor)
+            consumedByScrollbar = onMouseButtonDown(x, y, picked);
+
+        if (pickedTextEditor && !consumedByScrollbar)
+            onEditorClick(x, y);
+
+        // In Ctrl camera-unlock mode keep current focus unchanged.
+        if (!i->ctrlHeld)
+        {
+            setFocusedEntityImpl(*i, picked);
+
+            if (i->focusedEntity)
+            {
+                i->movementKeyMask = 0;
+                if (_renderSystem)
+                {
+                    _renderSystem->setMoveForwardActive(false);
+                    _renderSystem->setMoveBackwardActive(false);
+                    _renderSystem->setMoveLeftActive(false);
+                    _renderSystem->setMoveRightActive(false);
+                    _renderSystem->setMoveUpActive(false);
+                    _renderSystem->setMoveDownActive(false);
+                    _renderSystem->setSprintActive(false);
+                }
+            }
+        }
+    }
+
+    if (_renderSystem && button == vigine::ecs::platform::MouseButton::Right &&
+        (!i->focusedEntity || i->ctrlHeld || i->objectDragActive))
+        _renderSystem->beginCameraDrag(x, y);
+}
+
+void TextEditorSystem::routeMouseButtonUp(vigine::ecs::platform::MouseButton button,
+                                          int /*x*/, int /*y*/)
+{
+    auto *i = interaction();
+    if (!i)
+        return;
+
+    if (button == vigine::ecs::platform::MouseButton::Left)
+        onMouseButtonUp();
+
+    if (_renderSystem && button == vigine::ecs::platform::MouseButton::Right &&
+        (!i->focusedEntity || i->ctrlHeld || i->objectDragActive))
+        _renderSystem->endCameraDrag();
+}
+
+void TextEditorSystem::routeMouseMove(int x, int y)
+{
+    auto *i = interaction();
+    if (!i)
+        return;
+
+    i->lastMouseRayX     = x;
+    i->lastMouseRayY     = y;
+    i->hasMouseRaySample = true;
+
+    if (i->objectDragActive)
+        updateObjectDrag(*i, x, y, /*suppressZDelta=*/true);
+
+    onMouseMove(x, y);
+
+    if (_renderSystem &&
+        (!i->focusedEntity || i->ctrlHeld || i->objectDragActive))
+        _renderSystem->updateCameraDrag(x, y);
+}
+
+void TextEditorSystem::routeMouseWheel(int delta, int x, int y)
+{
+    auto *i = interaction();
+    if (!i)
+        return;
+
+    // In object-drag mode: wheel adjusts object distance from camera.
+    if (i->objectDragActive)
+    {
+        const float wheelSteps             = static_cast<float>(delta) / 120.0f;
+        const float factor                 = std::pow(0.90f, -wheelSteps);
+        i->objectDragDistanceFromCamera    = (std::max)(0.15f,
+                                                          i->objectDragDistanceFromCamera * factor);
+        // Allow Z movement so the object actually moves in depth, not just XY.
+        updateObjectDrag(*i, x, y, /*suppressZDelta=*/false);
+        return;
+    }
+
+    // When text editor is focused (and Ctrl not held): scroll text, not camera.
+    if (i->focusedEntity && !i->ctrlHeld)
+    {
+        onMouseWheel(delta);
+        return;
+    }
+
+    if (_renderSystem && (!i->focusedEntity || i->ctrlHeld))
+        _renderSystem->zoomCamera(delta);
+}
+
+void TextEditorSystem::routeKeyDown(const vigine::ecs::platform::KeyEvent &event)
+{
+    auto *i = interaction();
+    if (!i)
+        return;
+
+    if (event.keyCode == kKeyControl || event.keyCode == kKeyLeftControl ||
+        event.keyCode == kKeyRightControl)
+        i->ctrlHeld = true;
+
+    if (!event.isRepeat &&
+        (event.keyCode == kKeyAlt || event.keyCode == kKeyLeftAlt ||
+         event.keyCode == kKeyRightAlt))
+    {
+        if (i->objectDragActive)
+        {
+            endObjectDrag(*i);
+        } else if (i->focusedEntity)
+        {
+            const int mx = i->hasMouseRaySample ? i->lastMouseRayX : 0;
+            const int my = i->hasMouseRaySample ? i->lastMouseRayY : 0;
+            static_cast<void>(beginObjectDrag(*i, i->focusedEntity, mx, my));
+        }
+        return;
+    }
+
+    if (event.keyCode == kKeyRayToggle && !event.isRepeat)
+    {
+        i->mouseRayVisible = !i->mouseRayVisible;
+
+        if (i->mouseRayVisible)
+        {
+            if (i->hasMouseRaySample)
+                updateMouseRayVisualization(*i, i->lastMouseRayX, i->lastMouseRayY);
+        } else if (ensureMouseRayEntity(*i) && _renderSystem)
+        {
+            _renderSystem->bindEntity(i->mouseRayEntity);
+            if (auto *rc = _renderSystem->boundRenderComponent())
+            {
+                auto transform = rc->getTransform();
+                transform.setPosition({0.0f, -100.0f, 0.0f});
+                transform.setScale({0.01f, 0.01f, 0.01f});
+                rc->setTransform(transform);
+            }
+            _renderSystem->unbindEntity();
+        }
+    }
+
+    if (event.keyCode == kKeyBillboardToggle && !event.isRepeat)
+    {
+        if (_renderSystem)
+            _renderSystem->toggleBillboard();
+    }
+
+    if (!i->focusedEntity || i->ctrlHeld || i->objectDragActive)
+        updateCameraMovementKey(*i, event.keyCode, true);
+
+    if (event.keyCode == kKeyEscape)
+    {
+        setFocusedEntityImpl(*i, nullptr);
+        return;
+    }
+
+    if (handleClipboardShortcut(event))
+        return;
+
+    if (i->focusedEntity && isEditorEntity(i->focusedEntity))
+        onKeyDown(event.keyCode);
+}
+
+void TextEditorSystem::routeKeyUp(const vigine::ecs::platform::KeyEvent &event)
+{
+    auto *i = interaction();
+    if (!i)
+        return;
+
+    if (event.keyCode == kKeyControl || event.keyCode == kKeyLeftControl ||
+        event.keyCode == kKeyRightControl)
+        i->ctrlHeld = false;
+
+    if (!i->focusedEntity || i->ctrlHeld || i->objectDragActive)
+        updateCameraMovementKey(*i, event.keyCode, false);
+}
+
+void TextEditorSystem::routeChar(const vigine::ecs::platform::TextEvent &event)
+{
+    auto *i = interaction();
+    if (!i)
+        return;
+    if (i->focusedEntity && isEditorEntity(i->focusedEntity))
+        onChar(event, i->movementKeyMask);
+}
+
+void TextEditorSystem::routeWindowResized(int width, int height)
+{
+    auto *i = interaction();
+    if (!i || !_renderSystem)
+        return;
+    if (width <= 0 || height <= 0)
+        return;
+
+    i->pendingResizeWidth  = static_cast<uint32_t>(width);
+    i->pendingResizeHeight = static_cast<uint32_t>(height);
+    i->resizePending       = true;
+    i->lastResizeEvent     = std::chrono::steady_clock::now();
+}
+
+// ---- Implementation helpers (private) ------------------------------------
+
+void TextEditorSystem::setFocusedEntityImpl(TextEditorComponent &i, vigine::Entity *entity)
+{
+    if (entity == i.focusedEntity)
+        return;
+
+    // Any focus change exits move mode.
+    if (i.objectDragActive)
+        endObjectDrag(i);
+
+    if (i.focusedEntity && _renderSystem && i.hasFocusedOriginalScale)
+    {
+        _renderSystem->bindEntity(i.focusedEntity);
+        if (auto *rc = _renderSystem->boundRenderComponent())
+        {
+            auto transform = rc->getTransform();
+            transform.setScale(i.focusedOriginalScale);
+            rc->setTransform(transform);
+        }
+        _renderSystem->unbindEntity();
+    }
+
+    i.focusedEntity           = entity;
+    i.hasFocusedOriginalScale = false;
+
+    // Editor entities receive focus for input but should not get the
+    // scale-up visual effect.
+    const bool isEditor = isEditorEntity(entity);
+
+    setFocused(i.focusedEntity != nullptr && isEditor);
+
+    if (i.focusedEntity && _renderSystem && !isEditor)
+    {
+        _renderSystem->bindEntity(i.focusedEntity);
+        if (auto *rc = _renderSystem->boundRenderComponent())
+        {
+            auto transform              = rc->getTransform();
+            i.focusedOriginalScale      = transform.getScale();
+            transform.setScale(i.focusedOriginalScale * 1.08f);
+            rc->setTransform(transform);
+            i.hasFocusedOriginalScale   = true;
+        }
+        _renderSystem->unbindEntity();
+    }
+}
+
+bool TextEditorSystem::ensureMouseRayEntity(TextEditorComponent &i)
+{
+    if (i.mouseRayEntity)
+        return true;
+
+    if (!_entityManager || !_renderSystem)
+        return false;
+
+    auto *existing = _entityManager->getEntityByAlias("MouseRayEntity");
+    i.mouseRayEntity = existing ? static_cast<vigine::Entity *>(existing) : nullptr;
+    if (!i.mouseRayEntity)
+    {
+        i.mouseRayEntity = _entityManager->createEntity();
+        if (!i.mouseRayEntity)
+            return false;
+
+        _entityManager->addAlias(i.mouseRayEntity, "MouseRayEntity");
+    }
+
+    _renderSystem->createComponents(i.mouseRayEntity);
+    _renderSystem->bindEntity(i.mouseRayEntity);
+    auto *rc = _renderSystem->boundRenderComponent();
+    if (!rc)
+    {
+        _renderSystem->unbindEntity();
+        return false;
+    }
+
+    auto rayMesh = vigine::ecs::graphics::MeshComponent::createCube();
+    rayMesh.setProceduralInShader(true, 36);
+    rc->setMesh(rayMesh);
+    {
+        vigine::ecs::graphics::ShaderComponent shader("cube.vert.spv", "cube.frag.spv");
+        rc->setShader(shader);
+    }
+    rc->setPickable(false);
+
+    vigine::ecs::graphics::TransformComponent transform;
+    transform.setPosition({0.0f, -100.0f, 0.0f});
+    transform.setScale({0.01f, 0.01f, 0.01f});
+    rc->setTransform(transform);
+
+    _renderSystem->unbindEntity();
+    return true;
+}
+
+bool TextEditorSystem::ensureMouseClickSphereEntity(TextEditorComponent &i)
+{
+    if (i.mouseClickSphereEntity)
+        return true;
+
+    if (!_entityManager || !_renderSystem)
+        return false;
+
+    auto *existing = _entityManager->getEntityByAlias("MouseClickSphereEntity");
+    i.mouseClickSphereEntity = existing ? static_cast<vigine::Entity *>(existing) : nullptr;
+    if (!i.mouseClickSphereEntity)
+    {
+        i.mouseClickSphereEntity = _entityManager->createEntity();
+        if (!i.mouseClickSphereEntity)
+            return false;
+
+        _entityManager->addAlias(i.mouseClickSphereEntity, "MouseClickSphereEntity");
+    }
+
+    _renderSystem->createComponents(i.mouseClickSphereEntity);
+    _renderSystem->bindEntity(i.mouseClickSphereEntity);
+    auto *rc = _renderSystem->boundRenderComponent();
+    if (!rc)
+    {
+        _renderSystem->unbindEntity();
+        return false;
+    }
+
+    auto sphereMesh = vigine::ecs::graphics::MeshComponent::createCube();
+    sphereMesh.setProceduralInShader(true, 768);
+    rc->setMesh(sphereMesh);
+    {
+        vigine::ecs::graphics::ShaderComponent shader("sphere.vert.spv", "sphere.frag.spv");
+        rc->setShader(shader);
+    }
+    rc->setPickable(false);
+
+    vigine::ecs::graphics::TransformComponent transform;
+    transform.setPosition({0.0f, -100.0f, 0.0f});
+    transform.setScale({0.06f, 0.06f, 0.06f});
+    rc->setTransform(transform);
+
+    _renderSystem->unbindEntity();
+    return true;
+}
+
+void TextEditorSystem::updateMouseRayVisualization(TextEditorComponent &i, int x, int y)
+{
+    if (!_renderSystem)
+        return;
+
+    if (!ensureMouseRayEntity(i))
+        return;
+
+    glm::vec3 clickRayOrigin(0.0f);
+    glm::vec3 clickRayDirection(0.0f);
+    if (!_renderSystem->screenPointToRayFromNearPlane(x, y, clickRayOrigin, clickRayDirection))
+        return;
+
+    const glm::vec3 rayDirection  = glm::normalize(clickRayDirection);
+
+    constexpr float kRayLength    = 60.0f;
+    constexpr float kRayThickness = 0.012f;
+    constexpr float kStartOffset  = 0.03f;
+
+    const glm::vec3 rayStart      = clickRayOrigin + clickRayDirection * kStartOffset;
+
+    const glm::vec3 center        = rayStart + rayDirection * (kRayLength * 0.5f);
+    const glm::quat orientation   = glm::rotation(glm::vec3(0.0f, 0.0f, 1.0f), rayDirection);
+    const glm::vec3 rotationEuler = glm::eulerAngles(orientation);
+
+    _renderSystem->bindEntity(i.mouseRayEntity);
+    if (auto *rc = _renderSystem->boundRenderComponent())
+    {
+        auto transform = rc->getTransform();
+        if (i.mouseRayVisible)
+        {
+            transform.setPosition(center);
+            transform.setRotation(rotationEuler);
+            transform.setScale({kRayThickness, kRayThickness, kRayLength});
+        } else
+        {
+            transform.setPosition({0.0f, -100.0f, 0.0f});
+            transform.setScale({0.01f, 0.01f, 0.01f});
+        }
+        rc->setTransform(transform);
+    }
+    _renderSystem->unbindEntity();
+}
+
+void TextEditorSystem::updateMouseClickSphereVisualization(TextEditorComponent &i, int x, int y)
+{
+    if (!_renderSystem)
+        return;
+
+    if (!ensureMouseClickSphereEntity(i))
+        return;
+
+    glm::vec3 clickRayOrigin(0.0f);
+    glm::vec3 clickRayDirection(0.0f);
+    if (!_renderSystem->screenPointToRayFromNearPlane(x, y, clickRayOrigin, clickRayDirection))
+        return;
+
+    constexpr float kStartOffset = 0.03f;
+    const glm::vec3 sphereCenter = clickRayOrigin + clickRayDirection * kStartOffset;
+
+    _renderSystem->bindEntity(i.mouseClickSphereEntity);
+    if (auto *rc = _renderSystem->boundRenderComponent())
+    {
+        auto transform = rc->getTransform();
+        transform.setPosition(sphereCenter);
+        transform.setScale({0.05f, 0.05f, 0.05f});
+        rc->setTransform(transform);
+    }
+    _renderSystem->unbindEntity();
+}
+
+bool TextEditorSystem::beginObjectDrag(TextEditorComponent &i, vigine::Entity *entity,
+                                       int x, int y)
+{
+    if (!entity || !_renderSystem)
+        return false;
+
+    _renderSystem->bindEntity(entity);
+    auto *rc = _renderSystem->boundRenderComponent();
+    if (!rc)
+    {
+        _renderSystem->unbindEntity();
+        return false;
+    }
+
+    const auto transform = rc->getTransform();
+    _renderSystem->unbindEntity();
+
+    glm::vec3 rayOrigin(0.0f);
+    glm::vec3 rayDirection(0.0f);
+    if (!_renderSystem->screenPointToRayFromNearPlane(x, y, rayOrigin, rayDirection))
+        return false;
+
+    const float dirLen = glm::length(rayDirection);
+    if (dirLen < 1e-6f)
+        return false;
+    rayDirection                          /= dirLen;
+
+    i.objectDragDistanceFromCamera         = glm::dot(transform.getPosition() - rayOrigin,
+                                                       rayDirection);
+    if (i.objectDragDistanceFromCamera <= 0.0f)
+        return false;
+
+    const glm::vec3 hit = rayOrigin + rayDirection * i.objectDragDistanceFromCamera;
+
+    i.objectDragActive       = true;
+    i.objectDragEditorGroup  = isEditorEntity(entity);
+    i.objectDragEntity       = entity;
+    i.objectDragGrabOffset   = transform.getPosition() - hit;
+    return true;
+}
+
+void TextEditorSystem::updateObjectDrag(TextEditorComponent &i, int x, int y, bool suppressZDelta)
+{
+    if (!i.objectDragActive || !i.objectDragEntity || !_renderSystem)
+        return;
+
+    glm::vec3 rayOrigin(0.0f);
+    glm::vec3 rayDirection(0.0f);
+    if (!_renderSystem->screenPointToRayFromNearPlane(x, y, rayOrigin, rayDirection))
+        return;
+
+    const float dirLen = glm::length(rayDirection);
+    if (dirLen < 1e-6f)
+        return;
+    rayDirection           /= dirLen;
+
+    const glm::vec3 hit     = rayOrigin + rayDirection * i.objectDragDistanceFromCamera;
+    const glm::vec3 newPos  = hit + i.objectDragGrabOffset;
+
+    _renderSystem->bindEntity(i.objectDragEntity);
+    auto *dragRc = _renderSystem->boundRenderComponent();
+    if (!dragRc)
+    {
+        _renderSystem->unbindEntity();
+        return;
+    }
+
+    auto dragTr     = dragRc->getTransform();
+    glm::vec3 delta = newPos - dragTr.getPosition();
+    if (i.objectDragEditorGroup)
+    {
+        if (suppressZDelta)
+            delta.z = 0.0f;
+        else
+        {
+            delta.x = 0.0f;
+            delta.y = 0.0f;
+        }
+    }
+
+    dragTr.setPosition(dragTr.getPosition() + delta);
+    dragRc->setTransform(dragTr);
+
+    if (i.objectDragEditorGroup)
+        dragRc->translateGlyphVertices(delta);
+
+    _renderSystem->unbindEntity();
+
+    if (i.objectDragEditorGroup && _entityManager)
+    {
+        const char *editorAliases[] = {
+            "TextEditBgEntity",
+            "TextEditEntity",
+            "TextEditScrollbarTrackEntity",
+            "TextEditScrollbarThumbEntity",
+            "TextEditFocusTopEntity",
+            "TextEditFocusBottomEntity",
+            "TextEditFocusLeftEntity",
+            "TextEditFocusRightEntity",
+        };
+
+        for (const char *alias : editorAliases)
+        {
+            auto *e = _entityManager->getEntityByAlias(alias);
+            if (!e || e == i.objectDragEntity)
+                continue;
+
+            _renderSystem->bindEntity(e);
+            if (auto *rc = _renderSystem->boundRenderComponent())
+            {
+                auto tr = rc->getTransform();
+                tr.setPosition(tr.getPosition() + delta);
+                rc->setTransform(tr);
+
+                if (std::strcmp(alias, "TextEditEntity") == 0)
+                    rc->translateGlyphVertices(delta);
+            }
+            _renderSystem->unbindEntity();
+        }
+
+        offsetEditorFrame(delta.x, delta.y, delta.z);
+        refreshEditorLayout();
+        _renderSystem->markGlyphDirty();
+    }
+}
+
+void TextEditorSystem::endObjectDrag(TextEditorComponent &i)
+{
+    i.objectDragActive             = false;
+    i.objectDragEditorGroup        = false;
+    i.objectDragEntity             = nullptr;
+    i.objectDragDistanceFromCamera = 0.0f;
+    i.objectDragGrabOffset         = {0.0f, 0.0f, 0.0f};
+}
+
+void TextEditorSystem::updateCameraMovementKey(TextEditorComponent &i, unsigned int keyCode,
+                                               bool pressed)
+{
+    if (!_renderSystem)
+        return;
+
+    auto setMoveMaskBit = [&i, pressed](uint8_t bit) {
+        if (pressed)
+            i.movementKeyMask = static_cast<uint8_t>(i.movementKeyMask | bit);
+        else
+            i.movementKeyMask = static_cast<uint8_t>(i.movementKeyMask & ~bit);
+    };
+
+    switch (keyCode)
+    {
+    case kKeyW:
+        _renderSystem->setMoveForwardActive(pressed);
+        setMoveMaskBit(1u << 0);
+        break;
+    case kKeyS:
+        _renderSystem->setMoveBackwardActive(pressed);
+        setMoveMaskBit(1u << 2);
+        break;
+    case kKeyA:
+        _renderSystem->setMoveLeftActive(pressed);
+        setMoveMaskBit(1u << 1);
+        break;
+    case kKeyD:
+        _renderSystem->setMoveRightActive(pressed);
+        setMoveMaskBit(1u << 3);
+        break;
+    case kKeyQ:
+        _renderSystem->setMoveDownActive(pressed);
+        setMoveMaskBit(1u << 4);
+        break;
+    case kKeyE:
+        _renderSystem->setMoveUpActive(pressed);
+        setMoveMaskBit(1u << 5);
+        break;
+    case kKeyShift:
+    case kKeyLeftShift:
+    case kKeyRightShift:
+        _renderSystem->setSprintActive(pressed);
+        break;
+    default:
+        break;
+    }
+}
+
+void TextEditorSystem::applyPendingResizeIfPaused(TextEditorComponent &i)
+{
+    if (!i.resizePending || !_renderSystem)
+        return;
+
+    const auto now    = std::chrono::steady_clock::now();
+    const bool paused = now - i.lastResizeEvent >= std::chrono::milliseconds(80);
+    if (!paused)
+        return;
+
+    if (i.pendingResizeWidth == i.appliedResizeWidth &&
+        i.pendingResizeHeight == i.appliedResizeHeight)
+    {
+        i.resizePending = false;
+        return;
+    }
+
+    const bool resized = _renderSystem->resize(i.pendingResizeWidth, i.pendingResizeHeight);
+    if (resized)
+    {
+        i.appliedResizeWidth  = i.pendingResizeWidth;
+        i.appliedResizeHeight = i.pendingResizeHeight;
+        i.lastResizeApply     = now;
+    }
+    i.resizePending = false;
+}
+
+bool TextEditorSystem::handleClipboardShortcut(const vigine::ecs::platform::KeyEvent &event)
+{
+    auto *i = interaction();
+    if (!i || !i->focusedEntity)
+        return false;
+    if (!isEditorEntity(i->focusedEntity))
+        return false;
+
+    const bool ctrlPressed = (event.modifiers & vigine::ecs::platform::KeyModifierControl) != 0;
+    if (!ctrlPressed)
+        return false;
+
+    if (event.keyCode == 'C' || event.keyCode == 'X')
+    {
+#ifdef _WIN32
+        const std::wstring wide = wideFromUtf8(text());
+        if (!wide.empty() && OpenClipboard(nullptr))
+        {
+            static_cast<void>(EmptyClipboard());
+            const SIZE_T bytes = (wide.size() + 1) * sizeof(wchar_t);
+            HGLOBAL memory     = GlobalAlloc(GMEM_MOVEABLE, bytes);
+            if (memory)
+            {
+                void *ptr = GlobalLock(memory);
+                if (ptr)
+                {
+                    std::memcpy(ptr, wide.c_str(), bytes);
+                    GlobalUnlock(memory);
+                    static_cast<void>(SetClipboardData(CF_UNICODETEXT, memory));
+                    memory = nullptr;
+                }
+            }
+            if (memory)
+                GlobalFree(memory);
+            CloseClipboard();
+        }
+#endif
+
+        if (event.keyCode == 'X')
+            clearText();
+        return true;
+    }
+
+    if (event.keyCode == 'V')
+    {
+#ifdef _WIN32
+        if (OpenClipboard(nullptr))
+        {
+            HANDLE data = GetClipboardData(CF_UNICODETEXT);
+            if (data)
+            {
+                auto *wide = static_cast<const wchar_t *>(GlobalLock(data));
+                if (wide)
+                {
+                    insertUtf8(utf8FromWide(wide));
+                    GlobalUnlock(data);
+                }
+            }
+            CloseClipboard();
+        }
+#endif
+        return true;
+    }
+
+    return false;
+}

--- a/example/window/system/texteditorsystem.h
+++ b/example/window/system/texteditorsystem.h
@@ -3,6 +3,7 @@
 #include <vigine/api/ecs/platform/iwindoweventhandler.h>
 #include <vigine/impl/ecs/graphics/textcomponent.h>
 
+#include "../component/texteditorcomponent.h"
 #include "../texteditstate.h"
 
 #include <chrono>
@@ -10,6 +11,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace vigine
@@ -26,6 +28,34 @@ class RenderSystem;
 } // namespace ecs
 } // namespace vigine
 
+/**
+ * @brief Editor / interaction system that owns the @c TextEditState
+ *        text buffer and the per-entity @c TextEditorComponent UI
+ *        state, and that drives every window-event hook
+ *        @c RunWindowTask used to handle directly.
+ *
+ * The system used to expose a small set of editor-only event hooks
+ * (@ref onChar, @ref onKeyDown, @ref onMouseWheel ...). It now also
+ * absorbs the focus / object-drag / mouse-ray / mouse-click-sphere /
+ * Ctrl-tracking / movement-key / debounced-resize state @c RunWindowTask
+ * used to carry as raw members. The state lives in
+ * @ref TextEditorComponent records bound through
+ * @ref bindInteractionEntity; @ref RunWindowTask drops to a thin
+ * event router that resolves @ref TextEditorService and forwards
+ * each callback verbatim.
+ *
+ * Wiring: @ref bind connects the system to the engine's entity
+ * manager + graphics service / render system. Setup tasks in the
+ * example (@c SetupTextEditTask) call @ref bindInteractionEntity
+ * for the @c MainWindow entity after the editor visuals are built;
+ * the system stores per-entity @ref TextEditorComponent records
+ * keyed by raw entity pointer.
+ *
+ * Threading: all event handlers run on whatever thread the platform
+ * pump fires the underlying @c WindowEventHandler callback on (the
+ * Win32 message-pump thread on Windows). The system carries no
+ * synchronisation; callers serialise their event dispatch.
+ */
 class TextEditorSystem
 {
   public:
@@ -34,11 +64,6 @@ class TextEditorSystem
     /**
      * @brief Wires the editor system to the entity manager and the
      *        graphics service / render system pair.
-     *
-     * The example holds the entity manager directly because the engine
-     * front door does not surface it through @ref vigine::IContext.
-     * The signature therefore takes the entity manager as its own
-     * parameter.
      */
     void bind(vigine::EntityManager *entityManager,
               vigine::ecs::graphics::GraphicsService *graphicsService,
@@ -65,6 +90,82 @@ class TextEditorSystem
 
     [[nodiscard]] const std::string &text() const;
 
+    // ====================================================================
+    //  Window-interaction surface
+    //
+    //  The methods below absorb the per-event logic @c RunWindowTask used
+    //  to carry directly (focus tracking, object-drag math, mouse-ray
+    //  visualization, modifier-key bookkeeping, debounced swapchain
+    //  resize). The system reads / writes a @ref TextEditorComponent
+    //  record bound through @ref bindInteractionEntity; the @c RunWindowTask
+    //  side becomes a thin router that forwards each callback to the
+    //  matching method below.
+    // ====================================================================
+
+    /**
+     * @brief Registers a fresh @ref TextEditorComponent against
+     *        @p entity (or replaces any previously-bound component
+     *        for that entity).
+     *
+     * The @c MainWindow entity is the canonical binding in the
+     * example; the system keeps one live record per registered
+     * entity. Returns the component reference so the setup task can
+     * fill in the @c mouseRayEntity / @c mouseClickSphereEntity
+     * pointers and any other entity handles the runtime path needs.
+     */
+    TextEditorComponent &bindInteractionEntity(vigine::Entity *entity);
+
+    /**
+     * @brief Returns the bound @ref TextEditorComponent for @p entity,
+     *        or @c nullptr when no component was bound under that
+     *        entity.
+     */
+    [[nodiscard]] TextEditorComponent *interaction(vigine::Entity *entity);
+    [[nodiscard]] const TextEditorComponent *
+        interaction(const vigine::Entity *entity) const;
+
+    /**
+     * @brief Returns the single live binding the example wires to
+     *        @c MainWindow, or @c nullptr when no entity has been
+     *        bound yet.
+     *
+     * The example registers exactly one interaction component (against
+     * the @c MainWindow entity) and then drives every event through
+     * the no-arg accessor; multi-window callers iterate
+     * @ref interaction explicitly per entity.
+     */
+    [[nodiscard]] TextEditorComponent *interaction();
+    [[nodiscard]] const TextEditorComponent *interaction() const;
+
+    // ---- Window event router (operates on the bound interaction) ------
+
+    void routeMouseButtonDown(vigine::ecs::platform::MouseButton button, int x, int y);
+    void routeMouseButtonUp(vigine::ecs::platform::MouseButton button, int x, int y);
+    void routeMouseMove(int x, int y);
+    void routeMouseWheel(int delta, int x, int y);
+    void routeKeyDown(const vigine::ecs::platform::KeyEvent &event);
+    void routeKeyUp(const vigine::ecs::platform::KeyEvent &event);
+    void routeChar(const vigine::ecs::platform::TextEvent &event);
+    void routeWindowResized(int width, int height);
+
+    /**
+     * @brief Returns the focused entity from the bound component
+     *        (@c nullptr when nothing is focused or no component is
+     *        bound).
+     */
+    [[nodiscard]] vigine::Entity *focusedEntity() const;
+
+    /**
+     * @brief Returns the movement-key bitmask snapshot, or @c 0 when
+     *        no component is bound.
+     *
+     * Exposed so callers that emit signals on key-down (e.g. @c onChar
+     * forwarding from the platform pump) can pass the current
+     * movement state into the editor's text-input pipeline without
+     * re-reading the component.
+     */
+    [[nodiscard]] uint8_t movementKeyMask() const;
+
   private:
     void applyScrollOffset(float newOffset);
     void updateScrollbarVisuals();
@@ -76,6 +177,60 @@ class TextEditorSystem
 
     static std::size_t nextUtf8Pos(const std::string &text, std::size_t pos);
     static bool isContinuationByte(unsigned char byte);
+
+    // ---- Window-interaction helpers (work on the bound component) ----
+
+    /**
+     * @brief Sets the focused entity on the bound component, applying
+     *        the scale-up visual on the new focus and restoring the
+     *        previous focus's original scale.
+     *
+     * Editor entities (those that satisfy @ref isEditorEntity) receive
+     * focus without the scale bump.
+     */
+    void setFocusedEntityImpl(TextEditorComponent &interaction, vigine::Entity *entity);
+
+    /**
+     * @brief Lazily creates / refreshes the mouse-ray visualization
+     *        entity referenced by the bound component, then updates
+     *        its transform to a ray cast from the camera through
+     *        screen pixel @p (x, y).
+     */
+    void updateMouseRayVisualization(TextEditorComponent &interaction, int x, int y);
+    void updateMouseClickSphereVisualization(TextEditorComponent &interaction, int x, int y);
+    bool ensureMouseRayEntity(TextEditorComponent &interaction);
+    bool ensureMouseClickSphereEntity(TextEditorComponent &interaction);
+
+    /**
+     * @brief Begins dragging @p entity from screen pixel @p (x, y).
+     *
+     * Computes the distance + grab offset, stores them on the
+     * component, and flags whether the dragged entity is part of the
+     * editor entity group.
+     */
+    bool beginObjectDrag(TextEditorComponent &interaction, vigine::Entity *entity, int x, int y);
+    void updateObjectDrag(TextEditorComponent &interaction, int x, int y, bool suppressZDelta);
+    void endObjectDrag(TextEditorComponent &interaction);
+
+    /**
+     * @brief Maps a Win32-style virtual key code to its movement /
+     *        sprint binding and updates the camera-drive flags + the
+     *        component's movement-key bitmask.
+     */
+    void updateCameraMovementKey(TextEditorComponent &interaction, unsigned int keyCode,
+                                 bool pressed);
+
+    /**
+     * @brief Applies the pending swapchain resize stored on @p interaction
+     *        when at least 80 ms have passed since the last resize
+     *        event, then renders the next frame.
+     *
+     * Called from @ref onFrame so the render-system tick observes the
+     * already-applied size when it draws.
+     */
+    void applyPendingResizeIfPaused(TextEditorComponent &interaction);
+
+    bool handleClipboardShortcut(const vigine::ecs::platform::KeyEvent &event);
 
   private:
     std::shared_ptr<TextEditState> _state;
@@ -97,4 +252,9 @@ class TextEditorSystem
     bool _scrollbarDragging{false};
     float _scrollbarDragYOffset{0.0f};
     bool _focused{false};
+
+    // Per-entity interaction component records. The example wires
+    // exactly one (against MainWindow); multi-window callers add
+    // more through @ref bindInteractionEntity.
+    std::unordered_map<vigine::Entity *, TextEditorComponent> _interactions;
 };

--- a/example/window/task/vulkan/initvulkantask.cpp
+++ b/example/window/task/vulkan/initvulkantask.cpp
@@ -1,6 +1,8 @@
 #include "initvulkantask.h"
 
+#include <vigine/api/ecs/ientitymanager.h>
 #include <vigine/api/engine/iengine_token.h>
+#include <vigine/api/service/wellknown.h>
 #include <vigine/impl/ecs/entitymanager.h>
 #include <vigine/impl/ecs/graphics/rendersystem.h>
 #include <vigine/impl/ecs/graphics/graphicsservice.h>
@@ -10,37 +12,28 @@
 
 InitVulkanTask::InitVulkanTask() = default;
 
-void InitVulkanTask::setEntityManager(vigine::EntityManager *entityManager) noexcept
-{
-    _entityManager = entityManager;
-}
-
-void InitVulkanTask::setPlatformServiceId(vigine::service::ServiceId id) noexcept
-{
-    _platformServiceId = id;
-}
-
-void InitVulkanTask::setGraphicsServiceId(vigine::service::ServiceId id) noexcept
-{
-    _graphicsServiceId = id;
-}
-
 vigine::Result InitVulkanTask::run()
 {
     std::cout << "Initializing Vulkan API..." << std::endl;
-
-    if (!_entityManager)
-        return vigine::Result(vigine::Result::Code::Error, "EntityManager is unavailable");
 
     auto *token = apiToken();
     if (!token)
         return vigine::Result(vigine::Result::Code::Error, "Engine token is unavailable");
 
-    auto platformResult = token->service(_platformServiceId);
-    auto graphicsResult = token->service(_graphicsServiceId);
+    auto entityManagerResult = token->entityManager();
+    if (!entityManagerResult.ok())
+        return vigine::Result(vigine::Result::Code::Error, "Entity manager is unavailable");
+    auto *entityManager =
+        dynamic_cast<vigine::EntityManager *>(&entityManagerResult.value());
+    if (!entityManager)
+        return vigine::Result(vigine::Result::Code::Error,
+                              "Entity manager has unexpected type");
+
+    auto platformResult = token->service(vigine::service::wellknown::platformService);
+    auto graphicsResult = token->service(vigine::service::wellknown::graphicsService);
     if (!platformResult.ok() || !graphicsResult.ok())
         return vigine::Result(vigine::Result::Code::Error,
-                              "Render or Platform service not available");
+                              "Platform or Graphics service unavailable");
 
     auto *platformService =
         dynamic_cast<vigine::ecs::platform::PlatformService *>(&platformResult.value());
@@ -54,7 +47,7 @@ vigine::Result InitVulkanTask::run()
     if (!renderSystem)
         return vigine::Result(vigine::Result::Code::Error, "Render system not available");
 
-    auto *entity = _entityManager->getEntityByAlias("MainWindow");
+    auto *entity = entityManager->getEntityByAlias("MainWindow");
     if (!entity)
         return vigine::Result(vigine::Result::Code::Error, "MainWindow entity not found");
 

--- a/example/window/task/vulkan/initvulkantask.cpp
+++ b/example/window/task/vulkan/initvulkantask.cpp
@@ -32,7 +32,7 @@ vigine::Result InitVulkanTask::run()
     if (!_entityManager)
         return vigine::Result(vigine::Result::Code::Error, "EntityManager is unavailable");
 
-    auto *token = api();
+    auto *token = apiToken();
     if (!token)
         return vigine::Result(vigine::Result::Code::Error, "Engine token is unavailable");
 

--- a/example/window/task/vulkan/initvulkantask.h
+++ b/example/window/task/vulkan/initvulkantask.h
@@ -1,25 +1,6 @@
 #pragma once
 
 #include <vigine/api/taskflow/abstracttask.h>
-#include <vigine/api/service/serviceid.h>
-
-namespace vigine
-{
-class EntityManager;
-
-namespace ecs
-{
-namespace graphics
-{
-class GraphicsService;
-class RenderSystem;
-} // namespace graphics
-namespace platform
-{
-class PlatformService;
-}
-} // namespace ecs
-} // namespace vigine
 
 class InitVulkanTask final : public vigine::AbstractTask
 {
@@ -27,13 +8,4 @@ class InitVulkanTask final : public vigine::AbstractTask
     InitVulkanTask();
 
     [[nodiscard]] vigine::Result run() override;
-
-    void setEntityManager(vigine::EntityManager *entityManager) noexcept;
-    void setPlatformServiceId(vigine::service::ServiceId id) noexcept;
-    void setGraphicsServiceId(vigine::service::ServiceId id) noexcept;
-
-  private:
-    vigine::EntityManager *_entityManager{nullptr};
-    vigine::service::ServiceId _platformServiceId{};
-    vigine::service::ServiceId _graphicsServiceId{};
 };

--- a/example/window/task/vulkan/loadtexturestask.cpp
+++ b/example/window/task/vulkan/loadtexturestask.cpp
@@ -1,7 +1,9 @@
 #include "imageloader.h"
 #include "loadtexturestask.h"
 
+#include <vigine/api/ecs/ientitymanager.h>
 #include <vigine/api/engine/iengine_token.h>
+#include <vigine/api/service/wellknown.h>
 #include <vigine/impl/ecs/entitymanager.h>
 #include <vigine/impl/ecs/graphics/rendersystem.h>
 #include <vigine/impl/ecs/graphics/texturecomponent.h>
@@ -12,26 +14,22 @@
 #include <filesystem>
 #include <iostream>
 
-void LoadTexturesTask::setEntityManager(vigine::EntityManager *entityManager) noexcept
-{
-    _entityManager = entityManager;
-}
-
-void LoadTexturesTask::setGraphicsServiceId(vigine::service::ServiceId id) noexcept
-{
-    _graphicsServiceId = id;
-}
-
 vigine::Result LoadTexturesTask::run()
 {
-    if (!_entityManager)
-        return vigine::Result(vigine::Result::Code::Error, "EntityManager is unavailable");
-
     auto *token = apiToken();
     if (!token)
         return vigine::Result(vigine::Result::Code::Error, "Engine token is unavailable");
 
-    auto graphicsResult = token->service(_graphicsServiceId);
+    auto entityManagerResult = token->entityManager();
+    if (!entityManagerResult.ok())
+        return vigine::Result(vigine::Result::Code::Error, "Entity manager is unavailable");
+    auto *entityManager =
+        dynamic_cast<vigine::EntityManager *>(&entityManagerResult.value());
+    if (!entityManager)
+        return vigine::Result(vigine::Result::Code::Error,
+                              "Entity manager has unexpected type");
+
+    auto graphicsResult = token->service(vigine::service::wellknown::graphicsService);
     if (!graphicsResult.ok())
         return vigine::Result(vigine::Result::Code::Error, "Graphics service is unavailable");
 
@@ -112,7 +110,7 @@ vigine::Result LoadTexturesTask::run()
         }
 
         // Create entity for this texture
-        auto *textureEntity = _entityManager->createEntity();
+        auto *textureEntity = entityManager->createEntity();
         if (!textureEntity)
         {
             std::cerr << "Failed to create entity for texture: " << imagePath << std::endl;
@@ -121,7 +119,7 @@ vigine::Result LoadTexturesTask::run()
 
         // Use sequential index based on successful loads so entity names are always 0,1,2...
         std::string entityName = "TextureEntity_" + std::to_string(loadedIndex++);
-        _entityManager->addAlias(textureEntity, entityName);
+        entityManager->addAlias(textureEntity, entityName);
 
         // Create texture component for this entity
         renderSystem->createTextureComponent(textureEntity);

--- a/example/window/task/vulkan/loadtexturestask.cpp
+++ b/example/window/task/vulkan/loadtexturestask.cpp
@@ -27,7 +27,7 @@ vigine::Result LoadTexturesTask::run()
     if (!_entityManager)
         return vigine::Result(vigine::Result::Code::Error, "EntityManager is unavailable");
 
-    auto *token = api();
+    auto *token = apiToken();
     if (!token)
         return vigine::Result(vigine::Result::Code::Error, "Engine token is unavailable");
 

--- a/example/window/task/vulkan/loadtexturestask.h
+++ b/example/window/task/vulkan/loadtexturestask.h
@@ -1,20 +1,6 @@
 #pragma once
 
 #include <vigine/api/taskflow/abstracttask.h>
-#include <vigine/api/service/serviceid.h>
-
-namespace vigine
-{
-class EntityManager;
-
-namespace ecs
-{
-namespace graphics
-{
-class GraphicsService;
-}
-} // namespace ecs
-} // namespace vigine
 
 class LoadTexturesTask final : public vigine::AbstractTask
 {
@@ -22,11 +8,4 @@ class LoadTexturesTask final : public vigine::AbstractTask
     LoadTexturesTask() = default;
 
     [[nodiscard]] vigine::Result run() override;
-
-    void setEntityManager(vigine::EntityManager *entityManager) noexcept;
-    void setGraphicsServiceId(vigine::service::ServiceId id) noexcept;
-
-  private:
-    vigine::EntityManager *_entityManager{nullptr};
-    vigine::service::ServiceId _graphicsServiceId{};
 };

--- a/example/window/task/vulkan/rendercubetask.cpp
+++ b/example/window/task/vulkan/rendercubetask.cpp
@@ -13,8 +13,8 @@ vigine::Result RenderCubeTask::run()
         // The bound state has been invalidated since the last tick. Stop
         // further work and return an error so the FSM transition table
         // can route the WorkState onto its error follow-on -- the
-        // engine-token contract guarantees @ref api()->service /
-        // @ref api()->ecs return @ref vigine::engine::Result::Code::Expired
+        // engine-token contract guarantees @ref apiToken()->service /
+        // @ref apiToken()->ecs return @ref vigine::engine::Result::Code::Expired
         // here too (note: that is vigine::engine::Result<T>::Code, distinct
         // from the vigine::Result::Code returned by run()), but the
         // explicit short-circuit makes the intent obvious.
@@ -26,7 +26,7 @@ vigine::Result RenderCubeTask::run()
 
     if (!_expirationSubscription)
     {
-        if (auto *token = api())
+        if (auto *token = apiToken())
         {
             _expirationSubscription =
                 token->subscribeExpiration([this]() {

--- a/example/window/task/vulkan/setupcubetask.cpp
+++ b/example/window/task/vulkan/setupcubetask.cpp
@@ -30,7 +30,7 @@ vigine::Result SetupCubeTask::run()
     if (!_entityManager)
         return vigine::Result(vigine::Result::Code::Error, "EntityManager is unavailable");
 
-    auto *token = api();
+    auto *token = apiToken();
     if (!token)
         return vigine::Result(vigine::Result::Code::Error, "Engine token is unavailable");
 

--- a/example/window/task/vulkan/setupcubetask.cpp
+++ b/example/window/task/vulkan/setupcubetask.cpp
@@ -1,6 +1,8 @@
 #include "setupcubetask.h"
 
+#include <vigine/api/ecs/ientitymanager.h>
 #include <vigine/api/engine/iengine_token.h>
+#include <vigine/api/service/wellknown.h>
 #include <vigine/impl/ecs/entitymanager.h>
 #include <vigine/impl/ecs/graphics/meshcomponent.h>
 #include <vigine/impl/ecs/graphics/rendercomponent.h>
@@ -13,28 +15,24 @@
 
 SetupCubeTask::SetupCubeTask() = default;
 
-void SetupCubeTask::setEntityManager(vigine::EntityManager *entityManager) noexcept
-{
-    _entityManager = entityManager;
-}
-
-void SetupCubeTask::setGraphicsServiceId(vigine::service::ServiceId id) noexcept
-{
-    _graphicsServiceId = id;
-}
-
 vigine::Result SetupCubeTask::run()
 {
     std::cout << "Setting up cube geometry..." << std::endl;
-
-    if (!_entityManager)
-        return vigine::Result(vigine::Result::Code::Error, "EntityManager is unavailable");
 
     auto *token = apiToken();
     if (!token)
         return vigine::Result(vigine::Result::Code::Error, "Engine token is unavailable");
 
-    auto graphicsResult = token->service(_graphicsServiceId);
+    auto entityManagerResult = token->entityManager();
+    if (!entityManagerResult.ok())
+        return vigine::Result(vigine::Result::Code::Error, "Entity manager is unavailable");
+    auto *entityManager =
+        dynamic_cast<vigine::EntityManager *>(&entityManagerResult.value());
+    if (!entityManager)
+        return vigine::Result(vigine::Result::Code::Error,
+                              "Entity manager has unexpected type");
+
+    auto graphicsResult = token->service(vigine::service::wellknown::graphicsService);
     if (!graphicsResult.ok())
         return vigine::Result(vigine::Result::Code::Error, "Graphics service is unavailable");
 
@@ -46,11 +44,11 @@ vigine::Result SetupCubeTask::run()
 
     auto *renderSystem = graphicsService->renderSystem();
 
-    auto *cubeEntity = _entityManager->createEntity();
+    auto *cubeEntity = entityManager->createEntity();
     if (!cubeEntity)
         return vigine::Result(vigine::Result::Code::Error, "Failed to create cube entity");
 
-    _entityManager->addAlias(cubeEntity, "CubeEntity");
+    entityManager->addAlias(cubeEntity, "CubeEntity");
 
     renderSystem->createComponents(cubeEntity);
     renderSystem->bindEntity(cubeEntity);

--- a/example/window/task/vulkan/setupcubetask.h
+++ b/example/window/task/vulkan/setupcubetask.h
@@ -1,20 +1,6 @@
 #pragma once
 
 #include <vigine/api/taskflow/abstracttask.h>
-#include <vigine/api/service/serviceid.h>
-
-namespace vigine
-{
-class EntityManager;
-
-namespace ecs
-{
-namespace graphics
-{
-class GraphicsService;
-}
-} // namespace ecs
-} // namespace vigine
 
 class SetupCubeTask final : public vigine::AbstractTask
 {
@@ -22,11 +8,4 @@ class SetupCubeTask final : public vigine::AbstractTask
     SetupCubeTask();
 
     [[nodiscard]] vigine::Result run() override;
-
-    void setEntityManager(vigine::EntityManager *entityManager) noexcept;
-    void setGraphicsServiceId(vigine::service::ServiceId id) noexcept;
-
-  private:
-    vigine::EntityManager *_entityManager{nullptr};
-    vigine::service::ServiceId _graphicsServiceId{};
 };

--- a/example/window/task/vulkan/setuphelpergeometrytask.cpp
+++ b/example/window/task/vulkan/setuphelpergeometrytask.cpp
@@ -30,7 +30,7 @@ vigine::Result SetupHelperGeometryTask::run()
     if (!_entityManager)
         return vigine::Result(vigine::Result::Code::Error, "EntityManager is unavailable");
 
-    auto *token = api();
+    auto *token = apiToken();
     if (!token)
         return vigine::Result(vigine::Result::Code::Error, "Engine token is unavailable");
 

--- a/example/window/task/vulkan/setuphelpergeometrytask.cpp
+++ b/example/window/task/vulkan/setuphelpergeometrytask.cpp
@@ -1,6 +1,8 @@
 #include "setuphelpergeometrytask.h"
 
+#include <vigine/api/ecs/ientitymanager.h>
 #include <vigine/api/engine/iengine_token.h>
+#include <vigine/api/service/wellknown.h>
 #include <vigine/impl/ecs/entitymanager.h>
 #include <vigine/impl/ecs/graphics/meshcomponent.h>
 #include <vigine/impl/ecs/graphics/rendercomponent.h>
@@ -13,44 +15,41 @@
 
 SetupHelperGeometryTask::SetupHelperGeometryTask() = default;
 
-void SetupHelperGeometryTask::setEntityManager(vigine::EntityManager *entityManager) noexcept
-{
-    _entityManager = entityManager;
-}
-
-void SetupHelperGeometryTask::setGraphicsServiceId(vigine::service::ServiceId id) noexcept
-{
-    _graphicsServiceId = id;
-}
-
 vigine::Result SetupHelperGeometryTask::run()
 {
     std::cout << "Setting up helper geometry (pyramid, grid, sun)..." << std::endl;
-
-    if (!_entityManager)
-        return vigine::Result(vigine::Result::Code::Error, "EntityManager is unavailable");
 
     auto *token = apiToken();
     if (!token)
         return vigine::Result(vigine::Result::Code::Error, "Engine token is unavailable");
 
-    auto graphicsResult = token->service(_graphicsServiceId);
+    auto entityManagerResult = token->entityManager();
+    if (!entityManagerResult.ok())
+        return vigine::Result(vigine::Result::Code::Error, "Entity manager is unavailable");
+    auto *entityManager =
+        dynamic_cast<vigine::EntityManager *>(&entityManagerResult.value());
+    if (!entityManager)
+        return vigine::Result(vigine::Result::Code::Error,
+                              "Entity manager has unexpected type");
+
+    auto graphicsResult = token->service(vigine::service::wellknown::graphicsService);
     if (!graphicsResult.ok())
         return vigine::Result(vigine::Result::Code::Error, "Graphics service is unavailable");
 
     auto *graphicsService =
         dynamic_cast<vigine::ecs::graphics::GraphicsService *>(&graphicsResult.value());
     if (!graphicsService || !graphicsService->renderSystem())
-        return vigine::Result(vigine::Result::Code::Error, "Graphics service is unavailable");
+        return vigine::Result(vigine::Result::Code::Error,
+                              "Graphics service is unavailable");
 
     auto *renderSystem = graphicsService->renderSystem();
 
     // --- Pyramid Entity ---
-    auto *pyramidEntity = _entityManager->createEntity();
+    auto *pyramidEntity = entityManager->createEntity();
     if (!pyramidEntity)
         return vigine::Result(vigine::Result::Code::Error, "Failed to create pyramid entity");
 
-    _entityManager->addAlias(pyramidEntity, "PyramidEntity");
+    entityManager->addAlias(pyramidEntity, "PyramidEntity");
 
     renderSystem->createComponents(pyramidEntity);
     renderSystem->bindEntity(pyramidEntity);
@@ -79,11 +78,11 @@ vigine::Result SetupHelperGeometryTask::run()
     renderSystem->unbindEntity();
 
     // --- Grid Entity ---
-    auto *gridEntity = _entityManager->createEntity();
+    auto *gridEntity = entityManager->createEntity();
     if (!gridEntity)
         return vigine::Result(vigine::Result::Code::Error, "Failed to create grid entity");
 
-    _entityManager->addAlias(gridEntity, "GridEntity");
+    entityManager->addAlias(gridEntity, "GridEntity");
 
     renderSystem->createComponents(gridEntity);
     renderSystem->bindEntity(gridEntity);
@@ -112,11 +111,11 @@ vigine::Result SetupHelperGeometryTask::run()
     renderSystem->unbindEntity();
 
     // --- Sun Entity ---
-    auto *sunEntity = _entityManager->createEntity();
+    auto *sunEntity = entityManager->createEntity();
     if (!sunEntity)
         return vigine::Result(vigine::Result::Code::Error, "Failed to create sun entity");
 
-    _entityManager->addAlias(sunEntity, "SunEntity");
+    entityManager->addAlias(sunEntity, "SunEntity");
 
     renderSystem->createComponents(sunEntity);
     renderSystem->bindEntity(sunEntity);

--- a/example/window/task/vulkan/setuphelpergeometrytask.h
+++ b/example/window/task/vulkan/setuphelpergeometrytask.h
@@ -1,20 +1,6 @@
 #pragma once
 
 #include <vigine/api/taskflow/abstracttask.h>
-#include <vigine/api/service/serviceid.h>
-
-namespace vigine
-{
-class EntityManager;
-
-namespace ecs
-{
-namespace graphics
-{
-class GraphicsService;
-}
-} // namespace ecs
-} // namespace vigine
 
 class SetupHelperGeometryTask final : public vigine::AbstractTask
 {
@@ -22,11 +8,4 @@ class SetupHelperGeometryTask final : public vigine::AbstractTask
     SetupHelperGeometryTask();
 
     [[nodiscard]] vigine::Result run() override;
-
-    void setEntityManager(vigine::EntityManager *entityManager) noexcept;
-    void setGraphicsServiceId(vigine::service::ServiceId id) noexcept;
-
-  private:
-    vigine::EntityManager *_entityManager{nullptr};
-    vigine::service::ServiceId _graphicsServiceId{};
 };

--- a/example/window/task/vulkan/setuptextedittask.cpp
+++ b/example/window/task/vulkan/setuptextedittask.cpp
@@ -104,6 +104,15 @@ vigine::Result SetupTextEditTask::run()
     if (!state)
         return vigine::Result(vigine::Result::Code::Error, "TextEditState is null");
 
+    // Bind the interaction component against the MainWindow entity so
+    // every per-event method on TextEditorSystem (routeMouseButtonDown,
+    // routeKeyDown, routeWindowResized, ...) has a live record to read
+    // and write through. The component carries every piece of UI
+    // state @c RunWindowTask used to keep on its own object — focus,
+    // object drag, mouse-ray helper, modifier keys, debounced resize.
+    if (auto *mainWindow = entityManager->getEntityByAlias("MainWindow"))
+        editorService->bindInteractionEntity(mainWindow);
+
     const auto fontPath = resolveFontPath();
     if (fontPath.empty())
         return vigine::Result(vigine::Result::Code::Error,

--- a/example/window/task/vulkan/setuptextedittask.cpp
+++ b/example/window/task/vulkan/setuptextedittask.cpp
@@ -1,6 +1,10 @@
 #include "setuptextedittask.h"
 
+#include <vigine/api/context/icontext.h>
+#include <vigine/api/ecs/ientitymanager.h>
+#include <vigine/api/engine/iengine.h>
 #include <vigine/api/engine/iengine_token.h>
+#include <vigine/api/service/wellknown.h>
 #include <vigine/impl/ecs/entitymanager.h>
 #include <vigine/impl/ecs/graphics/meshcomponent.h>
 #include <vigine/impl/ecs/graphics/rendercomponent.h>
@@ -9,6 +13,11 @@
 #include <vigine/impl/ecs/graphics/textcomponent.h>
 #include <vigine/impl/ecs/graphics/transformcomponent.h>
 #include <vigine/impl/ecs/graphics/graphicsservice.h>
+
+#include "../../services/texteditorservice.h"
+#include "../../services/wellknown.h"
+#include "../../system/texteditorsystem.h"
+#include "../../texteditstate.h"
 
 #include <filesystem>
 #include <glm/glm.hpp>
@@ -46,32 +55,24 @@ std::string resolveFontPath()
 }
 } // namespace
 
-SetupTextEditTask::SetupTextEditTask(std::shared_ptr<TextEditState> state,
-                                     std::shared_ptr<TextEditorSystem> editorSystem)
-    : _state(std::move(state)), _editorSystem(std::move(editorSystem))
-{
-}
-
-void SetupTextEditTask::setEntityManager(vigine::EntityManager *entityManager) noexcept
-{
-    _entityManager = entityManager;
-}
-
-void SetupTextEditTask::setGraphicsServiceId(vigine::service::ServiceId id) noexcept
-{
-    _graphicsServiceId = id;
-}
+SetupTextEditTask::SetupTextEditTask() = default;
 
 vigine::Result SetupTextEditTask::run()
 {
-    if (!_entityManager)
-        return vigine::Result(vigine::Result::Code::Error, "EntityManager is unavailable");
-
     auto *token = apiToken();
     if (!token)
         return vigine::Result(vigine::Result::Code::Error, "Engine token is unavailable");
 
-    auto graphicsResult = token->service(_graphicsServiceId);
+    auto entityManagerResult = token->entityManager();
+    if (!entityManagerResult.ok())
+        return vigine::Result(vigine::Result::Code::Error, "Entity manager is unavailable");
+    auto *entityManager =
+        dynamic_cast<vigine::EntityManager *>(&entityManagerResult.value());
+    if (!entityManager)
+        return vigine::Result(vigine::Result::Code::Error,
+                              "Entity manager has unexpected type");
+
+    auto graphicsResult = token->service(vigine::service::wellknown::graphicsService);
     if (!graphicsResult.ok())
         return vigine::Result(vigine::Result::Code::Error, "Graphics service is unavailable");
 
@@ -82,10 +83,25 @@ vigine::Result SetupTextEditTask::run()
 
     auto *renderSystem = graphicsService->renderSystem();
 
-    if (_editorSystem)
-        _editorSystem->bind(_entityManager, graphicsService, renderSystem);
+    // Resolve the app-scope TextEditorService and ensure it is wired
+    // (binds the underlying TextEditorSystem to the entity manager and
+    // graphics service / render system on the first call; idempotent).
+    auto editorSvcResult =
+        token->service(example::services::wellknown::textEditor);
+    if (!editorSvcResult.ok())
+        return vigine::Result(vigine::Result::Code::Error,
+                              "Text editor service is unavailable");
+    auto *editorService =
+        dynamic_cast<TextEditorService *>(&editorSvcResult.value());
+    if (!editorService)
+        return vigine::Result(vigine::Result::Code::Error,
+                              "Text editor service has unexpected type");
 
-    if (!_state)
+    editorService->ensureWired(token->engine().context());
+    auto state        = editorService->state();
+    auto editorSystem = editorService->system();
+
+    if (!state)
         return vigine::Result(vigine::Result::Code::Error, "TextEditState is null");
 
     const auto fontPath = resolveFontPath();
@@ -95,11 +111,11 @@ vigine::Result SetupTextEditTask::run()
 
     // --- Background panel ---
     {
-        auto *bgEntity = _entityManager->createEntity();
+        auto *bgEntity = entityManager->createEntity();
         if (!bgEntity)
             return vigine::Result(vigine::Result::Code::Error, "Failed to create TextEditBgEntity");
 
-        _entityManager->addAlias(bgEntity, "TextEditBgEntity");
+        entityManager->addAlias(bgEntity, "TextEditBgEntity");
         renderSystem->createComponents(bgEntity);
         renderSystem->bindEntity(bgEntity);
 
@@ -133,12 +149,12 @@ vigine::Result SetupTextEditTask::run()
 
     // --- Vertical scrollbar track + thumb ---
     {
-        auto *trackEntity = _entityManager->createEntity();
+        auto *trackEntity = entityManager->createEntity();
         if (!trackEntity)
             return vigine::Result(vigine::Result::Code::Error,
                                   "Failed to create TextEditScrollbarTrackEntity");
 
-        _entityManager->addAlias(trackEntity, "TextEditScrollbarTrackEntity");
+        entityManager->addAlias(trackEntity, "TextEditScrollbarTrackEntity");
         renderSystem->createComponents(trackEntity);
         renderSystem->bindEntity(trackEntity);
 
@@ -165,12 +181,12 @@ vigine::Result SetupTextEditTask::run()
         rc->setTransform(transform);
         renderSystem->unbindEntity();
 
-        auto *thumbEntity = _entityManager->createEntity();
+        auto *thumbEntity = entityManager->createEntity();
         if (!thumbEntity)
             return vigine::Result(vigine::Result::Code::Error,
                                   "Failed to create TextEditScrollbarThumbEntity");
 
-        _entityManager->addAlias(thumbEntity, "TextEditScrollbarThumbEntity");
+        entityManager->addAlias(thumbEntity, "TextEditScrollbarThumbEntity");
         renderSystem->createComponents(thumbEntity);
         renderSystem->bindEntity(thumbEntity);
 
@@ -200,11 +216,11 @@ vigine::Result SetupTextEditTask::run()
 
     // --- Editable text (bitmap-style with individual character planes) ---
     {
-        auto *textEntity = _entityManager->createEntity();
+        auto *textEntity = entityManager->createEntity();
         if (!textEntity)
             return vigine::Result(vigine::Result::Code::Error, "Failed to create TextEditEntity");
 
-        _entityManager->addAlias(textEntity, "TextEditEntity");
+        entityManager->addAlias(textEntity, "TextEditEntity");
         renderSystem->createComponents(textEntity);
         renderSystem->bindEntity(textEntity);
 
@@ -219,9 +235,9 @@ vigine::Result SetupTextEditTask::run()
         vigine::ecs::graphics::TextComponent text;
         text.setEnabled(true);
         text.setDrawBaseInstance(false);
-        text.setText(_state->text);
-        text.setCursorBytePos(_state->cursorPos);
-        text.setCursorVisible(_state->showCursor);
+        text.setText(state->text);
+        text.setCursorBytePos(state->cursorPos);
+        text.setCursorVisible(state->showCursor);
         text.setFontPath(fontPath);
         text.setPixelSize(28);
         text.setVoxelSize(0.0022f);
@@ -283,12 +299,12 @@ vigine::Result SetupTextEditTask::run()
 
         for (const auto &alias : aliases)
         {
-            auto *e = _entityManager->createEntity();
+            auto *e = entityManager->createEntity();
             if (!e)
                 return vigine::Result(vigine::Result::Code::Error,
                                       "Failed to create focus frame entity");
 
-            _entityManager->addAlias(e, alias);
+            entityManager->addAlias(e, alias);
             renderSystem->createComponents(e);
             renderSystem->bindEntity(e);
 
@@ -317,10 +333,10 @@ vigine::Result SetupTextEditTask::run()
         }
     }
 
-    if (_editorSystem)
+    if (editorSystem)
     {
-        _editorSystem->setLayout(40, kPanelWidth, kPanelHeight);
-        _editorSystem->setFocused(false);
+        editorSystem->setLayout(40, kPanelWidth, kPanelHeight);
+        editorSystem->setFocused(false);
     }
 
     return vigine::Result();

--- a/example/window/task/vulkan/setuptextedittask.cpp
+++ b/example/window/task/vulkan/setuptextedittask.cpp
@@ -99,7 +99,7 @@ vigine::Result SetupTextEditTask::run()
 
     editorService->ensureWired(token->engine().context());
     auto state        = editorService->state();
-    auto editorSystem = editorService->system();
+    auto editorSystem = editorService->textEditorSystem();
 
     if (!state)
         return vigine::Result(vigine::Result::Code::Error, "TextEditState is null");

--- a/example/window/task/vulkan/setuptextedittask.cpp
+++ b/example/window/task/vulkan/setuptextedittask.cpp
@@ -67,7 +67,7 @@ vigine::Result SetupTextEditTask::run()
     if (!_entityManager)
         return vigine::Result(vigine::Result::Code::Error, "EntityManager is unavailable");
 
-    auto *token = api();
+    auto *token = apiToken();
     if (!token)
         return vigine::Result(vigine::Result::Code::Error, "Engine token is unavailable");
 

--- a/example/window/task/vulkan/setuptextedittask.h
+++ b/example/window/task/vulkan/setuptextedittask.h
@@ -1,48 +1,24 @@
 #pragma once
 
 #include <vigine/api/taskflow/abstracttask.h>
-#include <vigine/api/service/serviceid.h>
 
-#include "../../system/texteditorsystem.h"
-#include "../../texteditstate.h"
-
-#include <memory>
-
-
-namespace vigine
-{
-class EntityManager;
-
-namespace ecs
-{
-namespace graphics
-{
-class GraphicsService;
-}
-} // namespace ecs
-} // namespace vigine
-
-// Creates two entities for the 3D text editor:
-//   "TextEditBgEntity"  - flat rectangular background panel (MeshComponent plane)
-//   "TextEditEntity"    - bitmap text with individual character planes
-//
-// Each character is rendered as a small plane with a unique color based on its ASCII value.
-// Shares TextEditState with RunWindowTask so that keyboard input can update the
-// text and the dirty flag triggers a mesh rebuild every frame.
+/**
+ * @brief Creates entities for the 3D text editor:
+ *   "TextEditBgEntity"               - flat rectangular background panel
+ *   "TextEditEntity"                 - editable text (instanced glyph quads)
+ *   "TextEditScrollbarTrackEntity"   - scrollbar track
+ *   "TextEditScrollbarThumbEntity"   - scrollbar thumb
+ *   "TextEditFocus*Entity"           - focus frame (4 thin lines, hidden by default)
+ *
+ * The task self-resolves every dependency through @ref apiToken in
+ * @ref run — the engine-default entity manager + the well-known
+ * graphics service for render-system access, and the app-scope
+ * @c TextEditorService for the editor's state + system pair.
+ */
 class SetupTextEditTask final : public vigine::AbstractTask
 {
   public:
-    SetupTextEditTask(std::shared_ptr<TextEditState> state,
-                      std::shared_ptr<TextEditorSystem> editorSystem);
+    SetupTextEditTask();
 
     [[nodiscard]] vigine::Result run() override;
-
-    void setEntityManager(vigine::EntityManager *entityManager) noexcept;
-    void setGraphicsServiceId(vigine::service::ServiceId id) noexcept;
-
-  private:
-    std::shared_ptr<TextEditState> _state;
-    std::shared_ptr<TextEditorSystem> _editorSystem;
-    vigine::EntityManager *_entityManager{nullptr};
-    vigine::service::ServiceId _graphicsServiceId{};
 };

--- a/example/window/task/vulkan/setuptexttask.cpp
+++ b/example/window/task/vulkan/setuptexttask.cpp
@@ -53,7 +53,7 @@ vigine::Result SetupTextTask::run()
     if (!_entityManager)
         return vigine::Result(vigine::Result::Code::Error, "EntityManager is unavailable");
 
-    auto *token = api();
+    auto *token = apiToken();
     if (!token)
         return vigine::Result(vigine::Result::Code::Error, "Engine token is unavailable");
 

--- a/example/window/task/vulkan/setuptexttask.cpp
+++ b/example/window/task/vulkan/setuptexttask.cpp
@@ -1,6 +1,8 @@
 #include "setuptexttask.h"
 
+#include <vigine/api/ecs/ientitymanager.h>
 #include <vigine/api/engine/iengine_token.h>
+#include <vigine/api/service/wellknown.h>
 #include <vigine/impl/ecs/entitymanager.h>
 #include <vigine/impl/ecs/graphics/rendercomponent.h>
 #include <vigine/impl/ecs/graphics/rendersystem.h>
@@ -38,33 +40,30 @@ std::string resolveFontPath()
 
 SetupTextTask::SetupTextTask() = default;
 
-void SetupTextTask::setEntityManager(vigine::EntityManager *entityManager) noexcept
-{
-    _entityManager = entityManager;
-}
-
-void SetupTextTask::setGraphicsServiceId(vigine::service::ServiceId id) noexcept
-{
-    _graphicsServiceId = id;
-}
-
 vigine::Result SetupTextTask::run()
 {
-    if (!_entityManager)
-        return vigine::Result(vigine::Result::Code::Error, "EntityManager is unavailable");
-
     auto *token = apiToken();
     if (!token)
         return vigine::Result(vigine::Result::Code::Error, "Engine token is unavailable");
 
-    auto graphicsResult = token->service(_graphicsServiceId);
+    auto entityManagerResult = token->entityManager();
+    if (!entityManagerResult.ok())
+        return vigine::Result(vigine::Result::Code::Error, "Entity manager is unavailable");
+    auto *entityManager =
+        dynamic_cast<vigine::EntityManager *>(&entityManagerResult.value());
+    if (!entityManager)
+        return vigine::Result(vigine::Result::Code::Error,
+                              "Entity manager has unexpected type");
+
+    auto graphicsResult = token->service(vigine::service::wellknown::graphicsService);
     if (!graphicsResult.ok())
         return vigine::Result(vigine::Result::Code::Error, "Graphics service is unavailable");
 
     auto *graphicsService =
         dynamic_cast<vigine::ecs::graphics::GraphicsService *>(&graphicsResult.value());
     if (!graphicsService || !graphicsService->renderSystem())
-        return vigine::Result(vigine::Result::Code::Error, "Graphics service is unavailable");
+        return vigine::Result(vigine::Result::Code::Error,
+                              "Graphics service is unavailable");
 
     auto *renderSystem = graphicsService->renderSystem();
 
@@ -73,11 +72,11 @@ vigine::Result SetupTextTask::run()
         return vigine::Result(vigine::Result::Code::Error,
                               "Font file not found (assets/fonts/segoeui.ttf)");
 
-    auto *textEntity = _entityManager->createEntity();
+    auto *textEntity = entityManager->createEntity();
     if (!textEntity)
         return vigine::Result(vigine::Result::Code::Error, "Failed to create text entity");
 
-    _entityManager->addAlias(textEntity, "TextEntity");
+    entityManager->addAlias(textEntity, "TextEntity");
 
     renderSystem->createComponents(textEntity);
     renderSystem->bindEntity(textEntity);

--- a/example/window/task/vulkan/setuptexttask.h
+++ b/example/window/task/vulkan/setuptexttask.h
@@ -1,20 +1,6 @@
 #pragma once
 
 #include <vigine/api/taskflow/abstracttask.h>
-#include <vigine/api/service/serviceid.h>
-
-namespace vigine
-{
-class EntityManager;
-
-namespace ecs
-{
-namespace graphics
-{
-class GraphicsService;
-}
-} // namespace ecs
-} // namespace vigine
 
 class SetupTextTask final : public vigine::AbstractTask
 {
@@ -22,11 +8,4 @@ class SetupTextTask final : public vigine::AbstractTask
     SetupTextTask();
 
     [[nodiscard]] vigine::Result run() override;
-
-    void setEntityManager(vigine::EntityManager *entityManager) noexcept;
-    void setGraphicsServiceId(vigine::service::ServiceId id) noexcept;
-
-  private:
-    vigine::EntityManager *_entityManager{nullptr};
-    vigine::service::ServiceId _graphicsServiceId{};
 };

--- a/example/window/task/vulkan/setuptexturedplanestask.cpp
+++ b/example/window/task/vulkan/setuptexturedplanestask.cpp
@@ -1,6 +1,8 @@
 #include "setuptexturedplanestask.h"
 
+#include <vigine/api/ecs/ientitymanager.h>
 #include <vigine/api/engine/iengine_token.h>
+#include <vigine/api/service/wellknown.h>
 #include <vigine/impl/ecs/entitymanager.h>
 #include <vigine/impl/ecs/graphics/meshcomponent.h>
 #include <vigine/impl/ecs/graphics/rendercomponent.h>
@@ -13,28 +15,24 @@
 #include <cmath>
 #include <iostream>
 
-void SetupTexturedPlanesTask::setEntityManager(vigine::EntityManager *entityManager) noexcept
-{
-    _entityManager = entityManager;
-}
-
-void SetupTexturedPlanesTask::setGraphicsServiceId(vigine::service::ServiceId id) noexcept
-{
-    _graphicsServiceId = id;
-}
-
 vigine::Result SetupTexturedPlanesTask::run()
 {
     std::cout << "Setting up textured planes..." << std::endl;
-
-    if (!_entityManager)
-        return vigine::Result(vigine::Result::Code::Error, "EntityManager is unavailable");
 
     auto *token = apiToken();
     if (!token)
         return vigine::Result(vigine::Result::Code::Error, "Engine token is unavailable");
 
-    auto graphicsResult = token->service(_graphicsServiceId);
+    auto entityManagerResult = token->entityManager();
+    if (!entityManagerResult.ok())
+        return vigine::Result(vigine::Result::Code::Error, "Entity manager is unavailable");
+    auto *entityManager =
+        dynamic_cast<vigine::EntityManager *>(&entityManagerResult.value());
+    if (!entityManager)
+        return vigine::Result(vigine::Result::Code::Error,
+                              "Entity manager has unexpected type");
+
+    auto graphicsResult = token->service(vigine::service::wellknown::graphicsService);
     if (!graphicsResult.ok())
         return vigine::Result(vigine::Result::Code::Error, "Graphics service is unavailable");
 
@@ -54,7 +52,7 @@ vigine::Result SetupTexturedPlanesTask::run()
 
     // Discover all loaded texture entities (TextureEntity_0, TextureEntity_1, ...)
     size_t textureCount = 0;
-    while (_entityManager->getEntityByAlias("TextureEntity_" + std::to_string(textureCount)))
+    while (entityManager->getEntityByAlias("TextureEntity_" + std::to_string(textureCount)))
         ++textureCount;
 
     std::cout << "Found " << textureCount << " texture entities" << std::endl;
@@ -92,7 +90,7 @@ vigine::Result SetupTexturedPlanesTask::run()
     for (const auto &config : planes)
     {
         // Find texture entity
-        auto *textureEntity = _entityManager->getEntityByAlias(config.textureEntityName);
+        auto *textureEntity = entityManager->getEntityByAlias(config.textureEntityName);
         if (!textureEntity)
         {
             std::cerr << "Texture entity not found: " << config.textureEntityName << std::endl;
@@ -100,14 +98,14 @@ vigine::Result SetupTexturedPlanesTask::run()
         }
 
         // Create plane entity
-        auto *planeEntity = _entityManager->createEntity();
+        auto *planeEntity = entityManager->createEntity();
         if (!planeEntity)
         {
             std::cerr << "Failed to create plane entity: " << config.entityName << std::endl;
             continue;
         }
 
-        _entityManager->addAlias(planeEntity, config.entityName);
+        entityManager->addAlias(planeEntity, config.entityName);
         renderSystem->createComponents(planeEntity);
         renderSystem->bindEntity(planeEntity);
 

--- a/example/window/task/vulkan/setuptexturedplanestask.cpp
+++ b/example/window/task/vulkan/setuptexturedplanestask.cpp
@@ -30,7 +30,7 @@ vigine::Result SetupTexturedPlanesTask::run()
     if (!_entityManager)
         return vigine::Result(vigine::Result::Code::Error, "EntityManager is unavailable");
 
-    auto *token = api();
+    auto *token = apiToken();
     if (!token)
         return vigine::Result(vigine::Result::Code::Error, "Engine token is unavailable");
 

--- a/example/window/task/vulkan/setuptexturedplanestask.h
+++ b/example/window/task/vulkan/setuptexturedplanestask.h
@@ -1,20 +1,6 @@
 #pragma once
 
 #include <vigine/api/taskflow/abstracttask.h>
-#include <vigine/api/service/serviceid.h>
-
-namespace vigine
-{
-class EntityManager;
-
-namespace ecs
-{
-namespace graphics
-{
-class GraphicsService;
-}
-} // namespace ecs
-} // namespace vigine
 
 class SetupTexturedPlanesTask final : public vigine::AbstractTask
 {
@@ -22,11 +8,4 @@ class SetupTexturedPlanesTask final : public vigine::AbstractTask
     SetupTexturedPlanesTask() = default;
 
     [[nodiscard]] vigine::Result run() override;
-
-    void setEntityManager(vigine::EntityManager *entityManager) noexcept;
-    void setGraphicsServiceId(vigine::service::ServiceId id) noexcept;
-
-  private:
-    vigine::EntityManager *_entityManager{nullptr};
-    vigine::service::ServiceId _graphicsServiceId{};
 };

--- a/example/window/task/window/initwindowtask.cpp
+++ b/example/window/task/window/initwindowtask.cpp
@@ -1,22 +1,14 @@
 #include "initwindowtask.h"
 
+#include <vigine/api/ecs/ientitymanager.h>
 #include <vigine/api/engine/iengine_token.h>
-#include "vigine/impl/ecs/entitymanager.h"
+#include <vigine/api/service/wellknown.h>
+#include <vigine/impl/ecs/entitymanager.h>
 #include <vigine/impl/ecs/platform/platformservice.h>
 
 #include "../../handler/windoweventhandler.h"
 
 InitWindowTask::InitWindowTask() = default;
-
-void InitWindowTask::setEntityManager(vigine::EntityManager *entityManager) noexcept
-{
-    _entityManager = entityManager;
-}
-
-void InitWindowTask::setPlatformServiceId(vigine::service::ServiceId id) noexcept
-{
-    _platformServiceId = id;
-}
 
 void InitWindowTask::createEventHandlers()
 {
@@ -26,14 +18,20 @@ void InitWindowTask::createEventHandlers()
 
 vigine::Result InitWindowTask::run()
 {
-    if (!_entityManager)
-        return vigine::Result(vigine::Result::Code::Error, "EntityManager is unavailable");
-
     auto *token = apiToken();
     if (!token)
         return vigine::Result(vigine::Result::Code::Error, "Engine token is unavailable");
 
-    auto platformResult = token->service(_platformServiceId);
+    auto entityManagerResult = token->entityManager();
+    if (!entityManagerResult.ok())
+        return vigine::Result(vigine::Result::Code::Error, "Entity manager is unavailable");
+    auto *entityManager =
+        dynamic_cast<vigine::EntityManager *>(&entityManagerResult.value());
+    if (!entityManager)
+        return vigine::Result(vigine::Result::Code::Error,
+                              "Entity manager has unexpected type");
+
+    auto platformResult = token->service(vigine::service::wellknown::platformService);
     if (!platformResult.ok())
         return vigine::Result(vigine::Result::Code::Error, "Platform service is unavailable");
 
@@ -43,7 +41,7 @@ vigine::Result InitWindowTask::run()
         return vigine::Result(vigine::Result::Code::Error,
                               "Platform service has unexpected type");
 
-    auto *entity = _entityManager->createEntity();
+    auto *entity = entityManager->createEntity();
 
     createEventHandlers();
 
@@ -56,7 +54,7 @@ vigine::Result InitWindowTask::run()
     if (bindResult.isError())
         return bindResult;
 
-    _entityManager->addAlias(entity, "MainWindow");
+    entityManager->addAlias(entity, "MainWindow");
 
     return vigine::Result();
 }

--- a/example/window/task/window/initwindowtask.cpp
+++ b/example/window/task/window/initwindowtask.cpp
@@ -29,7 +29,7 @@ vigine::Result InitWindowTask::run()
     if (!_entityManager)
         return vigine::Result(vigine::Result::Code::Error, "EntityManager is unavailable");
 
-    auto *token = api();
+    auto *token = apiToken();
     if (!token)
         return vigine::Result(vigine::Result::Code::Error, "Engine token is unavailable");
 

--- a/example/window/task/window/initwindowtask.h
+++ b/example/window/task/window/initwindowtask.h
@@ -2,35 +2,19 @@
 
 #include <vigine/api/taskflow/abstracttask.h>
 #include <vigine/api/ecs/platform/iwindoweventhandler.h>
-#include <vigine/api/service/serviceid.h>
 
 #include <memory>
 #include <vector>
-
-namespace vigine
-{
-class EntityManager;
-
-namespace ecs
-{
-namespace platform
-{
-class PlatformService;
-}
-} // namespace ecs
-} // namespace vigine
 
 /**
  * @brief Creates the main window entity and binds the platform service
  *        + a fresh @c WindowComponent + the example's event handler.
  *
- * Constructed before @c IEngine::run with the legacy @c EntityManager
- * pointer and the @ref vigine::service::ServiceId stamped for the
- * platform service at registration time. @ref run resolves the
- * platform service through @ref apiToken()->service so the lookup honours
- * the engine-token gate; on a token-expired return path the task
- * surfaces the error to the FSM transition table without touching the
- * service.
+ * The task self-resolves every dependency through @ref apiToken
+ * inside @ref run: the engine-token's entity manager (the engine's
+ * default @c EntityManager) and the well-known platform service id
+ * resolve every handle the task needs without anyone wiring them up
+ * via setters at construction time.
  */
 class InitWindowTask final : public vigine::AbstractTask
 {
@@ -39,13 +23,8 @@ class InitWindowTask final : public vigine::AbstractTask
 
     [[nodiscard]] vigine::Result run() override;
 
-    void setEntityManager(vigine::EntityManager *entityManager) noexcept;
-    void setPlatformServiceId(vigine::service::ServiceId id) noexcept;
-
   private:
     void createEventHandlers();
 
-    vigine::EntityManager *_entityManager{nullptr};
-    vigine::service::ServiceId _platformServiceId{};
     std::vector<std::unique_ptr<vigine::ecs::platform::IWindowEventHandlerComponent>> _eventHandlers;
 };

--- a/example/window/task/window/initwindowtask.h
+++ b/example/window/task/window/initwindowtask.h
@@ -27,7 +27,7 @@ class PlatformService;
  * Constructed before @c IEngine::run with the legacy @c EntityManager
  * pointer and the @ref vigine::service::ServiceId stamped for the
  * platform service at registration time. @ref run resolves the
- * platform service through @ref api()->service so the lookup honours
+ * platform service through @ref apiToken()->service so the lookup honours
  * the engine-token gate; on a token-expired return path the task
  * surfaces the error to the FSM transition table without touching the
  * service.

--- a/example/window/task/window/runwindowtask.cpp
+++ b/example/window/task/window/runwindowtask.cpp
@@ -1,8 +1,12 @@
 #include "runwindowtask.h"
 
+#include <vigine/api/context/icontext.h>
+#include <vigine/api/ecs/ientitymanager.h>
 #include <vigine/api/engine/iengine.h>
 #include <vigine/api/engine/iengine_token.h>
+#include <vigine/api/messaging/isignalemitter.h>
 #include <vigine/api/messaging/isubscriptiontoken.h>
+#include <vigine/api/service/wellknown.h>
 #include "vigine/impl/ecs/entity.h"
 #include "vigine/impl/ecs/entitymanager.h"
 #include "vigine/impl/ecs/graphics/meshcomponent.h"
@@ -14,6 +18,9 @@
 #include <vigine/impl/ecs/platform/platformservice.h>
 
 #include "../../handler/windoweventhandler.h"
+#include "../../services/texteditorservice.h"
+#include "../../services/wellknown.h"
+#include "../../system/texteditorsystem.h"
 #include "impl/ecs/platform/windowcomponent.h"
 #include "windoweventpayload.h"
 
@@ -86,61 +93,51 @@ std::wstring wideFromUtf8(const std::string &utf8)
 
 RunWindowTask::RunWindowTask() {}
 
-void RunWindowTask::setEntityManager(vigine::EntityManager *entityManager) noexcept
+RunWindowTask::Deps RunWindowTask::resolveDeps() const
 {
-    _entityManager = entityManager;
-}
+    Deps deps;
 
-void RunWindowTask::setPlatformServiceId(vigine::service::ServiceId id) noexcept
-{
-    _platformServiceId = id;
-}
-
-void RunWindowTask::setGraphicsServiceId(vigine::service::ServiceId id) noexcept
-{
-    _graphicsServiceId = id;
-}
-
-void RunWindowTask::setEngine(vigine::engine::IEngine *engine) noexcept
-{
-    _engine = engine;
-}
-
-bool RunWindowTask::resolveServices()
-{
-    auto *token = apiToken();
+    auto *token = const_cast<RunWindowTask *>(this)->apiToken();
     if (!token)
-        return false;
+        return deps;
 
-    if (!_platformService)
+    auto entityManagerResult = token->entityManager();
+    if (entityManagerResult.ok())
+        deps.entityManager =
+            dynamic_cast<vigine::EntityManager *>(&entityManagerResult.value());
+
+    auto platformResult = token->service(vigine::service::wellknown::platformService);
+    if (platformResult.ok())
+        deps.platformService = dynamic_cast<vigine::ecs::platform::PlatformService *>(
+            &platformResult.value());
+
+    auto graphicsResult = token->service(vigine::service::wellknown::graphicsService);
+    if (graphicsResult.ok())
     {
-        const auto platformResult = token->service(_platformServiceId);
-        if (!platformResult.ok())
-            return false;
-        _platformService =
-            dynamic_cast<vigine::ecs::platform::PlatformService *>(&platformResult.value());
-        if (!_platformService)
-            return false;
+        deps.graphicsService = dynamic_cast<vigine::ecs::graphics::GraphicsService *>(
+            &graphicsResult.value());
+        if (deps.graphicsService)
+            deps.renderSystem = deps.graphicsService->renderSystem();
     }
 
-    if (!_graphicsService)
+    deps.signalEmitter = &token->signalEmitter();
+    deps.engine        = &token->engine();
+
+    auto editorSvcResult = token->service(example::services::wellknown::textEditor);
+    if (editorSvcResult.ok())
     {
-        const auto graphicsResult = token->service(_graphicsServiceId);
-        if (!graphicsResult.ok())
-            return false;
-        _graphicsService =
-            dynamic_cast<vigine::ecs::graphics::GraphicsService *>(&graphicsResult.value());
-        if (!_graphicsService)
-            return false;
+        if (auto *editorService =
+                dynamic_cast<TextEditorService *>(&editorSvcResult.value()))
+        {
+            // ensureWired is idempotent — first call binds the
+            // underlying TextEditorSystem to the entity manager and
+            // graphics service, every subsequent call is a no-op.
+            editorService->ensureWired(deps.engine->context());
+            deps.textEditorSystem = editorService->system();
+        }
     }
 
-    if (!_renderSystem && _graphicsService)
-        _renderSystem = _graphicsService->renderSystem();
-
-    if (_textEditorSystem)
-        _textEditorSystem->bind(_entityManager, _graphicsService, _renderSystem);
-
-    return true;
+    return deps;
 }
 
 // COPILOT_TODO: Guarantee unbindEntity() on every early exit via an
@@ -148,20 +145,16 @@ bool RunWindowTask::resolveServices()
 // can stay bound to the entity after an error return path.
 vigine::Result RunWindowTask::run()
 {
-    if (!_entityManager)
-        return vigine::Result(vigine::Result::Code::Error, "EntityManager is unavailable");
-
-    if (!resolveServices())
+    auto deps = resolveDeps();
+    if (!deps.entityManager || !deps.platformService || !deps.graphicsService ||
+        !deps.renderSystem || !deps.engine)
         return vigine::Result(vigine::Result::Code::Error,
-                              "Platform/Graphics service is unavailable");
+                              "RunWindowTask: failed to resolve engine dependencies");
 
     // Subscribe a one-shot expiration callback the FIRST time the task
-    // runs. Subsequent ticks (the legacy task flow only schedules this
-    // task once per state entry, but defending against re-entry keeps
-    // the lifetime invariant clean) keep the existing subscription. The
-    // callback flips _shutdownRequested and asks the platform service
-    // to close the active windows so the blocking showWindow call
-    // unwinds and run() returns.
+    // runs. The callback flips _shutdownRequested and asks the platform
+    // service to close the active windows so the blocking showWindow
+    // call unwinds and run() returns.
     if (!_expirationSubscription)
     {
         if (auto *token = apiToken())
@@ -171,15 +164,15 @@ vigine::Result RunWindowTask::run()
         }
     }
 
-    auto *entity = _entityManager->getEntityByAlias("MainWindow");
+    auto *entity = deps.entityManager->getEntityByAlias("MainWindow");
     if (!entity)
         return vigine::Result(vigine::Result::Code::Error, "MainWindow entity not found");
     _mainWindowEntity = entity;
 
-    static_cast<void>(ensureMouseRayEntity());
-    static_cast<void>(ensureMouseClickSphereEntity());
+    static_cast<void>(ensureMouseRayEntity(deps));
+    static_cast<void>(ensureMouseClickSphereEntity(deps));
 
-    auto windows = _platformService->windowComponents(entity);
+    auto windows = deps.platformService->windowComponents(entity);
     if (windows.empty())
         return vigine::Result(vigine::Result::Code::Error, "Window component is unavailable");
 
@@ -190,7 +183,7 @@ vigine::Result RunWindowTask::run()
             return vigine::Result(vigine::Result::Code::Error,
                                   "Window component is unavailable");
 
-        auto eventHandlers = _platformService->windowEventHandlers(entity, window);
+        auto eventHandlers = deps.platformService->windowEventHandlers(entity, window);
         if (eventHandlers.empty())
             return vigine::Result(vigine::Result::Code::Error,
                                   "Window event handler is unavailable");
@@ -239,12 +232,10 @@ vigine::Result RunWindowTask::run()
 
         std::cout << "[RunWindowTask] Showing window " << (windowIndex + 1) << std::endl;
         window->setFrameCallback([this, window]() {
-            // Token expired (FSM transitioned away from the bound state
-            // while the frame callback was running) -- skip the render
-            // tick and post a WM_CLOSE so the platform message loop in
-            // @c WinAPIComponent::show observes a quit and unwinds. The
-            // check is lock-free and bounds the latency between the
-            // FSM transition and the window-close to one frame.
+            // Token expired -- post a WM_CLOSE so the platform message
+            // loop in @c WinAPIComponent::show observes a quit and
+            // unwinds. Lock-free check; bounds the FSM-transition →
+            // window-close latency to one frame.
             if (_shutdownRequested.load(std::memory_order_acquire))
             {
 #ifdef _WIN32
@@ -260,9 +251,14 @@ vigine::Result RunWindowTask::run()
                 return;
             }
 
+            // Per-frame deps resolution. Same engine-default services
+            // resolve every tick; the lookup is cheap (registry hash +
+            // dynamic_cast) and keeps the "no caches" rule visible.
+            auto frameDeps = resolveDeps();
+
             bool resizedThisTick = false;
 
-            if (_resizePending && _renderSystem)
+            if (_resizePending && frameDeps.renderSystem)
             {
                 const auto now    = std::chrono::steady_clock::now();
                 const bool paused = now - _lastResizeEvent >= std::chrono::milliseconds(80);
@@ -271,8 +267,8 @@ vigine::Result RunWindowTask::run()
                     if (_pendingResizeWidth != _appliedResizeWidth ||
                         _pendingResizeHeight != _appliedResizeHeight)
                     {
-                        const bool resized =
-                            _renderSystem->resize(_pendingResizeWidth, _pendingResizeHeight);
+                        const bool resized = frameDeps.renderSystem->resize(
+                            _pendingResizeWidth, _pendingResizeHeight);
                         if (!resized)
                         {
                             std::cerr << "[RunWindowTask] Failed to recreate swapchain on "
@@ -292,21 +288,21 @@ vigine::Result RunWindowTask::run()
                 }
             }
 
-            if (_textEditorSystem)
-                _textEditorSystem->onFrame();
+            if (frameDeps.textEditorSystem)
+                frameDeps.textEditorSystem->onFrame();
 
-            if (_renderSystem && !resizedThisTick)
+            if (frameDeps.renderSystem && !resizedThisTick)
             {
-                _renderSystem->update();
+                frameDeps.renderSystem->update();
 #ifdef _WIN32
                 if (auto *winApiWindow =
                         dynamic_cast<vigine::ecs::platform::WinAPIComponent *>(window))
                     winApiWindow->setRenderedVertexCount(
-                        _renderSystem->lastRenderedVertexCount());
+                        frameDeps.renderSystem->lastRenderedVertexCount());
 #endif
             }
         });
-        auto showResult = _platformService->showWindow(window);
+        auto showResult = deps.platformService->showWindow(window);
         if (showResult.isError())
             return showResult;
         std::cout << "[RunWindowTask] Window " << (windowIndex + 1) << " closed, continuing"
@@ -319,76 +315,74 @@ vigine::Result RunWindowTask::run()
     // do this anyway, but ordering keeps the contract obvious.
     _expirationSubscription.reset();
 
-    // The platform showWindow loop returned, which means every window
-    // closed (typically via WM_CLOSE or the user dismissing the OS
-    // window). Ask the engine to stop the main pump so @c IEngine::run
-    // returns to @c main and the process exits cleanly. The shutdown
-    // is idempotent so a duplicate call from a future re-run path is
-    // safe; @c shutdown is also TSAN-clean from any thread.
-    if (_engine)
-        _engine->shutdown();
+    // Ask the engine to stop the main pump so @c IEngine::run returns
+    // to @c main and the process exits cleanly.
+    deps.engine->shutdown();
 
     return vigine::Result();
 }
 
 void RunWindowTask::onMouseButtonDown(vigine::ecs::platform::MouseButton button, int x, int y)
 {
+    auto deps = resolveDeps();
+
     if (button == vigine::ecs::platform::MouseButton::Left)
     {
-        vigine::Entity *picked =
-            _renderSystem ? _renderSystem->pickFirstIntersectedEntity(x, y) : nullptr;
+        vigine::Entity *picked = deps.renderSystem
+                                     ? deps.renderSystem->pickFirstIntersectedEntity(x, y)
+                                     : nullptr;
 
         _lastMouseRayX     = x;
         _lastMouseRayY     = y;
         _hasMouseRaySample = true;
 
         const bool pickedTextEditor =
-            _textEditorSystem && _textEditorSystem->isEditorEntity(picked);
+            deps.textEditorSystem && deps.textEditorSystem->isEditorEntity(picked);
 
         // Freeze click marker first, then build ray from the same click point.
-        updateMouseClickSphereVisualization(x, y);
-        updateMouseRayVisualization(x, y);
+        updateMouseClickSphereVisualization(deps, x, y);
+        updateMouseRayVisualization(deps, x, y);
 
         bool consumedByScrollbar = false;
-        if (pickedTextEditor && _textEditorSystem)
-            consumedByScrollbar = _textEditorSystem->onMouseButtonDown(x, y, picked);
+        if (pickedTextEditor && deps.textEditorSystem)
+            consumedByScrollbar = deps.textEditorSystem->onMouseButtonDown(x, y, picked);
 
-        if (pickedTextEditor && _textEditorSystem && !consumedByScrollbar)
-            _textEditorSystem->onEditorClick(x, y);
+        if (pickedTextEditor && deps.textEditorSystem && !consumedByScrollbar)
+            deps.textEditorSystem->onEditorClick(x, y);
 
         // In Ctrl camera-unlock mode keep current focus unchanged.
         if (!_ctrlHeld)
         {
             // Restore normal behavior: clicked entity receives focus, including text
             // editor.
-            setFocusedEntity(picked);
+            setFocusedEntity(deps, picked);
 
             if (_focusedEntity)
             {
                 _movementKeyMask = 0;
-                if (_renderSystem)
+                if (deps.renderSystem)
                 {
-                    _renderSystem->setMoveForwardActive(false);
-                    _renderSystem->setMoveBackwardActive(false);
-                    _renderSystem->setMoveLeftActive(false);
-                    _renderSystem->setMoveRightActive(false);
-                    _renderSystem->setMoveUpActive(false);
-                    _renderSystem->setMoveDownActive(false);
-                    _renderSystem->setSprintActive(false);
+                    deps.renderSystem->setMoveForwardActive(false);
+                    deps.renderSystem->setMoveBackwardActive(false);
+                    deps.renderSystem->setMoveLeftActive(false);
+                    deps.renderSystem->setMoveRightActive(false);
+                    deps.renderSystem->setMoveUpActive(false);
+                    deps.renderSystem->setMoveDownActive(false);
+                    deps.renderSystem->setSprintActive(false);
                 }
             }
         }
     }
 
-    if (_renderSystem && button == vigine::ecs::platform::MouseButton::Right &&
+    if (deps.renderSystem && button == vigine::ecs::platform::MouseButton::Right &&
         (!_focusedEntity || _ctrlHeld || _objectDragActive))
-        _renderSystem->beginCameraDrag(x, y);
+        deps.renderSystem->beginCameraDrag(x, y);
 
     std::cout << "[RunWindowTask::onMouseButtonDown] button=" << static_cast<int>(button)
               << ", x=" << x << ", y=" << y << std::endl;
-    if (_signalEmitter)
+    if (deps.signalEmitter)
     {
-        static_cast<void>(_signalEmitter->emit(
+        static_cast<void>(deps.signalEmitter->emit(
             std::make_unique<MouseButtonDownPayload>(button, x, y)));
     }
 }
@@ -398,12 +392,14 @@ void RunWindowTask::onMouseButtonUp(vigine::ecs::platform::MouseButton button, i
     static_cast<void>(x);
     static_cast<void>(y);
 
-    if (button == vigine::ecs::platform::MouseButton::Left && _textEditorSystem)
-        _textEditorSystem->onMouseButtonUp();
+    auto deps = resolveDeps();
 
-    if (_renderSystem && button == vigine::ecs::platform::MouseButton::Right &&
+    if (button == vigine::ecs::platform::MouseButton::Left && deps.textEditorSystem)
+        deps.textEditorSystem->onMouseButtonUp();
+
+    if (deps.renderSystem && button == vigine::ecs::platform::MouseButton::Right &&
         (!_focusedEntity || _ctrlHeld || _objectDragActive))
-        _renderSystem->endCameraDrag();
+        deps.renderSystem->endCameraDrag();
 }
 
 void RunWindowTask::onMouseMove(int x, int y)
@@ -412,18 +408,22 @@ void RunWindowTask::onMouseMove(int x, int y)
     _lastMouseRayY     = y;
     _hasMouseRaySample = true;
 
+    auto deps = resolveDeps();
+
     if (_objectDragActive)
-        updateObjectDrag(x, y);
+        updateObjectDrag(deps, x, y);
 
-    if (_textEditorSystem)
-        _textEditorSystem->onMouseMove(x, y);
+    if (deps.textEditorSystem)
+        deps.textEditorSystem->onMouseMove(x, y);
 
-    if (_renderSystem && (!_focusedEntity || _ctrlHeld || _objectDragActive))
-        _renderSystem->updateCameraDrag(x, y);
+    if (deps.renderSystem && (!_focusedEntity || _ctrlHeld || _objectDragActive))
+        deps.renderSystem->updateCameraDrag(x, y);
 }
 
 void RunWindowTask::onMouseWheel(int delta, int x, int y)
 {
+    auto deps = resolveDeps();
+
     // In object-drag mode: wheel adjusts object distance from camera.
     if (_objectDragActive)
     {
@@ -433,23 +433,25 @@ void RunWindowTask::onMouseWheel(int delta, int x, int y)
         const float factor      = std::pow(0.90f, -wheelSteps);
         _dragDistanceFromCamera = (std::max)(0.15f, _dragDistanceFromCamera * factor);
         // Allow Z movement so the object actually moves in depth, not just XY.
-        updateObjectDrag(x, y, /*suppressZDelta=*/false);
+        updateObjectDrag(deps, x, y, /*suppressZDelta=*/false);
         return;
     }
 
     // When text editor is focused (and Ctrl not held): scroll text, not camera.
-    if (_focusedEntity && !_ctrlHeld && _textEditorSystem)
+    if (_focusedEntity && !_ctrlHeld && deps.textEditorSystem)
     {
-        _textEditorSystem->onMouseWheel(delta);
+        deps.textEditorSystem->onMouseWheel(delta);
         return;
     }
 
-    if (_renderSystem && (!_focusedEntity || _ctrlHeld))
-        _renderSystem->zoomCamera(delta);
+    if (deps.renderSystem && (!_focusedEntity || _ctrlHeld))
+        deps.renderSystem->zoomCamera(delta);
 }
 
 void RunWindowTask::onKeyDown(const vigine::ecs::platform::KeyEvent &event)
 {
+    auto deps = resolveDeps();
+
     if (event.keyCode == kKeyControl || event.keyCode == kKeyLeftControl ||
         event.keyCode == kKeyRightControl)
         _ctrlHeld = true;
@@ -464,7 +466,7 @@ void RunWindowTask::onKeyDown(const vigine::ecs::platform::KeyEvent &event)
         {
             const int mx = _hasMouseRaySample ? _lastMouseRayX : 0;
             const int my = _hasMouseRaySample ? _lastMouseRayY : 0;
-            static_cast<void>(beginObjectDrag(_focusedEntity, mx, my));
+            static_cast<void>(beginObjectDrag(deps, _focusedEntity, mx, my));
         }
         return;
     }
@@ -476,64 +478,68 @@ void RunWindowTask::onKeyDown(const vigine::ecs::platform::KeyEvent &event)
         if (_mouseRayVisible)
         {
             if (_hasMouseRaySample)
-                updateMouseRayVisualization(_lastMouseRayX, _lastMouseRayY);
-        } else if (ensureMouseRayEntity() && _renderSystem)
+                updateMouseRayVisualization(deps, _lastMouseRayX, _lastMouseRayY);
+        } else if (ensureMouseRayEntity(deps) && deps.renderSystem)
         {
-            _renderSystem->bindEntity(_mouseRayEntity);
-            if (auto *rc = _renderSystem->boundRenderComponent())
+            deps.renderSystem->bindEntity(_mouseRayEntity);
+            if (auto *rc = deps.renderSystem->boundRenderComponent())
             {
                 auto transform = rc->getTransform();
                 transform.setPosition({0.0f, -100.0f, 0.0f});
                 transform.setScale({0.01f, 0.01f, 0.01f});
                 rc->setTransform(transform);
             }
-            _renderSystem->unbindEntity();
+            deps.renderSystem->unbindEntity();
         }
     }
 
     if (event.keyCode == kKeyBillboardToggle && !event.isRepeat)
     {
-        if (_renderSystem)
-            _renderSystem->toggleBillboard();
+        if (deps.renderSystem)
+            deps.renderSystem->toggleBillboard();
     }
 
     if (!_focusedEntity || _ctrlHeld || _objectDragActive)
-        updateCameraMovementKey(event.keyCode, true);
+        updateCameraMovementKey(deps.renderSystem, event.keyCode, true);
 
     if (event.keyCode == kKeyEscape)
     {
-        setFocusedEntity(nullptr);
+        setFocusedEntity(deps, nullptr);
         return;
     }
 
-    if (handleClipboardShortcut(event))
+    if (handleClipboardShortcut(deps.textEditorSystem, event))
         return;
 
-    if (_textEditorSystem && isFocusedTextEditor())
-        _textEditorSystem->onKeyDown(event.keyCode);
+    if (deps.textEditorSystem && isFocusedTextEditor(deps.textEditorSystem))
+        deps.textEditorSystem->onKeyDown(event.keyCode);
 
     if (!event.isRepeat)
         std::cout << "[RunWindowTask::onKeyDown] keyCode=" << event.keyCode
                   << ", scanCode=" << event.scanCode << std::endl;
-    if (_signalEmitter)
+    if (deps.signalEmitter)
     {
-        static_cast<void>(_signalEmitter->emit(std::make_unique<KeyDownPayload>(event)));
+        static_cast<void>(deps.signalEmitter->emit(std::make_unique<KeyDownPayload>(event)));
     }
 }
 
 void RunWindowTask::onKeyUp(const vigine::ecs::platform::KeyEvent &event)
 {
+    auto deps = resolveDeps();
+
     if (event.keyCode == kKeyControl || event.keyCode == kKeyLeftControl ||
         event.keyCode == kKeyRightControl)
         _ctrlHeld = false;
 
     if (!_focusedEntity || _ctrlHeld || _objectDragActive)
-        updateCameraMovementKey(event.keyCode, false);
+        updateCameraMovementKey(deps.renderSystem, event.keyCode, false);
 }
 
-void RunWindowTask::updateCameraMovementKey(unsigned int keyCode, bool pressed)
+void RunWindowTask::updateCameraMovementKey(vigine::ecs::graphics::RenderSystem *renderSystem,
+                                            unsigned int                          keyCode,
+                                            bool                                  pressed)
 {
-    if (!_renderSystem)
+    if (!renderSystem)
         return;
 
     auto setMoveMaskBit = [this, pressed](uint8_t bit) {
@@ -546,33 +552,33 @@ void RunWindowTask::updateCameraMovementKey(unsigned int keyCode, bool pressed)
     switch (keyCode)
     {
     case kKeyW:
-        _renderSystem->setMoveForwardActive(pressed);
+        renderSystem->setMoveForwardActive(pressed);
         setMoveMaskBit(MoveKeyW);
         break;
     case kKeyS:
-        _renderSystem->setMoveBackwardActive(pressed);
+        renderSystem->setMoveBackwardActive(pressed);
         setMoveMaskBit(MoveKeyS);
         break;
     case kKeyA:
-        _renderSystem->setMoveLeftActive(pressed);
+        renderSystem->setMoveLeftActive(pressed);
         setMoveMaskBit(MoveKeyA);
         break;
     case kKeyD:
-        _renderSystem->setMoveRightActive(pressed);
+        renderSystem->setMoveRightActive(pressed);
         setMoveMaskBit(MoveKeyD);
         break;
     case kKeyQ:
-        _renderSystem->setMoveDownActive(pressed);
+        renderSystem->setMoveDownActive(pressed);
         setMoveMaskBit(MoveKeyQ);
         break;
     case kKeyE:
-        _renderSystem->setMoveUpActive(pressed);
+        renderSystem->setMoveUpActive(pressed);
         setMoveMaskBit(MoveKeyE);
         break;
     case kKeyShift:
     case kKeyLeftShift:
     case kKeyRightShift:
-        _renderSystem->setSprintActive(pressed);
+        renderSystem->setSprintActive(pressed);
         break;
     default:
         break;
@@ -582,7 +588,7 @@ void RunWindowTask::updateCameraMovementKey(unsigned int keyCode, bool pressed)
 void RunWindowTask::onWindowResized(vigine::ecs::platform::WindowComponent *window, int width,
                                     int height)
 {
-    if (!_renderSystem || !_platformService || !window)
+    if (!window)
         return;
 
     if (width <= 0 || height <= 0)
@@ -595,27 +601,18 @@ void RunWindowTask::onWindowResized(vigine::ecs::platform::WindowComponent *wind
     _lastResizeEvent     = std::chrono::steady_clock::now();
 }
 
-void RunWindowTask::setTextEditorSystem(std::shared_ptr<TextEditorSystem> editorSystem)
-{
-    _textEditorSystem = std::move(editorSystem);
-    if (_textEditorSystem)
-        _textEditorSystem->bind(_entityManager, _graphicsService, _renderSystem);
-}
-
-void RunWindowTask::setSignalEmitter(vigine::messaging::ISignalEmitter *emitter) noexcept
-{
-    _signalEmitter = emitter;
-}
-
 void RunWindowTask::onChar(const vigine::ecs::platform::TextEvent &event)
 {
-    if (_textEditorSystem && isFocusedTextEditor())
-        _textEditorSystem->onChar(event, _movementKeyMask);
+    auto deps = resolveDeps();
+    if (deps.textEditorSystem && isFocusedTextEditor(deps.textEditorSystem))
+        deps.textEditorSystem->onChar(event, _movementKeyMask);
 }
 
-bool RunWindowTask::handleClipboardShortcut(const vigine::ecs::platform::KeyEvent &event)
+bool RunWindowTask::handleClipboardShortcut(
+    const std::shared_ptr<TextEditorSystem> &textEditorSystem,
+    const vigine::ecs::platform::KeyEvent   &event)
 {
-    if (!_textEditorSystem || !isFocusedTextEditor())
+    if (!textEditorSystem || !isFocusedTextEditor(textEditorSystem))
         return false;
 
     const bool ctrlPressed = (event.modifiers & vigine::ecs::platform::KeyModifierControl) != 0;
@@ -625,7 +622,7 @@ bool RunWindowTask::handleClipboardShortcut(const vigine::ecs::platform::KeyEven
     if (event.keyCode == 'C' || event.keyCode == 'X')
     {
 #ifdef _WIN32
-        const std::wstring wide = wideFromUtf8(_textEditorSystem->text());
+        const std::wstring wide = wideFromUtf8(textEditorSystem->text());
         if (!wide.empty() && OpenClipboard(nullptr))
         {
             static_cast<void>(EmptyClipboard());
@@ -648,8 +645,8 @@ bool RunWindowTask::handleClipboardShortcut(const vigine::ecs::platform::KeyEven
         }
 #endif
 
-        if (event.keyCode == 'X' && _textEditorSystem)
-            _textEditorSystem->clearText();
+        if (event.keyCode == 'X')
+            textEditorSystem->clearText();
         return true;
     }
 
@@ -664,8 +661,7 @@ bool RunWindowTask::handleClipboardShortcut(const vigine::ecs::platform::KeyEven
                 auto *wide = static_cast<const wchar_t *>(GlobalLock(data));
                 if (wide)
                 {
-                    if (_textEditorSystem)
-                        _textEditorSystem->insertUtf8(utf8FromWide(wide));
+                    textEditorSystem->insertUtf8(utf8FromWide(wide));
                     GlobalUnlock(data);
                 }
             }
@@ -678,15 +674,16 @@ bool RunWindowTask::handleClipboardShortcut(const vigine::ecs::platform::KeyEven
     return false;
 }
 
-bool RunWindowTask::isFocusedTextEditor() const
+bool RunWindowTask::isFocusedTextEditor(
+    const std::shared_ptr<TextEditorSystem> &textEditorSystem) const
 {
-    if (!_focusedEntity || !_textEditorSystem)
+    if (!_focusedEntity || !textEditorSystem)
         return false;
 
-    return _textEditorSystem->isEditorEntity(_focusedEntity);
+    return textEditorSystem->isEditorEntity(_focusedEntity);
 }
 
-void RunWindowTask::setFocusedEntity(vigine::Entity *entity)
+void RunWindowTask::setFocusedEntity(const Deps &deps, vigine::Entity *entity)
 {
     if (entity == _focusedEntity)
         return;
@@ -695,16 +692,16 @@ void RunWindowTask::setFocusedEntity(vigine::Entity *entity)
     if (_objectDragActive)
         endObjectDrag();
 
-    if (_focusedEntity && _renderSystem && _hasFocusedOriginalScale)
+    if (_focusedEntity && deps.renderSystem && _hasFocusedOriginalScale)
     {
-        _renderSystem->bindEntity(_focusedEntity);
-        if (auto *rc = _renderSystem->boundRenderComponent())
+        deps.renderSystem->bindEntity(_focusedEntity);
+        if (auto *rc = deps.renderSystem->boundRenderComponent())
         {
             auto transform = rc->getTransform();
             transform.setScale(_focusedOriginalScale);
             rc->setTransform(transform);
         }
-        _renderSystem->unbindEntity();
+        deps.renderSystem->unbindEntity();
     }
 
     _focusedEntity           = entity;
@@ -712,15 +709,15 @@ void RunWindowTask::setFocusedEntity(vigine::Entity *entity)
 
     // Editor entities receive focus for input but should not get the scale-up
     // visual effect.
-    const bool isEditor = _textEditorSystem && _textEditorSystem->isEditorEntity(entity);
+    const bool isEditor = deps.textEditorSystem && deps.textEditorSystem->isEditorEntity(entity);
 
-    if (_textEditorSystem)
-        _textEditorSystem->setFocused(_focusedEntity != nullptr && isEditor);
+    if (deps.textEditorSystem)
+        deps.textEditorSystem->setFocused(_focusedEntity != nullptr && isEditor);
 
-    if (_focusedEntity && _renderSystem && !isEditor)
+    if (_focusedEntity && deps.renderSystem && !isEditor)
     {
-        _renderSystem->bindEntity(_focusedEntity);
-        if (auto *rc = _renderSystem->boundRenderComponent())
+        deps.renderSystem->bindEntity(_focusedEntity);
+        if (auto *rc = deps.renderSystem->boundRenderComponent())
         {
             auto transform        = rc->getTransform();
             _focusedOriginalScale = transform.getScale();
@@ -728,29 +725,29 @@ void RunWindowTask::setFocusedEntity(vigine::Entity *entity)
             rc->setTransform(transform);
             _hasFocusedOriginalScale = true;
         }
-        _renderSystem->unbindEntity();
+        deps.renderSystem->unbindEntity();
     }
 }
 
-bool RunWindowTask::beginObjectDrag(vigine::Entity *entity, int x, int y)
+bool RunWindowTask::beginObjectDrag(const Deps &deps, vigine::Entity *entity, int x, int y)
 {
-    if (!entity || !_renderSystem)
+    if (!entity || !deps.renderSystem)
         return false;
 
-    _renderSystem->bindEntity(entity);
-    auto *rc = _renderSystem->boundRenderComponent();
+    deps.renderSystem->bindEntity(entity);
+    auto *rc = deps.renderSystem->boundRenderComponent();
     if (!rc)
     {
-        _renderSystem->unbindEntity();
+        deps.renderSystem->unbindEntity();
         return false;
     }
 
     const auto transform = rc->getTransform();
-    _renderSystem->unbindEntity();
+    deps.renderSystem->unbindEntity();
 
     glm::vec3 rayOrigin(0.0f);
     glm::vec3 rayDirection(0.0f);
-    if (!_renderSystem->screenPointToRayFromNearPlane(x, y, rayOrigin, rayDirection))
+    if (!deps.renderSystem->screenPointToRayFromNearPlane(x, y, rayOrigin, rayDirection))
         return false;
 
     const float dirLen = glm::length(rayDirection);
@@ -765,20 +762,20 @@ bool RunWindowTask::beginObjectDrag(vigine::Entity *entity, int x, int y)
     const glm::vec3 hit = rayOrigin + rayDirection * _dragDistanceFromCamera;
 
     _objectDragActive   = true;
-    _dragEditorGroup    = (_textEditorSystem && _textEditorSystem->isEditorEntity(entity));
+    _dragEditorGroup    = (deps.textEditorSystem && deps.textEditorSystem->isEditorEntity(entity));
     _dragEntity         = entity;
     _dragGrabOffset     = transform.getPosition() - hit;
     return true;
 }
 
-void RunWindowTask::updateObjectDrag(int x, int y, bool suppressZDelta)
+void RunWindowTask::updateObjectDrag(const Deps &deps, int x, int y, bool suppressZDelta)
 {
-    if (!_objectDragActive || !_dragEntity || !_renderSystem)
+    if (!_objectDragActive || !_dragEntity || !deps.renderSystem)
         return;
 
     glm::vec3 rayOrigin(0.0f);
     glm::vec3 rayDirection(0.0f);
-    if (!_renderSystem->screenPointToRayFromNearPlane(x, y, rayOrigin, rayDirection))
+    if (!deps.renderSystem->screenPointToRayFromNearPlane(x, y, rayOrigin, rayDirection))
         return;
 
     const float dirLen = glm::length(rayDirection);
@@ -789,11 +786,11 @@ void RunWindowTask::updateObjectDrag(int x, int y, bool suppressZDelta)
     const glm::vec3 hit     = rayOrigin + rayDirection * _dragDistanceFromCamera;
     const glm::vec3 newPos  = hit + _dragGrabOffset;
 
-    _renderSystem->bindEntity(_dragEntity);
-    auto *dragRc = _renderSystem->boundRenderComponent();
+    deps.renderSystem->bindEntity(_dragEntity);
+    auto *dragRc = deps.renderSystem->boundRenderComponent();
     if (!dragRc)
     {
-        _renderSystem->unbindEntity();
+        deps.renderSystem->unbindEntity();
         return;
     }
 
@@ -818,9 +815,9 @@ void RunWindowTask::updateObjectDrag(int x, int y, bool suppressZDelta)
     if (_dragEditorGroup)
         dragRc->translateGlyphVertices(delta);
 
-    _renderSystem->unbindEntity();
+    deps.renderSystem->unbindEntity();
 
-    if (_dragEditorGroup && _entityManager)
+    if (_dragEditorGroup && deps.entityManager)
     {
         const char *editorAliases[] = {
             "TextEditBgEntity",
@@ -835,12 +832,12 @@ void RunWindowTask::updateObjectDrag(int x, int y, bool suppressZDelta)
 
         for (const char *alias : editorAliases)
         {
-            auto *e = _entityManager->getEntityByAlias(alias);
+            auto *e = deps.entityManager->getEntityByAlias(alias);
             if (!e || e == _dragEntity)
                 continue;
 
-            _renderSystem->bindEntity(e);
-            if (auto *rc = _renderSystem->boundRenderComponent())
+            deps.renderSystem->bindEntity(e);
+            if (auto *rc = deps.renderSystem->boundRenderComponent())
             {
                 auto tr = rc->getTransform();
                 tr.setPosition(tr.getPosition() + delta);
@@ -849,17 +846,16 @@ void RunWindowTask::updateObjectDrag(int x, int y, bool suppressZDelta)
                 if (std::strcmp(alias, "TextEditEntity") == 0)
                     rc->translateGlyphVertices(delta);
             }
-            _renderSystem->unbindEntity();
+            deps.renderSystem->unbindEntity();
         }
 
-        if (_textEditorSystem)
+        if (deps.textEditorSystem)
         {
-            _textEditorSystem->offsetEditorFrame(delta.x, delta.y, delta.z);
-            _textEditorSystem->refreshEditorLayout();
+            deps.textEditorSystem->offsetEditorFrame(delta.x, delta.y, delta.z);
+            deps.textEditorSystem->refreshEditorLayout();
         }
         // Mark glyph dirty once per drag frame to upload translated vertices to GPU.
-        if (_renderSystem)
-            _renderSystem->markGlyphDirty();
+        deps.renderSystem->markGlyphDirty();
     }
 }
 
@@ -872,30 +868,31 @@ void RunWindowTask::endObjectDrag()
     _dragGrabOffset         = {0.0f, 0.0f, 0.0f};
 }
 
-bool RunWindowTask::ensureMouseRayEntity()
+bool RunWindowTask::ensureMouseRayEntity(const Deps &deps)
 {
     if (_mouseRayEntity)
         return true;
 
-    if (!_entityManager || !_renderSystem)
+    if (!deps.entityManager || !deps.renderSystem)
         return false;
 
-    _mouseRayEntity = _entityManager->getEntityByAlias("MouseRayEntity");
+    auto *existing = deps.entityManager->getEntityByAlias("MouseRayEntity");
+    _mouseRayEntity = existing ? static_cast<vigine::Entity *>(existing) : nullptr;
     if (!_mouseRayEntity)
     {
-        _mouseRayEntity = _entityManager->createEntity();
+        _mouseRayEntity = deps.entityManager->createEntity();
         if (!_mouseRayEntity)
             return false;
 
-        _entityManager->addAlias(_mouseRayEntity, "MouseRayEntity");
+        deps.entityManager->addAlias(_mouseRayEntity, "MouseRayEntity");
     }
 
-    _renderSystem->createComponents(_mouseRayEntity);
-    _renderSystem->bindEntity(_mouseRayEntity);
-    auto *rc = _renderSystem->boundRenderComponent();
+    deps.renderSystem->createComponents(_mouseRayEntity);
+    deps.renderSystem->bindEntity(_mouseRayEntity);
+    auto *rc = deps.renderSystem->boundRenderComponent();
     if (!rc)
     {
-        _renderSystem->unbindEntity();
+        deps.renderSystem->unbindEntity();
         return false;
     }
 
@@ -913,34 +910,35 @@ bool RunWindowTask::ensureMouseRayEntity()
     transform.setScale({0.01f, 0.01f, 0.01f});
     rc->setTransform(transform);
 
-    _renderSystem->unbindEntity();
+    deps.renderSystem->unbindEntity();
     return true;
 }
 
-bool RunWindowTask::ensureMouseClickSphereEntity()
+bool RunWindowTask::ensureMouseClickSphereEntity(const Deps &deps)
 {
     if (_mouseClickSphereEntity)
         return true;
 
-    if (!_entityManager || !_renderSystem)
+    if (!deps.entityManager || !deps.renderSystem)
         return false;
 
-    _mouseClickSphereEntity = _entityManager->getEntityByAlias("MouseClickSphereEntity");
+    auto *existing = deps.entityManager->getEntityByAlias("MouseClickSphereEntity");
+    _mouseClickSphereEntity = existing ? static_cast<vigine::Entity *>(existing) : nullptr;
     if (!_mouseClickSphereEntity)
     {
-        _mouseClickSphereEntity = _entityManager->createEntity();
+        _mouseClickSphereEntity = deps.entityManager->createEntity();
         if (!_mouseClickSphereEntity)
             return false;
 
-        _entityManager->addAlias(_mouseClickSphereEntity, "MouseClickSphereEntity");
+        deps.entityManager->addAlias(_mouseClickSphereEntity, "MouseClickSphereEntity");
     }
 
-    _renderSystem->createComponents(_mouseClickSphereEntity);
-    _renderSystem->bindEntity(_mouseClickSphereEntity);
-    auto *rc = _renderSystem->boundRenderComponent();
+    deps.renderSystem->createComponents(_mouseClickSphereEntity);
+    deps.renderSystem->bindEntity(_mouseClickSphereEntity);
+    auto *rc = deps.renderSystem->boundRenderComponent();
     if (!rc)
     {
-        _renderSystem->unbindEntity();
+        deps.renderSystem->unbindEntity();
         return false;
     }
 
@@ -958,21 +956,21 @@ bool RunWindowTask::ensureMouseClickSphereEntity()
     transform.setScale({0.06f, 0.06f, 0.06f});
     rc->setTransform(transform);
 
-    _renderSystem->unbindEntity();
+    deps.renderSystem->unbindEntity();
     return true;
 }
 
-void RunWindowTask::updateMouseRayVisualization(int x, int y)
+void RunWindowTask::updateMouseRayVisualization(const Deps &deps, int x, int y)
 {
-    if (!_renderSystem)
+    if (!deps.renderSystem)
         return;
 
-    if (!ensureMouseRayEntity())
+    if (!ensureMouseRayEntity(deps))
         return;
 
     glm::vec3 clickRayOrigin(0.0f);
     glm::vec3 clickRayDirection(0.0f);
-    if (!_renderSystem->screenPointToRayFromNearPlane(x, y, clickRayOrigin, clickRayDirection))
+    if (!deps.renderSystem->screenPointToRayFromNearPlane(x, y, clickRayOrigin, clickRayDirection))
         return;
 
     const glm::vec3 rayDirection  = glm::normalize(clickRayDirection);
@@ -988,8 +986,8 @@ void RunWindowTask::updateMouseRayVisualization(int x, int y)
     const glm::quat orientation   = glm::rotation(glm::vec3(0.0f, 0.0f, 1.0f), rayDirection);
     const glm::vec3 rotationEuler = glm::eulerAngles(orientation);
 
-    _renderSystem->bindEntity(_mouseRayEntity);
-    if (auto *rc = _renderSystem->boundRenderComponent())
+    deps.renderSystem->bindEntity(_mouseRayEntity);
+    if (auto *rc = deps.renderSystem->boundRenderComponent())
     {
         auto transform = rc->getTransform();
         if (_mouseRayVisible)
@@ -1004,32 +1002,32 @@ void RunWindowTask::updateMouseRayVisualization(int x, int y)
         }
         rc->setTransform(transform);
     }
-    _renderSystem->unbindEntity();
+    deps.renderSystem->unbindEntity();
 }
 
-void RunWindowTask::updateMouseClickSphereVisualization(int x, int y)
+void RunWindowTask::updateMouseClickSphereVisualization(const Deps &deps, int x, int y)
 {
-    if (!_renderSystem)
+    if (!deps.renderSystem)
         return;
 
-    if (!ensureMouseClickSphereEntity())
+    if (!ensureMouseClickSphereEntity(deps))
         return;
 
     glm::vec3 clickRayOrigin(0.0f);
     glm::vec3 clickRayDirection(0.0f);
-    if (!_renderSystem->screenPointToRayFromNearPlane(x, y, clickRayOrigin, clickRayDirection))
+    if (!deps.renderSystem->screenPointToRayFromNearPlane(x, y, clickRayOrigin, clickRayDirection))
         return;
 
     constexpr float kStartOffset = 0.03f;
     const glm::vec3 sphereCenter = clickRayOrigin + clickRayDirection * kStartOffset;
 
-    _renderSystem->bindEntity(_mouseClickSphereEntity);
-    if (auto *rc = _renderSystem->boundRenderComponent())
+    deps.renderSystem->bindEntity(_mouseClickSphereEntity);
+    if (auto *rc = deps.renderSystem->boundRenderComponent())
     {
         auto transform = rc->getTransform();
         transform.setPosition(sphereCenter);
         transform.setScale({0.05f, 0.05f, 0.05f});
         rc->setTransform(transform);
     }
-    _renderSystem->unbindEntity();
+    deps.renderSystem->unbindEntity();
 }

--- a/example/window/task/window/runwindowtask.cpp
+++ b/example/window/task/window/runwindowtask.cpp
@@ -7,26 +7,17 @@
 #include <vigine/api/messaging/isignalemitter.h>
 #include <vigine/api/messaging/isubscriptiontoken.h>
 #include <vigine/api/service/wellknown.h>
-#include "vigine/impl/ecs/entity.h"
-#include "vigine/impl/ecs/entitymanager.h"
-#include "vigine/impl/ecs/graphics/meshcomponent.h"
-#include "vigine/impl/ecs/graphics/rendercomponent.h"
-#include "vigine/impl/ecs/graphics/rendersystem.h"
-#include "vigine/impl/ecs/graphics/shadercomponent.h"
-#include "vigine/impl/ecs/graphics/transformcomponent.h"
+#include <vigine/impl/ecs/entitymanager.h>
 #include <vigine/impl/ecs/graphics/graphicsservice.h>
+#include <vigine/impl/ecs/graphics/rendersystem.h>
 #include <vigine/impl/ecs/platform/platformservice.h>
 
 #include "../../handler/windoweventhandler.h"
 #include "../../services/texteditorservice.h"
 #include "../../services/wellknown.h"
-#include "../../system/texteditorsystem.h"
 #include "impl/ecs/platform/windowcomponent.h"
 #include "windoweventpayload.h"
 
-#include <cstring>
-#include <glm/glm.hpp>
-#include <glm/gtx/quaternion.hpp>
 #include <iostream>
 #include <memory>
 
@@ -39,71 +30,21 @@
 
 namespace
 {
-constexpr unsigned int kKeyW               = 'W';
-constexpr unsigned int kKeyA               = 'A';
-constexpr unsigned int kKeyS               = 'S';
-constexpr unsigned int kKeyD               = 'D';
-constexpr unsigned int kKeyQ               = 'Q';
-constexpr unsigned int kKeyE               = 'E';
-constexpr unsigned int kKeyShift           = 0x10;
-constexpr unsigned int kKeyLeftShift       = 0xA0;
-constexpr unsigned int kKeyRightShift      = 0xA1;
-constexpr unsigned int kKeyControl         = 0x11;
-constexpr unsigned int kKeyLeftControl     = 0xA2;
-constexpr unsigned int kKeyRightControl    = 0xA3;
-constexpr unsigned int kKeyAlt             = 0x12;
-constexpr unsigned int kKeyLeftAlt         = 0xA4;
-constexpr unsigned int kKeyRightAlt        = 0xA5;
-constexpr unsigned int kKeyRayToggle       = 'R';
-constexpr unsigned int kKeyBillboardToggle = 'B';
-constexpr unsigned int kKeyEscape          = 0x1B;
 
-#ifdef _WIN32
-std::string utf8FromWide(const wchar_t *wide)
+// Resolves the editor service through the engine token and ensures
+// it is wired (idempotent). Returns @c nullptr when the token is
+// missing, the service is unavailable, or the type cast fails — the
+// caller skips its work.
+TextEditorService *resolveTextEditorService(vigine::engine::IEngineToken &token)
 {
-    if (!wide)
-        return {};
-
-    const int needed = WideCharToMultiByte(CP_UTF8, 0, wide, -1, nullptr, 0, nullptr, nullptr);
-    if (needed <= 1)
-        return {};
-
-    std::string result(static_cast<size_t>(needed - 1), '\0');
-    static_cast<void>(
-        WideCharToMultiByte(CP_UTF8, 0, wide, -1, result.data(), needed, nullptr, nullptr));
-    return result;
-}
-
-std::wstring wideFromUtf8(const std::string &utf8)
-{
-    if (utf8.empty())
-        return {};
-
-    const int needed = MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, nullptr, 0);
-    if (needed <= 1)
-        return {};
-
-    std::wstring result(static_cast<size_t>(needed - 1), L'\0');
-    static_cast<void>(MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, result.data(), needed));
-    return result;
-}
-#endif
-
-// ---------------------------------------------------------------------------
-// Local resolution helpers — pure functions over an engine token. Each helper
-// re-reads the relevant slot from @ref vigine::IContext on every call; no
-// task-side caching. Helpers fail soft (return @c nullptr) when the gated
-// accessor reports @c Expired / @c NotFound or when a dynamic_cast turns out
-// negative — the caller branches on the null and skips its work without
-// surfacing an error to the FSM.
-// ---------------------------------------------------------------------------
-
-vigine::EntityManager *resolveEntityManager(vigine::engine::IEngineToken &token)
-{
-    auto result = token.entityManager();
+    auto result = token.service(example::services::wellknown::textEditor);
     if (!result.ok())
         return nullptr;
-    return dynamic_cast<vigine::EntityManager *>(&result.value());
+    auto *service = dynamic_cast<TextEditorService *>(&result.value());
+    if (!service)
+        return nullptr;
+    service->ensureWired(token.engine().context());
+    return service;
 }
 
 vigine::ecs::platform::PlatformService *
@@ -115,45 +56,18 @@ resolvePlatformService(vigine::engine::IEngineToken &token)
     return dynamic_cast<vigine::ecs::platform::PlatformService *>(&result.value());
 }
 
-vigine::ecs::graphics::GraphicsService *
-resolveGraphicsService(vigine::engine::IEngineToken &token)
+vigine::EntityManager *resolveEntityManager(vigine::engine::IEngineToken &token)
 {
-    auto result = token.service(vigine::service::wellknown::graphicsService);
+    auto result = token.entityManager();
     if (!result.ok())
         return nullptr;
-    return dynamic_cast<vigine::ecs::graphics::GraphicsService *>(&result.value());
-}
-
-vigine::ecs::graphics::RenderSystem *
-resolveRenderSystem(vigine::engine::IEngineToken &token)
-{
-    auto *gs = resolveGraphicsService(token);
-    return gs ? gs->renderSystem() : nullptr;
-}
-
-std::shared_ptr<TextEditorSystem>
-resolveTextEditor(vigine::engine::IEngineToken &token)
-{
-    auto result = token.service(example::services::wellknown::textEditor);
-    if (!result.ok())
-        return nullptr;
-    auto *service = dynamic_cast<TextEditorService *>(&result.value());
-    if (!service)
-        return nullptr;
-    // ensureWired is idempotent — first call binds the underlying
-    // TextEditorSystem to the engine's entity manager + graphics
-    // service / render system; every subsequent call is a no-op.
-    service->ensureWired(token.engine().context());
-    return service->textEditorSystem();
+    return dynamic_cast<vigine::EntityManager *>(&result.value());
 }
 
 } // namespace
 
-RunWindowTask::RunWindowTask() {}
+RunWindowTask::RunWindowTask() = default;
 
-// COPILOT_TODO: Guarantee unbindEntity() on every early exit via an
-// RAII/scope guard; otherwise the underlying RenderSystem/WindowSystem
-// can stay bound to the entity after an error return path.
 vigine::Result RunWindowTask::run()
 {
     auto *token = apiToken();
@@ -162,9 +76,8 @@ vigine::Result RunWindowTask::run()
 
     auto *entityManager   = resolveEntityManager(*token);
     auto *platformService = resolvePlatformService(*token);
-    auto *graphicsService = resolveGraphicsService(*token);
-    auto *renderSystem    = graphicsService ? graphicsService->renderSystem() : nullptr;
-    if (!entityManager || !platformService || !graphicsService || !renderSystem)
+    auto *editorService   = resolveTextEditorService(*token);
+    if (!entityManager || !platformService || !editorService)
         return vigine::Result(vigine::Result::Code::Error,
                               "RunWindowTask: failed to resolve engine dependencies");
 
@@ -181,9 +94,6 @@ vigine::Result RunWindowTask::run()
     auto *entity = entityManager->getEntityByAlias("MainWindow");
     if (!entity)
         return vigine::Result(vigine::Result::Code::Error, "MainWindow entity not found");
-
-    static_cast<void>(ensureMouseRayEntity());
-    static_cast<void>(ensureMouseClickSphereEntity());
 
     auto windows = platformService->windowComponents(entity);
     if (windows.empty())
@@ -210,9 +120,6 @@ vigine::Result RunWindowTask::run()
 
             windowEventHandler->setMouseButtonDownCallback(
                 [this](vigine::ecs::platform::MouseButton button, int x, int y) {
-                    std::cout << "[RunWindowTask::run::lambda] button="
-                              << static_cast<int>(button) << ", x=" << x << ", y=" << y
-                              << std::endl;
                     onMouseButtonDown(button, x, y);
                 });
             windowEventHandler->setMouseButtonUpCallback(
@@ -224,22 +131,15 @@ vigine::Result RunWindowTask::run()
             windowEventHandler->setMouseWheelCallback(
                 [this](int delta, int x, int y) { onMouseWheel(delta, x, y); });
             windowEventHandler->setKeyDownCallback(
-                [this](const vigine::ecs::platform::KeyEvent &event) {
-                    if (!event.isRepeat)
-                        std::cout
-                            << "[RunWindowTask::run::lambda] keyCode=" << event.keyCode
-                            << ", scanCode=" << event.scanCode
-                            << ", modifiers=" << event.modifiers
-                            << ", repeatCount=" << event.repeatCount
-                            << ", isRepeat=" << event.isRepeat << std::endl;
-                    onKeyDown(event);
-                });
+                [this](const vigine::ecs::platform::KeyEvent &event) { onKeyDown(event); });
             windowEventHandler->setKeyUpCallback(
                 [this](const vigine::ecs::platform::KeyEvent &event) { onKeyUp(event); });
             windowEventHandler->setCharCallback(
                 [this](const vigine::ecs::platform::TextEvent &event) { onChar(event); });
-            windowEventHandler->setWindowResizedCallback([this, window](int width, int height) {
-                onWindowResized(window, width, height);
+            windowEventHandler->setWindowResizedCallback([this](int width, int height) {
+                if (auto *t = apiToken())
+                    if (auto *svc = resolveTextEditorService(*t))
+                        svc->onWindowResized(width, height);
             });
         }
 
@@ -264,60 +164,36 @@ vigine::Result RunWindowTask::run()
                 return;
             }
 
-            // Per-frame deps resolution. Same engine-default services
-            // resolve every tick; the lookup is cheap (registry hash
-            // + dynamic_cast) and keeps the "no caches" rule visible.
             auto *frameToken = apiToken();
             if (!frameToken)
                 return;
 
-            auto *frameRenderSystem = resolveRenderSystem(*frameToken);
-            auto  frameTextEditor   = resolveTextEditor(*frameToken);
+            // Editor onFrame: applies any pending swapchain resize
+            // (debounced 80 ms by the system), drives cursor blink,
+            // rebuilds the editor mesh on dirty state.
+            if (auto *svc = resolveTextEditorService(*frameToken))
+                svc->onFrame();
 
-            bool resizedThisTick = false;
-
-            if (_resizePending && frameRenderSystem)
+            // Render the next frame against the (possibly just-resized)
+            // surface.
+            auto graphicsResult =
+                frameToken->service(vigine::service::wellknown::graphicsService);
+            if (graphicsResult.ok())
             {
-                const auto now    = std::chrono::steady_clock::now();
-                const bool paused = now - _lastResizeEvent >= std::chrono::milliseconds(80);
-                if (paused)
+                if (auto *gs = dynamic_cast<vigine::ecs::graphics::GraphicsService *>(
+                        &graphicsResult.value()))
                 {
-                    if (_pendingResizeWidth != _appliedResizeWidth ||
-                        _pendingResizeHeight != _appliedResizeHeight)
+                    if (auto *rs = gs->renderSystem())
                     {
-                        const bool resized =
-                            frameRenderSystem->resize(_pendingResizeWidth, _pendingResizeHeight);
-                        if (!resized)
-                        {
-                            std::cerr << "[RunWindowTask] Failed to recreate swapchain on "
-                                         "resize: "
-                                      << _pendingResizeWidth << "x" << _pendingResizeHeight
-                                      << std::endl;
-                        } else
-                        {
-                            _appliedResizeWidth  = _pendingResizeWidth;
-                            _appliedResizeHeight = _pendingResizeHeight;
-                            _lastResizeApply     = now;
-                            resizedThisTick      = true;
-                        }
-                    }
-
-                    _resizePending = false;
-                }
-            }
-
-            if (frameTextEditor)
-                frameTextEditor->onFrame();
-
-            if (frameRenderSystem && !resizedThisTick)
-            {
-                frameRenderSystem->update();
+                        rs->update();
 #ifdef _WIN32
-                if (auto *winApiWindow =
-                        dynamic_cast<vigine::ecs::platform::WinAPIComponent *>(window))
-                    winApiWindow->setRenderedVertexCount(
-                        frameRenderSystem->lastRenderedVertexCount());
+                        if (auto *winApiWindow =
+                                dynamic_cast<vigine::ecs::platform::WinAPIComponent *>(window))
+                            winApiWindow->setRenderedVertexCount(
+                                rs->lastRenderedVertexCount());
 #endif
+                    }
+                }
             }
         });
         auto showResult = platformService->showWindow(window);
@@ -346,106 +222,34 @@ void RunWindowTask::onMouseButtonDown(vigine::ecs::platform::MouseButton button,
     if (!token)
         return;
 
-    auto *renderSystem  = resolveRenderSystem(*token);
-    auto  textEditor    = resolveTextEditor(*token);
-    auto *signalEmitter = &token->signalEmitter();
+    if (auto *svc = resolveTextEditorService(*token))
+        svc->onMouseButtonDown(button, x, y);
 
-    if (button == vigine::ecs::platform::MouseButton::Left)
-    {
-        vigine::Entity *picked =
-            renderSystem ? renderSystem->pickFirstIntersectedEntity(x, y) : nullptr;
-
-        _lastMouseRayX     = x;
-        _lastMouseRayY     = y;
-        _hasMouseRaySample = true;
-
-        const bool pickedTextEditor = textEditor && textEditor->isEditorEntity(picked);
-
-        // Freeze click marker first, then build ray from the same click point.
-        updateMouseClickSphereVisualization(x, y);
-        updateMouseRayVisualization(x, y);
-
-        bool consumedByScrollbar = false;
-        if (pickedTextEditor && textEditor)
-            consumedByScrollbar = textEditor->onMouseButtonDown(x, y, picked);
-
-        if (pickedTextEditor && textEditor && !consumedByScrollbar)
-            textEditor->onEditorClick(x, y);
-
-        // In Ctrl camera-unlock mode keep current focus unchanged.
-        if (!_ctrlHeld)
-        {
-            // Restore normal behavior: clicked entity receives focus, including text editor.
-            setFocusedEntity(picked);
-
-            if (_focusedEntity)
-            {
-                _movementKeyMask = 0;
-                if (renderSystem)
-                {
-                    renderSystem->setMoveForwardActive(false);
-                    renderSystem->setMoveBackwardActive(false);
-                    renderSystem->setMoveLeftActive(false);
-                    renderSystem->setMoveRightActive(false);
-                    renderSystem->setMoveUpActive(false);
-                    renderSystem->setMoveDownActive(false);
-                    renderSystem->setSprintActive(false);
-                }
-            }
-        }
-    }
-
-    if (renderSystem && button == vigine::ecs::platform::MouseButton::Right &&
-        (!_focusedEntity || _ctrlHeld || _objectDragActive))
-        renderSystem->beginCameraDrag(x, y);
-
-    std::cout << "[RunWindowTask::onMouseButtonDown] button=" << static_cast<int>(button)
-              << ", x=" << x << ", y=" << y << std::endl;
-    static_cast<void>(signalEmitter->emit(
+    // Fan-out the input event onto the signal bus so subscribers
+    // (e.g. @c ProcessInputEventTask) observe it through the
+    // engine's signal-emitter facade.
+    static_cast<void>(token->signalEmitter().emit(
         std::make_unique<MouseButtonDownPayload>(button, x, y)));
 }
 
 void RunWindowTask::onMouseButtonUp(vigine::ecs::platform::MouseButton button, int x, int y)
 {
-    static_cast<void>(x);
-    static_cast<void>(y);
-
     auto *token = apiToken();
     if (!token)
         return;
 
-    auto *renderSystem = resolveRenderSystem(*token);
-    auto  textEditor   = resolveTextEditor(*token);
-
-    if (button == vigine::ecs::platform::MouseButton::Left && textEditor)
-        textEditor->onMouseButtonUp();
-
-    if (renderSystem && button == vigine::ecs::platform::MouseButton::Right &&
-        (!_focusedEntity || _ctrlHeld || _objectDragActive))
-        renderSystem->endCameraDrag();
+    if (auto *svc = resolveTextEditorService(*token))
+        svc->onMouseButtonUp(button, x, y);
 }
 
 void RunWindowTask::onMouseMove(int x, int y)
 {
-    _lastMouseRayX     = x;
-    _lastMouseRayY     = y;
-    _hasMouseRaySample = true;
-
     auto *token = apiToken();
     if (!token)
         return;
 
-    auto *renderSystem = resolveRenderSystem(*token);
-    auto  textEditor   = resolveTextEditor(*token);
-
-    if (_objectDragActive)
-        updateObjectDrag(x, y);
-
-    if (textEditor)
-        textEditor->onMouseMove(x, y);
-
-    if (renderSystem && (!_focusedEntity || _ctrlHeld || _objectDragActive))
-        renderSystem->updateCameraDrag(x, y);
+    if (auto *svc = resolveTextEditorService(*token))
+        svc->onMouseMove(x, y);
 }
 
 void RunWindowTask::onMouseWheel(int delta, int x, int y)
@@ -454,29 +258,8 @@ void RunWindowTask::onMouseWheel(int delta, int x, int y)
     if (!token)
         return;
 
-    auto *renderSystem = resolveRenderSystem(*token);
-    auto  textEditor   = resolveTextEditor(*token);
-
-    // In object-drag mode: wheel adjusts object distance from camera.
-    if (_objectDragActive)
-    {
-        const float wheelSteps  = static_cast<float>(delta) / 120.0f;
-        const float factor      = std::pow(0.90f, -wheelSteps);
-        _dragDistanceFromCamera = (std::max)(0.15f, _dragDistanceFromCamera * factor);
-        // Allow Z movement so the object actually moves in depth, not just XY.
-        updateObjectDrag(x, y, /*suppressZDelta=*/false);
-        return;
-    }
-
-    // When text editor is focused (and Ctrl not held): scroll text, not camera.
-    if (_focusedEntity && !_ctrlHeld && textEditor)
-    {
-        textEditor->onMouseWheel(delta);
-        return;
-    }
-
-    if (renderSystem && (!_focusedEntity || _ctrlHeld))
-        renderSystem->zoomCamera(delta);
+    if (auto *svc = resolveTextEditorService(*token))
+        svc->onMouseWheel(delta, x, y);
 }
 
 void RunWindowTask::onKeyDown(const vigine::ecs::platform::KeyEvent &event)
@@ -485,154 +268,20 @@ void RunWindowTask::onKeyDown(const vigine::ecs::platform::KeyEvent &event)
     if (!token)
         return;
 
-    auto *renderSystem  = resolveRenderSystem(*token);
-    auto  textEditor    = resolveTextEditor(*token);
-    auto *signalEmitter = &token->signalEmitter();
+    if (auto *svc = resolveTextEditorService(*token))
+        svc->onKeyDown(event);
 
-    if (event.keyCode == kKeyControl || event.keyCode == kKeyLeftControl ||
-        event.keyCode == kKeyRightControl)
-        _ctrlHeld = true;
-
-    if (!event.isRepeat &&
-        (event.keyCode == kKeyAlt || event.keyCode == kKeyLeftAlt || event.keyCode == kKeyRightAlt))
-    {
-        if (_objectDragActive)
-        {
-            endObjectDrag();
-        } else if (_focusedEntity)
-        {
-            const int mx = _hasMouseRaySample ? _lastMouseRayX : 0;
-            const int my = _hasMouseRaySample ? _lastMouseRayY : 0;
-            static_cast<void>(beginObjectDrag(_focusedEntity, mx, my));
-        }
-        return;
-    }
-
-    if (event.keyCode == kKeyRayToggle && !event.isRepeat)
-    {
-        _mouseRayVisible = !_mouseRayVisible;
-
-        if (_mouseRayVisible)
-        {
-            if (_hasMouseRaySample)
-                updateMouseRayVisualization(_lastMouseRayX, _lastMouseRayY);
-        } else if (ensureMouseRayEntity() && renderSystem)
-        {
-            renderSystem->bindEntity(_mouseRayEntity);
-            if (auto *rc = renderSystem->boundRenderComponent())
-            {
-                auto transform = rc->getTransform();
-                transform.setPosition({0.0f, -100.0f, 0.0f});
-                transform.setScale({0.01f, 0.01f, 0.01f});
-                rc->setTransform(transform);
-            }
-            renderSystem->unbindEntity();
-        }
-    }
-
-    if (event.keyCode == kKeyBillboardToggle && !event.isRepeat)
-    {
-        if (renderSystem)
-            renderSystem->toggleBillboard();
-    }
-
-    if (!_focusedEntity || _ctrlHeld || _objectDragActive)
-        updateCameraMovementKey(event.keyCode, true);
-
-    if (event.keyCode == kKeyEscape)
-    {
-        setFocusedEntity(nullptr);
-        return;
-    }
-
-    if (handleClipboardShortcut(event))
-        return;
-
-    if (textEditor && isFocusedTextEditor())
-        textEditor->onKeyDown(event.keyCode);
-
-    if (!event.isRepeat)
-        std::cout << "[RunWindowTask::onKeyDown] keyCode=" << event.keyCode
-                  << ", scanCode=" << event.scanCode << std::endl;
-    static_cast<void>(signalEmitter->emit(std::make_unique<KeyDownPayload>(event)));
+    static_cast<void>(token->signalEmitter().emit(std::make_unique<KeyDownPayload>(event)));
 }
 
 void RunWindowTask::onKeyUp(const vigine::ecs::platform::KeyEvent &event)
 {
-    if (event.keyCode == kKeyControl || event.keyCode == kKeyLeftControl ||
-        event.keyCode == kKeyRightControl)
-        _ctrlHeld = false;
-
-    if (!_focusedEntity || _ctrlHeld || _objectDragActive)
-        updateCameraMovementKey(event.keyCode, false);
-}
-
-void RunWindowTask::updateCameraMovementKey(unsigned int keyCode, bool pressed)
-{
     auto *token = apiToken();
     if (!token)
         return;
-    auto *renderSystem = resolveRenderSystem(*token);
-    if (!renderSystem)
-        return;
 
-    auto setMoveMaskBit = [this, pressed](uint8_t bit) {
-        if (pressed)
-            _movementKeyMask = static_cast<uint8_t>(_movementKeyMask | bit);
-        else
-            _movementKeyMask = static_cast<uint8_t>(_movementKeyMask & ~bit);
-    };
-
-    switch (keyCode)
-    {
-    case kKeyW:
-        renderSystem->setMoveForwardActive(pressed);
-        setMoveMaskBit(MoveKeyW);
-        break;
-    case kKeyS:
-        renderSystem->setMoveBackwardActive(pressed);
-        setMoveMaskBit(MoveKeyS);
-        break;
-    case kKeyA:
-        renderSystem->setMoveLeftActive(pressed);
-        setMoveMaskBit(MoveKeyA);
-        break;
-    case kKeyD:
-        renderSystem->setMoveRightActive(pressed);
-        setMoveMaskBit(MoveKeyD);
-        break;
-    case kKeyQ:
-        renderSystem->setMoveDownActive(pressed);
-        setMoveMaskBit(MoveKeyQ);
-        break;
-    case kKeyE:
-        renderSystem->setMoveUpActive(pressed);
-        setMoveMaskBit(MoveKeyE);
-        break;
-    case kKeyShift:
-    case kKeyLeftShift:
-    case kKeyRightShift:
-        renderSystem->setSprintActive(pressed);
-        break;
-    default:
-        break;
-    }
-}
-
-void RunWindowTask::onWindowResized(vigine::ecs::platform::WindowComponent *window, int width,
-                                    int height)
-{
-    if (!window)
-        return;
-
-    if (width <= 0 || height <= 0)
-        return;
-
-    _pendingResizeWindow = window;
-    _pendingResizeWidth  = static_cast<uint32_t>(width);
-    _pendingResizeHeight = static_cast<uint32_t>(height);
-    _resizePending       = true;
-    _lastResizeEvent     = std::chrono::steady_clock::now();
+    if (auto *svc = resolveTextEditorService(*token))
+        svc->onKeyUp(event);
 }
 
 void RunWindowTask::onChar(const vigine::ecs::platform::TextEvent &event)
@@ -640,473 +289,7 @@ void RunWindowTask::onChar(const vigine::ecs::platform::TextEvent &event)
     auto *token = apiToken();
     if (!token)
         return;
-    auto textEditor = resolveTextEditor(*token);
-    if (textEditor && isFocusedTextEditor())
-        textEditor->onChar(event, _movementKeyMask);
-}
 
-bool RunWindowTask::handleClipboardShortcut(const vigine::ecs::platform::KeyEvent &event)
-{
-    auto *token = apiToken();
-    if (!token)
-        return false;
-    auto textEditor = resolveTextEditor(*token);
-    if (!textEditor || !isFocusedTextEditor())
-        return false;
-
-    const bool ctrlPressed = (event.modifiers & vigine::ecs::platform::KeyModifierControl) != 0;
-    if (!ctrlPressed)
-        return false;
-
-    if (event.keyCode == 'C' || event.keyCode == 'X')
-    {
-#ifdef _WIN32
-        const std::wstring wide = wideFromUtf8(textEditor->text());
-        if (!wide.empty() && OpenClipboard(nullptr))
-        {
-            static_cast<void>(EmptyClipboard());
-            const SIZE_T bytes = (wide.size() + 1) * sizeof(wchar_t);
-            HGLOBAL memory     = GlobalAlloc(GMEM_MOVEABLE, bytes);
-            if (memory)
-            {
-                void *ptr = GlobalLock(memory);
-                if (ptr)
-                {
-                    std::memcpy(ptr, wide.c_str(), bytes);
-                    GlobalUnlock(memory);
-                    static_cast<void>(SetClipboardData(CF_UNICODETEXT, memory));
-                    memory = nullptr;
-                }
-            }
-            if (memory)
-                GlobalFree(memory);
-            CloseClipboard();
-        }
-#endif
-
-        if (event.keyCode == 'X')
-            textEditor->clearText();
-        return true;
-    }
-
-    if (event.keyCode == 'V')
-    {
-#ifdef _WIN32
-        if (OpenClipboard(nullptr))
-        {
-            HANDLE data = GetClipboardData(CF_UNICODETEXT);
-            if (data)
-            {
-                auto *wide = static_cast<const wchar_t *>(GlobalLock(data));
-                if (wide)
-                {
-                    textEditor->insertUtf8(utf8FromWide(wide));
-                    GlobalUnlock(data);
-                }
-            }
-            CloseClipboard();
-        }
-#endif
-        return true;
-    }
-
-    return false;
-}
-
-bool RunWindowTask::isFocusedTextEditor() const
-{
-    if (!_focusedEntity)
-        return false;
-    auto *token = const_cast<RunWindowTask *>(this)->apiToken();
-    if (!token)
-        return false;
-    auto textEditor = resolveTextEditor(*token);
-    if (!textEditor)
-        return false;
-    return textEditor->isEditorEntity(_focusedEntity);
-}
-
-void RunWindowTask::setFocusedEntity(vigine::Entity *entity)
-{
-    if (entity == _focusedEntity)
-        return;
-
-    auto *token = apiToken();
-    if (!token)
-        return;
-    auto *renderSystem = resolveRenderSystem(*token);
-    auto  textEditor   = resolveTextEditor(*token);
-
-    // Any focus change exits move mode.
-    if (_objectDragActive)
-        endObjectDrag();
-
-    if (_focusedEntity && renderSystem && _hasFocusedOriginalScale)
-    {
-        renderSystem->bindEntity(_focusedEntity);
-        if (auto *rc = renderSystem->boundRenderComponent())
-        {
-            auto transform = rc->getTransform();
-            transform.setScale(_focusedOriginalScale);
-            rc->setTransform(transform);
-        }
-        renderSystem->unbindEntity();
-    }
-
-    _focusedEntity           = entity;
-    _hasFocusedOriginalScale = false;
-
-    // Editor entities receive focus for input but should not get the scale-up
-    // visual effect.
-    const bool isEditor = textEditor && textEditor->isEditorEntity(entity);
-
-    if (textEditor)
-        textEditor->setFocused(_focusedEntity != nullptr && isEditor);
-
-    if (_focusedEntity && renderSystem && !isEditor)
-    {
-        renderSystem->bindEntity(_focusedEntity);
-        if (auto *rc = renderSystem->boundRenderComponent())
-        {
-            auto transform        = rc->getTransform();
-            _focusedOriginalScale = transform.getScale();
-            transform.setScale(_focusedOriginalScale * 1.08f);
-            rc->setTransform(transform);
-            _hasFocusedOriginalScale = true;
-        }
-        renderSystem->unbindEntity();
-    }
-}
-
-bool RunWindowTask::beginObjectDrag(vigine::Entity *entity, int x, int y)
-{
-    if (!entity)
-        return false;
-    auto *token = apiToken();
-    if (!token)
-        return false;
-    auto *renderSystem = resolveRenderSystem(*token);
-    auto  textEditor   = resolveTextEditor(*token);
-    if (!renderSystem)
-        return false;
-
-    renderSystem->bindEntity(entity);
-    auto *rc = renderSystem->boundRenderComponent();
-    if (!rc)
-    {
-        renderSystem->unbindEntity();
-        return false;
-    }
-
-    const auto transform = rc->getTransform();
-    renderSystem->unbindEntity();
-
-    glm::vec3 rayOrigin(0.0f);
-    glm::vec3 rayDirection(0.0f);
-    if (!renderSystem->screenPointToRayFromNearPlane(x, y, rayOrigin, rayDirection))
-        return false;
-
-    const float dirLen = glm::length(rayDirection);
-    if (dirLen < 1e-6f)
-        return false;
-    rayDirection            /= dirLen;
-
-    _dragDistanceFromCamera  = glm::dot(transform.getPosition() - rayOrigin, rayDirection);
-    if (_dragDistanceFromCamera <= 0.0f)
-        return false;
-
-    const glm::vec3 hit = rayOrigin + rayDirection * _dragDistanceFromCamera;
-
-    _objectDragActive   = true;
-    _dragEditorGroup    = (textEditor && textEditor->isEditorEntity(entity));
-    _dragEntity         = entity;
-    _dragGrabOffset     = transform.getPosition() - hit;
-    return true;
-}
-
-void RunWindowTask::updateObjectDrag(int x, int y, bool suppressZDelta)
-{
-    if (!_objectDragActive || !_dragEntity)
-        return;
-
-    auto *token = apiToken();
-    if (!token)
-        return;
-    auto *entityManager = resolveEntityManager(*token);
-    auto *renderSystem  = resolveRenderSystem(*token);
-    auto  textEditor    = resolveTextEditor(*token);
-    if (!renderSystem)
-        return;
-
-    glm::vec3 rayOrigin(0.0f);
-    glm::vec3 rayDirection(0.0f);
-    if (!renderSystem->screenPointToRayFromNearPlane(x, y, rayOrigin, rayDirection))
-        return;
-
-    const float dirLen = glm::length(rayDirection);
-    if (dirLen < 1e-6f)
-        return;
-    rayDirection           /= dirLen;
-
-    const glm::vec3 hit     = rayOrigin + rayDirection * _dragDistanceFromCamera;
-    const glm::vec3 newPos  = hit + _dragGrabOffset;
-
-    renderSystem->bindEntity(_dragEntity);
-    auto *dragRc = renderSystem->boundRenderComponent();
-    if (!dragRc)
-    {
-        renderSystem->unbindEntity();
-        return;
-    }
-
-    auto dragTr     = dragRc->getTransform();
-    glm::vec3 delta = newPos - dragTr.getPosition();
-    if (_dragEditorGroup)
-    {
-        if (suppressZDelta)
-            delta.z = 0.0f; // lateral mouse move: keep editor layer depths stable
-        else
-        {
-            delta.x = 0.0f; // depth (wheel): no XY drift, only Z moves
-            delta.y = 0.0f;
-        }
-    }
-
-    dragTr.setPosition(dragTr.getPosition() + delta);
-    dragRc->setTransform(dragTr);
-
-    // If dragging an editor entity, update glyph vertices for TextEditEntity.
-    if (_dragEditorGroup)
-        dragRc->translateGlyphVertices(delta);
-
-    renderSystem->unbindEntity();
-
-    if (_dragEditorGroup && entityManager)
-    {
-        const char *editorAliases[] = {
-            "TextEditBgEntity",
-            "TextEditEntity",
-            "TextEditScrollbarTrackEntity",
-            "TextEditScrollbarThumbEntity",
-            "TextEditFocusTopEntity",
-            "TextEditFocusBottomEntity",
-            "TextEditFocusLeftEntity",
-            "TextEditFocusRightEntity",
-        };
-
-        for (const char *alias : editorAliases)
-        {
-            auto *e = entityManager->getEntityByAlias(alias);
-            if (!e || e == _dragEntity)
-                continue;
-
-            renderSystem->bindEntity(e);
-            if (auto *rc = renderSystem->boundRenderComponent())
-            {
-                auto tr = rc->getTransform();
-                tr.setPosition(tr.getPosition() + delta);
-                rc->setTransform(tr);
-
-                if (std::strcmp(alias, "TextEditEntity") == 0)
-                    rc->translateGlyphVertices(delta);
-            }
-            renderSystem->unbindEntity();
-        }
-
-        if (textEditor)
-        {
-            textEditor->offsetEditorFrame(delta.x, delta.y, delta.z);
-            textEditor->refreshEditorLayout();
-        }
-        renderSystem->markGlyphDirty();
-    }
-}
-
-void RunWindowTask::endObjectDrag()
-{
-    _objectDragActive       = false;
-    _dragEditorGroup        = false;
-    _dragEntity             = nullptr;
-    _dragDistanceFromCamera = 0.0f;
-    _dragGrabOffset         = {0.0f, 0.0f, 0.0f};
-}
-
-bool RunWindowTask::ensureMouseRayEntity()
-{
-    if (_mouseRayEntity)
-        return true;
-
-    auto *token = apiToken();
-    if (!token)
-        return false;
-    auto *entityManager = resolveEntityManager(*token);
-    auto *renderSystem  = resolveRenderSystem(*token);
-    if (!entityManager || !renderSystem)
-        return false;
-
-    _mouseRayEntity = entityManager->getEntityByAlias("MouseRayEntity");
-    if (!_mouseRayEntity)
-    {
-        _mouseRayEntity = entityManager->createEntity();
-        if (!_mouseRayEntity)
-            return false;
-
-        entityManager->addAlias(_mouseRayEntity, "MouseRayEntity");
-    }
-
-    renderSystem->createComponents(_mouseRayEntity);
-    renderSystem->bindEntity(_mouseRayEntity);
-    auto *rc = renderSystem->boundRenderComponent();
-    if (!rc)
-    {
-        renderSystem->unbindEntity();
-        return false;
-    }
-
-    auto rayMesh = vigine::ecs::graphics::MeshComponent::createCube();
-    rayMesh.setProceduralInShader(true, 36);
-    rc->setMesh(rayMesh);
-    {
-        vigine::ecs::graphics::ShaderComponent shader("cube.vert.spv", "cube.frag.spv");
-        rc->setShader(shader);
-    }
-    rc->setPickable(false);
-
-    vigine::ecs::graphics::TransformComponent transform;
-    transform.setPosition({0.0f, -100.0f, 0.0f});
-    transform.setScale({0.01f, 0.01f, 0.01f});
-    rc->setTransform(transform);
-
-    renderSystem->unbindEntity();
-    return true;
-}
-
-bool RunWindowTask::ensureMouseClickSphereEntity()
-{
-    if (_mouseClickSphereEntity)
-        return true;
-
-    auto *token = apiToken();
-    if (!token)
-        return false;
-    auto *entityManager = resolveEntityManager(*token);
-    auto *renderSystem  = resolveRenderSystem(*token);
-    if (!entityManager || !renderSystem)
-        return false;
-
-    _mouseClickSphereEntity = entityManager->getEntityByAlias("MouseClickSphereEntity");
-    if (!_mouseClickSphereEntity)
-    {
-        _mouseClickSphereEntity = entityManager->createEntity();
-        if (!_mouseClickSphereEntity)
-            return false;
-
-        entityManager->addAlias(_mouseClickSphereEntity, "MouseClickSphereEntity");
-    }
-
-    renderSystem->createComponents(_mouseClickSphereEntity);
-    renderSystem->bindEntity(_mouseClickSphereEntity);
-    auto *rc = renderSystem->boundRenderComponent();
-    if (!rc)
-    {
-        renderSystem->unbindEntity();
-        return false;
-    }
-
-    auto sphereMesh = vigine::ecs::graphics::MeshComponent::createCube();
-    sphereMesh.setProceduralInShader(true, 768); // Sphere shader generates 768 vertices
-    rc->setMesh(sphereMesh);
-    {
-        vigine::ecs::graphics::ShaderComponent shader("sphere.vert.spv", "sphere.frag.spv");
-        rc->setShader(shader);
-    }
-    rc->setPickable(false);
-
-    vigine::ecs::graphics::TransformComponent transform;
-    transform.setPosition({0.0f, -100.0f, 0.0f});
-    transform.setScale({0.06f, 0.06f, 0.06f});
-    rc->setTransform(transform);
-
-    renderSystem->unbindEntity();
-    return true;
-}
-
-void RunWindowTask::updateMouseRayVisualization(int x, int y)
-{
-    auto *token = apiToken();
-    if (!token)
-        return;
-    auto *renderSystem = resolveRenderSystem(*token);
-    if (!renderSystem)
-        return;
-
-    if (!ensureMouseRayEntity())
-        return;
-
-    glm::vec3 clickRayOrigin(0.0f);
-    glm::vec3 clickRayDirection(0.0f);
-    if (!renderSystem->screenPointToRayFromNearPlane(x, y, clickRayOrigin, clickRayDirection))
-        return;
-
-    const glm::vec3 rayDirection  = glm::normalize(clickRayDirection);
-
-    constexpr float kRayLength    = 60.0f;
-    constexpr float kRayThickness = 0.012f;
-    constexpr float kStartOffset  = 0.03f;
-
-    // Start and direction are both derived from clicked screen pixel.
-    const glm::vec3 rayStart      = clickRayOrigin + clickRayDirection * kStartOffset;
-
-    const glm::vec3 center        = rayStart + rayDirection * (kRayLength * 0.5f);
-    const glm::quat orientation   = glm::rotation(glm::vec3(0.0f, 0.0f, 1.0f), rayDirection);
-    const glm::vec3 rotationEuler = glm::eulerAngles(orientation);
-
-    renderSystem->bindEntity(_mouseRayEntity);
-    if (auto *rc = renderSystem->boundRenderComponent())
-    {
-        auto transform = rc->getTransform();
-        if (_mouseRayVisible)
-        {
-            transform.setPosition(center);
-            transform.setRotation(rotationEuler);
-            transform.setScale({kRayThickness, kRayThickness, kRayLength});
-        } else
-        {
-            transform.setPosition({0.0f, -100.0f, 0.0f});
-            transform.setScale({0.01f, 0.01f, 0.01f});
-        }
-        rc->setTransform(transform);
-    }
-    renderSystem->unbindEntity();
-}
-
-void RunWindowTask::updateMouseClickSphereVisualization(int x, int y)
-{
-    auto *token = apiToken();
-    if (!token)
-        return;
-    auto *renderSystem = resolveRenderSystem(*token);
-    if (!renderSystem)
-        return;
-
-    if (!ensureMouseClickSphereEntity())
-        return;
-
-    glm::vec3 clickRayOrigin(0.0f);
-    glm::vec3 clickRayDirection(0.0f);
-    if (!renderSystem->screenPointToRayFromNearPlane(x, y, clickRayOrigin, clickRayDirection))
-        return;
-
-    constexpr float kStartOffset = 0.03f;
-    const glm::vec3 sphereCenter = clickRayOrigin + clickRayDirection * kStartOffset;
-
-    renderSystem->bindEntity(_mouseClickSphereEntity);
-    if (auto *rc = renderSystem->boundRenderComponent())
-    {
-        auto transform = rc->getTransform();
-        transform.setPosition(sphereCenter);
-        transform.setScale({0.05f, 0.05f, 0.05f});
-        rc->setTransform(transform);
-    }
-    renderSystem->unbindEntity();
+    if (auto *svc = resolveTextEditorService(*token))
+        svc->onChar(event);
 }

--- a/example/window/task/window/runwindowtask.cpp
+++ b/example/window/task/window/runwindowtask.cpp
@@ -108,7 +108,7 @@ void RunWindowTask::setEngine(vigine::engine::IEngine *engine) noexcept
 
 bool RunWindowTask::resolveServices()
 {
-    auto *token = api();
+    auto *token = apiToken();
     if (!token)
         return false;
 
@@ -164,7 +164,7 @@ vigine::Result RunWindowTask::run()
     // unwinds and run() returns.
     if (!_expirationSubscription)
     {
-        if (auto *token = api())
+        if (auto *token = apiToken())
         {
             _expirationSubscription = token->subscribeExpiration(
                 [this]() { _shutdownRequested.store(true, std::memory_order_release); });

--- a/example/window/task/window/runwindowtask.cpp
+++ b/example/window/task/window/runwindowtask.cpp
@@ -89,65 +89,82 @@ std::wstring wideFromUtf8(const std::string &utf8)
 }
 #endif
 
+// ---------------------------------------------------------------------------
+// Local resolution helpers — pure functions over an engine token. Each helper
+// re-reads the relevant slot from @ref vigine::IContext on every call; no
+// task-side caching. Helpers fail soft (return @c nullptr) when the gated
+// accessor reports @c Expired / @c NotFound or when a dynamic_cast turns out
+// negative — the caller branches on the null and skips its work without
+// surfacing an error to the FSM.
+// ---------------------------------------------------------------------------
+
+vigine::EntityManager *resolveEntityManager(vigine::engine::IEngineToken &token)
+{
+    auto result = token.entityManager();
+    if (!result.ok())
+        return nullptr;
+    return dynamic_cast<vigine::EntityManager *>(&result.value());
+}
+
+vigine::ecs::platform::PlatformService *
+resolvePlatformService(vigine::engine::IEngineToken &token)
+{
+    auto result = token.service(vigine::service::wellknown::platformService);
+    if (!result.ok())
+        return nullptr;
+    return dynamic_cast<vigine::ecs::platform::PlatformService *>(&result.value());
+}
+
+vigine::ecs::graphics::GraphicsService *
+resolveGraphicsService(vigine::engine::IEngineToken &token)
+{
+    auto result = token.service(vigine::service::wellknown::graphicsService);
+    if (!result.ok())
+        return nullptr;
+    return dynamic_cast<vigine::ecs::graphics::GraphicsService *>(&result.value());
+}
+
+vigine::ecs::graphics::RenderSystem *
+resolveRenderSystem(vigine::engine::IEngineToken &token)
+{
+    auto *gs = resolveGraphicsService(token);
+    return gs ? gs->renderSystem() : nullptr;
+}
+
+std::shared_ptr<TextEditorSystem>
+resolveTextEditor(vigine::engine::IEngineToken &token)
+{
+    auto result = token.service(example::services::wellknown::textEditor);
+    if (!result.ok())
+        return nullptr;
+    auto *service = dynamic_cast<TextEditorService *>(&result.value());
+    if (!service)
+        return nullptr;
+    // ensureWired is idempotent — first call binds the underlying
+    // TextEditorSystem to the engine's entity manager + graphics
+    // service / render system; every subsequent call is a no-op.
+    service->ensureWired(token.engine().context());
+    return service->textEditorSystem();
+}
+
 } // namespace
 
 RunWindowTask::RunWindowTask() {}
-
-RunWindowTask::Deps RunWindowTask::resolveDeps() const
-{
-    Deps deps;
-
-    auto *token = const_cast<RunWindowTask *>(this)->apiToken();
-    if (!token)
-        return deps;
-
-    auto entityManagerResult = token->entityManager();
-    if (entityManagerResult.ok())
-        deps.entityManager =
-            dynamic_cast<vigine::EntityManager *>(&entityManagerResult.value());
-
-    auto platformResult = token->service(vigine::service::wellknown::platformService);
-    if (platformResult.ok())
-        deps.platformService = dynamic_cast<vigine::ecs::platform::PlatformService *>(
-            &platformResult.value());
-
-    auto graphicsResult = token->service(vigine::service::wellknown::graphicsService);
-    if (graphicsResult.ok())
-    {
-        deps.graphicsService = dynamic_cast<vigine::ecs::graphics::GraphicsService *>(
-            &graphicsResult.value());
-        if (deps.graphicsService)
-            deps.renderSystem = deps.graphicsService->renderSystem();
-    }
-
-    deps.signalEmitter = &token->signalEmitter();
-    deps.engine        = &token->engine();
-
-    auto editorSvcResult = token->service(example::services::wellknown::textEditor);
-    if (editorSvcResult.ok())
-    {
-        if (auto *editorService =
-                dynamic_cast<TextEditorService *>(&editorSvcResult.value()))
-        {
-            // ensureWired is idempotent — first call binds the
-            // underlying TextEditorSystem to the entity manager and
-            // graphics service, every subsequent call is a no-op.
-            editorService->ensureWired(deps.engine->context());
-            deps.textEditorSystem = editorService->system();
-        }
-    }
-
-    return deps;
-}
 
 // COPILOT_TODO: Guarantee unbindEntity() on every early exit via an
 // RAII/scope guard; otherwise the underlying RenderSystem/WindowSystem
 // can stay bound to the entity after an error return path.
 vigine::Result RunWindowTask::run()
 {
-    auto deps = resolveDeps();
-    if (!deps.entityManager || !deps.platformService || !deps.graphicsService ||
-        !deps.renderSystem || !deps.engine)
+    auto *token = apiToken();
+    if (!token)
+        return vigine::Result(vigine::Result::Code::Error, "Engine token is unavailable");
+
+    auto *entityManager   = resolveEntityManager(*token);
+    auto *platformService = resolvePlatformService(*token);
+    auto *graphicsService = resolveGraphicsService(*token);
+    auto *renderSystem    = graphicsService ? graphicsService->renderSystem() : nullptr;
+    if (!entityManager || !platformService || !graphicsService || !renderSystem)
         return vigine::Result(vigine::Result::Code::Error,
                               "RunWindowTask: failed to resolve engine dependencies");
 
@@ -157,22 +174,18 @@ vigine::Result RunWindowTask::run()
     // call unwinds and run() returns.
     if (!_expirationSubscription)
     {
-        if (auto *token = apiToken())
-        {
-            _expirationSubscription = token->subscribeExpiration(
-                [this]() { _shutdownRequested.store(true, std::memory_order_release); });
-        }
+        _expirationSubscription = token->subscribeExpiration(
+            [this]() { _shutdownRequested.store(true, std::memory_order_release); });
     }
 
-    auto *entity = deps.entityManager->getEntityByAlias("MainWindow");
+    auto *entity = entityManager->getEntityByAlias("MainWindow");
     if (!entity)
         return vigine::Result(vigine::Result::Code::Error, "MainWindow entity not found");
-    _mainWindowEntity = entity;
 
-    static_cast<void>(ensureMouseRayEntity(deps));
-    static_cast<void>(ensureMouseClickSphereEntity(deps));
+    static_cast<void>(ensureMouseRayEntity());
+    static_cast<void>(ensureMouseClickSphereEntity());
 
-    auto windows = deps.platformService->windowComponents(entity);
+    auto windows = platformService->windowComponents(entity);
     if (windows.empty())
         return vigine::Result(vigine::Result::Code::Error, "Window component is unavailable");
 
@@ -183,7 +196,7 @@ vigine::Result RunWindowTask::run()
             return vigine::Result(vigine::Result::Code::Error,
                                   "Window component is unavailable");
 
-        auto eventHandlers = deps.platformService->windowEventHandlers(entity, window);
+        auto eventHandlers = platformService->windowEventHandlers(entity, window);
         if (eventHandlers.empty())
             return vigine::Result(vigine::Result::Code::Error,
                                   "Window event handler is unavailable");
@@ -252,13 +265,18 @@ vigine::Result RunWindowTask::run()
             }
 
             // Per-frame deps resolution. Same engine-default services
-            // resolve every tick; the lookup is cheap (registry hash +
-            // dynamic_cast) and keeps the "no caches" rule visible.
-            auto frameDeps = resolveDeps();
+            // resolve every tick; the lookup is cheap (registry hash
+            // + dynamic_cast) and keeps the "no caches" rule visible.
+            auto *frameToken = apiToken();
+            if (!frameToken)
+                return;
+
+            auto *frameRenderSystem = resolveRenderSystem(*frameToken);
+            auto  frameTextEditor   = resolveTextEditor(*frameToken);
 
             bool resizedThisTick = false;
 
-            if (_resizePending && frameDeps.renderSystem)
+            if (_resizePending && frameRenderSystem)
             {
                 const auto now    = std::chrono::steady_clock::now();
                 const bool paused = now - _lastResizeEvent >= std::chrono::milliseconds(80);
@@ -267,8 +285,8 @@ vigine::Result RunWindowTask::run()
                     if (_pendingResizeWidth != _appliedResizeWidth ||
                         _pendingResizeHeight != _appliedResizeHeight)
                     {
-                        const bool resized = frameDeps.renderSystem->resize(
-                            _pendingResizeWidth, _pendingResizeHeight);
+                        const bool resized =
+                            frameRenderSystem->resize(_pendingResizeWidth, _pendingResizeHeight);
                         if (!resized)
                         {
                             std::cerr << "[RunWindowTask] Failed to recreate swapchain on "
@@ -288,21 +306,21 @@ vigine::Result RunWindowTask::run()
                 }
             }
 
-            if (frameDeps.textEditorSystem)
-                frameDeps.textEditorSystem->onFrame();
+            if (frameTextEditor)
+                frameTextEditor->onFrame();
 
-            if (frameDeps.renderSystem && !resizedThisTick)
+            if (frameRenderSystem && !resizedThisTick)
             {
-                frameDeps.renderSystem->update();
+                frameRenderSystem->update();
 #ifdef _WIN32
                 if (auto *winApiWindow =
                         dynamic_cast<vigine::ecs::platform::WinAPIComponent *>(window))
                     winApiWindow->setRenderedVertexCount(
-                        frameDeps.renderSystem->lastRenderedVertexCount());
+                        frameRenderSystem->lastRenderedVertexCount());
 #endif
             }
         });
-        auto showResult = deps.platformService->showWindow(window);
+        auto showResult = platformService->showWindow(window);
         if (showResult.isError())
             return showResult;
         std::cout << "[RunWindowTask] Window " << (windowIndex + 1) << " closed, continuing"
@@ -311,80 +329,80 @@ vigine::Result RunWindowTask::run()
 
     // Drop the expiration subscription explicitly so a late FSM
     // invalidation that arrives between this point and dtor cannot
-    // dereference the cached service pointers below. The dtor would
-    // do this anyway, but ordering keeps the contract obvious.
+    // dereference any stale handle below. The dtor would do this
+    // anyway, but ordering keeps the contract obvious.
     _expirationSubscription.reset();
 
     // Ask the engine to stop the main pump so @c IEngine::run returns
     // to @c main and the process exits cleanly.
-    deps.engine->shutdown();
+    token->engine().shutdown();
 
     return vigine::Result();
 }
 
 void RunWindowTask::onMouseButtonDown(vigine::ecs::platform::MouseButton button, int x, int y)
 {
-    auto deps = resolveDeps();
+    auto *token = apiToken();
+    if (!token)
+        return;
+
+    auto *renderSystem  = resolveRenderSystem(*token);
+    auto  textEditor    = resolveTextEditor(*token);
+    auto *signalEmitter = &token->signalEmitter();
 
     if (button == vigine::ecs::platform::MouseButton::Left)
     {
-        vigine::Entity *picked = deps.renderSystem
-                                     ? deps.renderSystem->pickFirstIntersectedEntity(x, y)
-                                     : nullptr;
+        vigine::Entity *picked =
+            renderSystem ? renderSystem->pickFirstIntersectedEntity(x, y) : nullptr;
 
         _lastMouseRayX     = x;
         _lastMouseRayY     = y;
         _hasMouseRaySample = true;
 
-        const bool pickedTextEditor =
-            deps.textEditorSystem && deps.textEditorSystem->isEditorEntity(picked);
+        const bool pickedTextEditor = textEditor && textEditor->isEditorEntity(picked);
 
         // Freeze click marker first, then build ray from the same click point.
-        updateMouseClickSphereVisualization(deps, x, y);
-        updateMouseRayVisualization(deps, x, y);
+        updateMouseClickSphereVisualization(x, y);
+        updateMouseRayVisualization(x, y);
 
         bool consumedByScrollbar = false;
-        if (pickedTextEditor && deps.textEditorSystem)
-            consumedByScrollbar = deps.textEditorSystem->onMouseButtonDown(x, y, picked);
+        if (pickedTextEditor && textEditor)
+            consumedByScrollbar = textEditor->onMouseButtonDown(x, y, picked);
 
-        if (pickedTextEditor && deps.textEditorSystem && !consumedByScrollbar)
-            deps.textEditorSystem->onEditorClick(x, y);
+        if (pickedTextEditor && textEditor && !consumedByScrollbar)
+            textEditor->onEditorClick(x, y);
 
         // In Ctrl camera-unlock mode keep current focus unchanged.
         if (!_ctrlHeld)
         {
-            // Restore normal behavior: clicked entity receives focus, including text
-            // editor.
-            setFocusedEntity(deps, picked);
+            // Restore normal behavior: clicked entity receives focus, including text editor.
+            setFocusedEntity(picked);
 
             if (_focusedEntity)
             {
                 _movementKeyMask = 0;
-                if (deps.renderSystem)
+                if (renderSystem)
                 {
-                    deps.renderSystem->setMoveForwardActive(false);
-                    deps.renderSystem->setMoveBackwardActive(false);
-                    deps.renderSystem->setMoveLeftActive(false);
-                    deps.renderSystem->setMoveRightActive(false);
-                    deps.renderSystem->setMoveUpActive(false);
-                    deps.renderSystem->setMoveDownActive(false);
-                    deps.renderSystem->setSprintActive(false);
+                    renderSystem->setMoveForwardActive(false);
+                    renderSystem->setMoveBackwardActive(false);
+                    renderSystem->setMoveLeftActive(false);
+                    renderSystem->setMoveRightActive(false);
+                    renderSystem->setMoveUpActive(false);
+                    renderSystem->setMoveDownActive(false);
+                    renderSystem->setSprintActive(false);
                 }
             }
         }
     }
 
-    if (deps.renderSystem && button == vigine::ecs::platform::MouseButton::Right &&
+    if (renderSystem && button == vigine::ecs::platform::MouseButton::Right &&
         (!_focusedEntity || _ctrlHeld || _objectDragActive))
-        deps.renderSystem->beginCameraDrag(x, y);
+        renderSystem->beginCameraDrag(x, y);
 
     std::cout << "[RunWindowTask::onMouseButtonDown] button=" << static_cast<int>(button)
               << ", x=" << x << ", y=" << y << std::endl;
-    if (deps.signalEmitter)
-    {
-        static_cast<void>(deps.signalEmitter->emit(
-            std::make_unique<MouseButtonDownPayload>(button, x, y)));
-    }
+    static_cast<void>(signalEmitter->emit(
+        std::make_unique<MouseButtonDownPayload>(button, x, y)));
 }
 
 void RunWindowTask::onMouseButtonUp(vigine::ecs::platform::MouseButton button, int x, int y)
@@ -392,14 +410,19 @@ void RunWindowTask::onMouseButtonUp(vigine::ecs::platform::MouseButton button, i
     static_cast<void>(x);
     static_cast<void>(y);
 
-    auto deps = resolveDeps();
+    auto *token = apiToken();
+    if (!token)
+        return;
 
-    if (button == vigine::ecs::platform::MouseButton::Left && deps.textEditorSystem)
-        deps.textEditorSystem->onMouseButtonUp();
+    auto *renderSystem = resolveRenderSystem(*token);
+    auto  textEditor   = resolveTextEditor(*token);
 
-    if (deps.renderSystem && button == vigine::ecs::platform::MouseButton::Right &&
+    if (button == vigine::ecs::platform::MouseButton::Left && textEditor)
+        textEditor->onMouseButtonUp();
+
+    if (renderSystem && button == vigine::ecs::platform::MouseButton::Right &&
         (!_focusedEntity || _ctrlHeld || _objectDragActive))
-        deps.renderSystem->endCameraDrag();
+        renderSystem->endCameraDrag();
 }
 
 void RunWindowTask::onMouseMove(int x, int y)
@@ -408,49 +431,63 @@ void RunWindowTask::onMouseMove(int x, int y)
     _lastMouseRayY     = y;
     _hasMouseRaySample = true;
 
-    auto deps = resolveDeps();
+    auto *token = apiToken();
+    if (!token)
+        return;
+
+    auto *renderSystem = resolveRenderSystem(*token);
+    auto  textEditor   = resolveTextEditor(*token);
 
     if (_objectDragActive)
-        updateObjectDrag(deps, x, y);
+        updateObjectDrag(x, y);
 
-    if (deps.textEditorSystem)
-        deps.textEditorSystem->onMouseMove(x, y);
+    if (textEditor)
+        textEditor->onMouseMove(x, y);
 
-    if (deps.renderSystem && (!_focusedEntity || _ctrlHeld || _objectDragActive))
-        deps.renderSystem->updateCameraDrag(x, y);
+    if (renderSystem && (!_focusedEntity || _ctrlHeld || _objectDragActive))
+        renderSystem->updateCameraDrag(x, y);
 }
 
 void RunWindowTask::onMouseWheel(int delta, int x, int y)
 {
-    auto deps = resolveDeps();
+    auto *token = apiToken();
+    if (!token)
+        return;
+
+    auto *renderSystem = resolveRenderSystem(*token);
+    auto  textEditor   = resolveTextEditor(*token);
 
     // In object-drag mode: wheel adjusts object distance from camera.
     if (_objectDragActive)
     {
-        const float wheelSteps = static_cast<float>(delta) / 120.0f;
-        // Wheel forward -> move object forward (farther from camera), and vice
-        // versa.
+        const float wheelSteps  = static_cast<float>(delta) / 120.0f;
         const float factor      = std::pow(0.90f, -wheelSteps);
         _dragDistanceFromCamera = (std::max)(0.15f, _dragDistanceFromCamera * factor);
         // Allow Z movement so the object actually moves in depth, not just XY.
-        updateObjectDrag(deps, x, y, /*suppressZDelta=*/false);
+        updateObjectDrag(x, y, /*suppressZDelta=*/false);
         return;
     }
 
     // When text editor is focused (and Ctrl not held): scroll text, not camera.
-    if (_focusedEntity && !_ctrlHeld && deps.textEditorSystem)
+    if (_focusedEntity && !_ctrlHeld && textEditor)
     {
-        deps.textEditorSystem->onMouseWheel(delta);
+        textEditor->onMouseWheel(delta);
         return;
     }
 
-    if (deps.renderSystem && (!_focusedEntity || _ctrlHeld))
-        deps.renderSystem->zoomCamera(delta);
+    if (renderSystem && (!_focusedEntity || _ctrlHeld))
+        renderSystem->zoomCamera(delta);
 }
 
 void RunWindowTask::onKeyDown(const vigine::ecs::platform::KeyEvent &event)
 {
-    auto deps = resolveDeps();
+    auto *token = apiToken();
+    if (!token)
+        return;
+
+    auto *renderSystem  = resolveRenderSystem(*token);
+    auto  textEditor    = resolveTextEditor(*token);
+    auto *signalEmitter = &token->signalEmitter();
 
     if (event.keyCode == kKeyControl || event.keyCode == kKeyLeftControl ||
         event.keyCode == kKeyRightControl)
@@ -466,7 +503,7 @@ void RunWindowTask::onKeyDown(const vigine::ecs::platform::KeyEvent &event)
         {
             const int mx = _hasMouseRaySample ? _lastMouseRayX : 0;
             const int my = _hasMouseRaySample ? _lastMouseRayY : 0;
-            static_cast<void>(beginObjectDrag(deps, _focusedEntity, mx, my));
+            static_cast<void>(beginObjectDrag(_focusedEntity, mx, my));
         }
         return;
     }
@@ -478,67 +515,64 @@ void RunWindowTask::onKeyDown(const vigine::ecs::platform::KeyEvent &event)
         if (_mouseRayVisible)
         {
             if (_hasMouseRaySample)
-                updateMouseRayVisualization(deps, _lastMouseRayX, _lastMouseRayY);
-        } else if (ensureMouseRayEntity(deps) && deps.renderSystem)
+                updateMouseRayVisualization(_lastMouseRayX, _lastMouseRayY);
+        } else if (ensureMouseRayEntity() && renderSystem)
         {
-            deps.renderSystem->bindEntity(_mouseRayEntity);
-            if (auto *rc = deps.renderSystem->boundRenderComponent())
+            renderSystem->bindEntity(_mouseRayEntity);
+            if (auto *rc = renderSystem->boundRenderComponent())
             {
                 auto transform = rc->getTransform();
                 transform.setPosition({0.0f, -100.0f, 0.0f});
                 transform.setScale({0.01f, 0.01f, 0.01f});
                 rc->setTransform(transform);
             }
-            deps.renderSystem->unbindEntity();
+            renderSystem->unbindEntity();
         }
     }
 
     if (event.keyCode == kKeyBillboardToggle && !event.isRepeat)
     {
-        if (deps.renderSystem)
-            deps.renderSystem->toggleBillboard();
+        if (renderSystem)
+            renderSystem->toggleBillboard();
     }
 
     if (!_focusedEntity || _ctrlHeld || _objectDragActive)
-        updateCameraMovementKey(deps.renderSystem, event.keyCode, true);
+        updateCameraMovementKey(event.keyCode, true);
 
     if (event.keyCode == kKeyEscape)
     {
-        setFocusedEntity(deps, nullptr);
+        setFocusedEntity(nullptr);
         return;
     }
 
-    if (handleClipboardShortcut(deps.textEditorSystem, event))
+    if (handleClipboardShortcut(event))
         return;
 
-    if (deps.textEditorSystem && isFocusedTextEditor(deps.textEditorSystem))
-        deps.textEditorSystem->onKeyDown(event.keyCode);
+    if (textEditor && isFocusedTextEditor())
+        textEditor->onKeyDown(event.keyCode);
 
     if (!event.isRepeat)
         std::cout << "[RunWindowTask::onKeyDown] keyCode=" << event.keyCode
                   << ", scanCode=" << event.scanCode << std::endl;
-    if (deps.signalEmitter)
-    {
-        static_cast<void>(deps.signalEmitter->emit(std::make_unique<KeyDownPayload>(event)));
-    }
+    static_cast<void>(signalEmitter->emit(std::make_unique<KeyDownPayload>(event)));
 }
 
 void RunWindowTask::onKeyUp(const vigine::ecs::platform::KeyEvent &event)
 {
-    auto deps = resolveDeps();
-
     if (event.keyCode == kKeyControl || event.keyCode == kKeyLeftControl ||
         event.keyCode == kKeyRightControl)
         _ctrlHeld = false;
 
     if (!_focusedEntity || _ctrlHeld || _objectDragActive)
-        updateCameraMovementKey(deps.renderSystem, event.keyCode, false);
+        updateCameraMovementKey(event.keyCode, false);
 }
 
-void RunWindowTask::updateCameraMovementKey(vigine::ecs::graphics::RenderSystem *renderSystem,
-                                            unsigned int                          keyCode,
-                                            bool                                  pressed)
+void RunWindowTask::updateCameraMovementKey(unsigned int keyCode, bool pressed)
 {
+    auto *token = apiToken();
+    if (!token)
+        return;
+    auto *renderSystem = resolveRenderSystem(*token);
     if (!renderSystem)
         return;
 
@@ -603,16 +637,21 @@ void RunWindowTask::onWindowResized(vigine::ecs::platform::WindowComponent *wind
 
 void RunWindowTask::onChar(const vigine::ecs::platform::TextEvent &event)
 {
-    auto deps = resolveDeps();
-    if (deps.textEditorSystem && isFocusedTextEditor(deps.textEditorSystem))
-        deps.textEditorSystem->onChar(event, _movementKeyMask);
+    auto *token = apiToken();
+    if (!token)
+        return;
+    auto textEditor = resolveTextEditor(*token);
+    if (textEditor && isFocusedTextEditor())
+        textEditor->onChar(event, _movementKeyMask);
 }
 
-bool RunWindowTask::handleClipboardShortcut(
-    const std::shared_ptr<TextEditorSystem> &textEditorSystem,
-    const vigine::ecs::platform::KeyEvent   &event)
+bool RunWindowTask::handleClipboardShortcut(const vigine::ecs::platform::KeyEvent &event)
 {
-    if (!textEditorSystem || !isFocusedTextEditor(textEditorSystem))
+    auto *token = apiToken();
+    if (!token)
+        return false;
+    auto textEditor = resolveTextEditor(*token);
+    if (!textEditor || !isFocusedTextEditor())
         return false;
 
     const bool ctrlPressed = (event.modifiers & vigine::ecs::platform::KeyModifierControl) != 0;
@@ -622,7 +661,7 @@ bool RunWindowTask::handleClipboardShortcut(
     if (event.keyCode == 'C' || event.keyCode == 'X')
     {
 #ifdef _WIN32
-        const std::wstring wide = wideFromUtf8(textEditorSystem->text());
+        const std::wstring wide = wideFromUtf8(textEditor->text());
         if (!wide.empty() && OpenClipboard(nullptr))
         {
             static_cast<void>(EmptyClipboard());
@@ -646,7 +685,7 @@ bool RunWindowTask::handleClipboardShortcut(
 #endif
 
         if (event.keyCode == 'X')
-            textEditorSystem->clearText();
+            textEditor->clearText();
         return true;
     }
 
@@ -661,7 +700,7 @@ bool RunWindowTask::handleClipboardShortcut(
                 auto *wide = static_cast<const wchar_t *>(GlobalLock(data));
                 if (wide)
                 {
-                    textEditorSystem->insertUtf8(utf8FromWide(wide));
+                    textEditor->insertUtf8(utf8FromWide(wide));
                     GlobalUnlock(data);
                 }
             }
@@ -674,34 +713,44 @@ bool RunWindowTask::handleClipboardShortcut(
     return false;
 }
 
-bool RunWindowTask::isFocusedTextEditor(
-    const std::shared_ptr<TextEditorSystem> &textEditorSystem) const
+bool RunWindowTask::isFocusedTextEditor() const
 {
-    if (!_focusedEntity || !textEditorSystem)
+    if (!_focusedEntity)
         return false;
-
-    return textEditorSystem->isEditorEntity(_focusedEntity);
+    auto *token = const_cast<RunWindowTask *>(this)->apiToken();
+    if (!token)
+        return false;
+    auto textEditor = resolveTextEditor(*token);
+    if (!textEditor)
+        return false;
+    return textEditor->isEditorEntity(_focusedEntity);
 }
 
-void RunWindowTask::setFocusedEntity(const Deps &deps, vigine::Entity *entity)
+void RunWindowTask::setFocusedEntity(vigine::Entity *entity)
 {
     if (entity == _focusedEntity)
         return;
+
+    auto *token = apiToken();
+    if (!token)
+        return;
+    auto *renderSystem = resolveRenderSystem(*token);
+    auto  textEditor   = resolveTextEditor(*token);
 
     // Any focus change exits move mode.
     if (_objectDragActive)
         endObjectDrag();
 
-    if (_focusedEntity && deps.renderSystem && _hasFocusedOriginalScale)
+    if (_focusedEntity && renderSystem && _hasFocusedOriginalScale)
     {
-        deps.renderSystem->bindEntity(_focusedEntity);
-        if (auto *rc = deps.renderSystem->boundRenderComponent())
+        renderSystem->bindEntity(_focusedEntity);
+        if (auto *rc = renderSystem->boundRenderComponent())
         {
             auto transform = rc->getTransform();
             transform.setScale(_focusedOriginalScale);
             rc->setTransform(transform);
         }
-        deps.renderSystem->unbindEntity();
+        renderSystem->unbindEntity();
     }
 
     _focusedEntity           = entity;
@@ -709,15 +758,15 @@ void RunWindowTask::setFocusedEntity(const Deps &deps, vigine::Entity *entity)
 
     // Editor entities receive focus for input but should not get the scale-up
     // visual effect.
-    const bool isEditor = deps.textEditorSystem && deps.textEditorSystem->isEditorEntity(entity);
+    const bool isEditor = textEditor && textEditor->isEditorEntity(entity);
 
-    if (deps.textEditorSystem)
-        deps.textEditorSystem->setFocused(_focusedEntity != nullptr && isEditor);
+    if (textEditor)
+        textEditor->setFocused(_focusedEntity != nullptr && isEditor);
 
-    if (_focusedEntity && deps.renderSystem && !isEditor)
+    if (_focusedEntity && renderSystem && !isEditor)
     {
-        deps.renderSystem->bindEntity(_focusedEntity);
-        if (auto *rc = deps.renderSystem->boundRenderComponent())
+        renderSystem->bindEntity(_focusedEntity);
+        if (auto *rc = renderSystem->boundRenderComponent())
         {
             auto transform        = rc->getTransform();
             _focusedOriginalScale = transform.getScale();
@@ -725,29 +774,36 @@ void RunWindowTask::setFocusedEntity(const Deps &deps, vigine::Entity *entity)
             rc->setTransform(transform);
             _hasFocusedOriginalScale = true;
         }
-        deps.renderSystem->unbindEntity();
+        renderSystem->unbindEntity();
     }
 }
 
-bool RunWindowTask::beginObjectDrag(const Deps &deps, vigine::Entity *entity, int x, int y)
+bool RunWindowTask::beginObjectDrag(vigine::Entity *entity, int x, int y)
 {
-    if (!entity || !deps.renderSystem)
+    if (!entity)
+        return false;
+    auto *token = apiToken();
+    if (!token)
+        return false;
+    auto *renderSystem = resolveRenderSystem(*token);
+    auto  textEditor   = resolveTextEditor(*token);
+    if (!renderSystem)
         return false;
 
-    deps.renderSystem->bindEntity(entity);
-    auto *rc = deps.renderSystem->boundRenderComponent();
+    renderSystem->bindEntity(entity);
+    auto *rc = renderSystem->boundRenderComponent();
     if (!rc)
     {
-        deps.renderSystem->unbindEntity();
+        renderSystem->unbindEntity();
         return false;
     }
 
     const auto transform = rc->getTransform();
-    deps.renderSystem->unbindEntity();
+    renderSystem->unbindEntity();
 
     glm::vec3 rayOrigin(0.0f);
     glm::vec3 rayDirection(0.0f);
-    if (!deps.renderSystem->screenPointToRayFromNearPlane(x, y, rayOrigin, rayDirection))
+    if (!renderSystem->screenPointToRayFromNearPlane(x, y, rayOrigin, rayDirection))
         return false;
 
     const float dirLen = glm::length(rayDirection);
@@ -762,20 +818,29 @@ bool RunWindowTask::beginObjectDrag(const Deps &deps, vigine::Entity *entity, in
     const glm::vec3 hit = rayOrigin + rayDirection * _dragDistanceFromCamera;
 
     _objectDragActive   = true;
-    _dragEditorGroup    = (deps.textEditorSystem && deps.textEditorSystem->isEditorEntity(entity));
+    _dragEditorGroup    = (textEditor && textEditor->isEditorEntity(entity));
     _dragEntity         = entity;
     _dragGrabOffset     = transform.getPosition() - hit;
     return true;
 }
 
-void RunWindowTask::updateObjectDrag(const Deps &deps, int x, int y, bool suppressZDelta)
+void RunWindowTask::updateObjectDrag(int x, int y, bool suppressZDelta)
 {
-    if (!_objectDragActive || !_dragEntity || !deps.renderSystem)
+    if (!_objectDragActive || !_dragEntity)
+        return;
+
+    auto *token = apiToken();
+    if (!token)
+        return;
+    auto *entityManager = resolveEntityManager(*token);
+    auto *renderSystem  = resolveRenderSystem(*token);
+    auto  textEditor    = resolveTextEditor(*token);
+    if (!renderSystem)
         return;
 
     glm::vec3 rayOrigin(0.0f);
     glm::vec3 rayDirection(0.0f);
-    if (!deps.renderSystem->screenPointToRayFromNearPlane(x, y, rayOrigin, rayDirection))
+    if (!renderSystem->screenPointToRayFromNearPlane(x, y, rayOrigin, rayDirection))
         return;
 
     const float dirLen = glm::length(rayDirection);
@@ -786,11 +851,11 @@ void RunWindowTask::updateObjectDrag(const Deps &deps, int x, int y, bool suppre
     const glm::vec3 hit     = rayOrigin + rayDirection * _dragDistanceFromCamera;
     const glm::vec3 newPos  = hit + _dragGrabOffset;
 
-    deps.renderSystem->bindEntity(_dragEntity);
-    auto *dragRc = deps.renderSystem->boundRenderComponent();
+    renderSystem->bindEntity(_dragEntity);
+    auto *dragRc = renderSystem->boundRenderComponent();
     if (!dragRc)
     {
-        deps.renderSystem->unbindEntity();
+        renderSystem->unbindEntity();
         return;
     }
 
@@ -811,13 +876,12 @@ void RunWindowTask::updateObjectDrag(const Deps &deps, int x, int y, bool suppre
     dragRc->setTransform(dragTr);
 
     // If dragging an editor entity, update glyph vertices for TextEditEntity.
-    // This handles the case when TextEditEntity itself is the drag target.
     if (_dragEditorGroup)
         dragRc->translateGlyphVertices(delta);
 
-    deps.renderSystem->unbindEntity();
+    renderSystem->unbindEntity();
 
-    if (_dragEditorGroup && deps.entityManager)
+    if (_dragEditorGroup && entityManager)
     {
         const char *editorAliases[] = {
             "TextEditBgEntity",
@@ -832,12 +896,12 @@ void RunWindowTask::updateObjectDrag(const Deps &deps, int x, int y, bool suppre
 
         for (const char *alias : editorAliases)
         {
-            auto *e = deps.entityManager->getEntityByAlias(alias);
+            auto *e = entityManager->getEntityByAlias(alias);
             if (!e || e == _dragEntity)
                 continue;
 
-            deps.renderSystem->bindEntity(e);
-            if (auto *rc = deps.renderSystem->boundRenderComponent())
+            renderSystem->bindEntity(e);
+            if (auto *rc = renderSystem->boundRenderComponent())
             {
                 auto tr = rc->getTransform();
                 tr.setPosition(tr.getPosition() + delta);
@@ -846,16 +910,15 @@ void RunWindowTask::updateObjectDrag(const Deps &deps, int x, int y, bool suppre
                 if (std::strcmp(alias, "TextEditEntity") == 0)
                     rc->translateGlyphVertices(delta);
             }
-            deps.renderSystem->unbindEntity();
+            renderSystem->unbindEntity();
         }
 
-        if (deps.textEditorSystem)
+        if (textEditor)
         {
-            deps.textEditorSystem->offsetEditorFrame(delta.x, delta.y, delta.z);
-            deps.textEditorSystem->refreshEditorLayout();
+            textEditor->offsetEditorFrame(delta.x, delta.y, delta.z);
+            textEditor->refreshEditorLayout();
         }
-        // Mark glyph dirty once per drag frame to upload translated vertices to GPU.
-        deps.renderSystem->markGlyphDirty();
+        renderSystem->markGlyphDirty();
     }
 }
 
@@ -868,31 +931,35 @@ void RunWindowTask::endObjectDrag()
     _dragGrabOffset         = {0.0f, 0.0f, 0.0f};
 }
 
-bool RunWindowTask::ensureMouseRayEntity(const Deps &deps)
+bool RunWindowTask::ensureMouseRayEntity()
 {
     if (_mouseRayEntity)
         return true;
 
-    if (!deps.entityManager || !deps.renderSystem)
+    auto *token = apiToken();
+    if (!token)
+        return false;
+    auto *entityManager = resolveEntityManager(*token);
+    auto *renderSystem  = resolveRenderSystem(*token);
+    if (!entityManager || !renderSystem)
         return false;
 
-    auto *existing = deps.entityManager->getEntityByAlias("MouseRayEntity");
-    _mouseRayEntity = existing ? static_cast<vigine::Entity *>(existing) : nullptr;
+    _mouseRayEntity = entityManager->getEntityByAlias("MouseRayEntity");
     if (!_mouseRayEntity)
     {
-        _mouseRayEntity = deps.entityManager->createEntity();
+        _mouseRayEntity = entityManager->createEntity();
         if (!_mouseRayEntity)
             return false;
 
-        deps.entityManager->addAlias(_mouseRayEntity, "MouseRayEntity");
+        entityManager->addAlias(_mouseRayEntity, "MouseRayEntity");
     }
 
-    deps.renderSystem->createComponents(_mouseRayEntity);
-    deps.renderSystem->bindEntity(_mouseRayEntity);
-    auto *rc = deps.renderSystem->boundRenderComponent();
+    renderSystem->createComponents(_mouseRayEntity);
+    renderSystem->bindEntity(_mouseRayEntity);
+    auto *rc = renderSystem->boundRenderComponent();
     if (!rc)
     {
-        deps.renderSystem->unbindEntity();
+        renderSystem->unbindEntity();
         return false;
     }
 
@@ -910,35 +977,39 @@ bool RunWindowTask::ensureMouseRayEntity(const Deps &deps)
     transform.setScale({0.01f, 0.01f, 0.01f});
     rc->setTransform(transform);
 
-    deps.renderSystem->unbindEntity();
+    renderSystem->unbindEntity();
     return true;
 }
 
-bool RunWindowTask::ensureMouseClickSphereEntity(const Deps &deps)
+bool RunWindowTask::ensureMouseClickSphereEntity()
 {
     if (_mouseClickSphereEntity)
         return true;
 
-    if (!deps.entityManager || !deps.renderSystem)
+    auto *token = apiToken();
+    if (!token)
+        return false;
+    auto *entityManager = resolveEntityManager(*token);
+    auto *renderSystem  = resolveRenderSystem(*token);
+    if (!entityManager || !renderSystem)
         return false;
 
-    auto *existing = deps.entityManager->getEntityByAlias("MouseClickSphereEntity");
-    _mouseClickSphereEntity = existing ? static_cast<vigine::Entity *>(existing) : nullptr;
+    _mouseClickSphereEntity = entityManager->getEntityByAlias("MouseClickSphereEntity");
     if (!_mouseClickSphereEntity)
     {
-        _mouseClickSphereEntity = deps.entityManager->createEntity();
+        _mouseClickSphereEntity = entityManager->createEntity();
         if (!_mouseClickSphereEntity)
             return false;
 
-        deps.entityManager->addAlias(_mouseClickSphereEntity, "MouseClickSphereEntity");
+        entityManager->addAlias(_mouseClickSphereEntity, "MouseClickSphereEntity");
     }
 
-    deps.renderSystem->createComponents(_mouseClickSphereEntity);
-    deps.renderSystem->bindEntity(_mouseClickSphereEntity);
-    auto *rc = deps.renderSystem->boundRenderComponent();
+    renderSystem->createComponents(_mouseClickSphereEntity);
+    renderSystem->bindEntity(_mouseClickSphereEntity);
+    auto *rc = renderSystem->boundRenderComponent();
     if (!rc)
     {
-        deps.renderSystem->unbindEntity();
+        renderSystem->unbindEntity();
         return false;
     }
 
@@ -956,21 +1027,25 @@ bool RunWindowTask::ensureMouseClickSphereEntity(const Deps &deps)
     transform.setScale({0.06f, 0.06f, 0.06f});
     rc->setTransform(transform);
 
-    deps.renderSystem->unbindEntity();
+    renderSystem->unbindEntity();
     return true;
 }
 
-void RunWindowTask::updateMouseRayVisualization(const Deps &deps, int x, int y)
+void RunWindowTask::updateMouseRayVisualization(int x, int y)
 {
-    if (!deps.renderSystem)
+    auto *token = apiToken();
+    if (!token)
+        return;
+    auto *renderSystem = resolveRenderSystem(*token);
+    if (!renderSystem)
         return;
 
-    if (!ensureMouseRayEntity(deps))
+    if (!ensureMouseRayEntity())
         return;
 
     glm::vec3 clickRayOrigin(0.0f);
     glm::vec3 clickRayDirection(0.0f);
-    if (!deps.renderSystem->screenPointToRayFromNearPlane(x, y, clickRayOrigin, clickRayDirection))
+    if (!renderSystem->screenPointToRayFromNearPlane(x, y, clickRayOrigin, clickRayDirection))
         return;
 
     const glm::vec3 rayDirection  = glm::normalize(clickRayDirection);
@@ -986,8 +1061,8 @@ void RunWindowTask::updateMouseRayVisualization(const Deps &deps, int x, int y)
     const glm::quat orientation   = glm::rotation(glm::vec3(0.0f, 0.0f, 1.0f), rayDirection);
     const glm::vec3 rotationEuler = glm::eulerAngles(orientation);
 
-    deps.renderSystem->bindEntity(_mouseRayEntity);
-    if (auto *rc = deps.renderSystem->boundRenderComponent())
+    renderSystem->bindEntity(_mouseRayEntity);
+    if (auto *rc = renderSystem->boundRenderComponent())
     {
         auto transform = rc->getTransform();
         if (_mouseRayVisible)
@@ -1002,32 +1077,36 @@ void RunWindowTask::updateMouseRayVisualization(const Deps &deps, int x, int y)
         }
         rc->setTransform(transform);
     }
-    deps.renderSystem->unbindEntity();
+    renderSystem->unbindEntity();
 }
 
-void RunWindowTask::updateMouseClickSphereVisualization(const Deps &deps, int x, int y)
+void RunWindowTask::updateMouseClickSphereVisualization(int x, int y)
 {
-    if (!deps.renderSystem)
+    auto *token = apiToken();
+    if (!token)
+        return;
+    auto *renderSystem = resolveRenderSystem(*token);
+    if (!renderSystem)
         return;
 
-    if (!ensureMouseClickSphereEntity(deps))
+    if (!ensureMouseClickSphereEntity())
         return;
 
     glm::vec3 clickRayOrigin(0.0f);
     glm::vec3 clickRayDirection(0.0f);
-    if (!deps.renderSystem->screenPointToRayFromNearPlane(x, y, clickRayOrigin, clickRayDirection))
+    if (!renderSystem->screenPointToRayFromNearPlane(x, y, clickRayOrigin, clickRayDirection))
         return;
 
     constexpr float kStartOffset = 0.03f;
     const glm::vec3 sphereCenter = clickRayOrigin + clickRayDirection * kStartOffset;
 
-    deps.renderSystem->bindEntity(_mouseClickSphereEntity);
-    if (auto *rc = deps.renderSystem->boundRenderComponent())
+    renderSystem->bindEntity(_mouseClickSphereEntity);
+    if (auto *rc = renderSystem->boundRenderComponent())
     {
         auto transform = rc->getTransform();
         transform.setPosition(sphereCenter);
         transform.setScale({0.05f, 0.05f, 0.05f});
         rc->setTransform(transform);
     }
-    deps.renderSystem->unbindEntity();
+    renderSystem->unbindEntity();
 }

--- a/example/window/task/window/runwindowtask.h
+++ b/example/window/task/window/runwindowtask.h
@@ -2,10 +2,6 @@
 
 #include <vigine/api/taskflow/abstracttask.h>
 #include <vigine/api/ecs/platform/iwindoweventhandler.h>
-#include <vigine/api/messaging/isignalemitter.h>
-#include <vigine/api/service/serviceid.h>
-
-#include "../../system/texteditorsystem.h"
 
 #include <atomic>
 #include <chrono>
@@ -17,6 +13,7 @@ namespace vigine
 {
 class EntityManager;
 class Entity;
+
 namespace ecs
 {
 namespace platform
@@ -30,32 +27,37 @@ class GraphicsService;
 class RenderSystem;
 } // namespace graphics
 } // namespace ecs
+
 namespace engine
 {
 class IEngine;
 } // namespace engine
+
+namespace messaging
+{
+class ISignalEmitter;
+class ISubscriptionToken;
+} // namespace messaging
 } // namespace vigine
+
+class TextEditorSystem;
 
 /**
  * @brief Window-driving task for the modern FSM-pumped engine.
  *
- * The task is constructed before @c IEngine::run with non-owning handles
- * to the legacy @c EntityManager and to the platform / graphics service
- * @ref vigine::service::ServiceId values stamped at registration time.
- * Each tick the task resolves the services through @ref apiToken()->service
- * (the gated state-scoped accessor on @ref vigine::engine::IEngineToken),
- * shows the platform window, and pumps the per-frame render callback
- * until the window closes.
+ * Every dependency the task needs (entity manager, platform / graphics
+ * services, render system, engine back-ref, signal emitter, app-scope
+ * text-editor service) is resolved through @ref apiToken at the call
+ * site. The task carries no DI-result members — only task-private state
+ * (focused entity, drag state, resize bookkeeping, the one-shot
+ * expiration subscription token).
  *
  * Token-expiration cooperation: on entry @ref run subscribes a one-shot
  * callback through @ref apiToken()->subscribeExpiration. When the FSM
  * transitions away from @c InitState the callback flips
  * @ref _shutdownRequested; the per-frame callback observes the flag,
  * stops issuing new render commands, and asks the platform service to
- * close the window so the blocking @c showWindow call returns. The flag
- * also guards every dereference of the cached service pointers so a late
- * frame callback that runs after the token expires turns into a no-op
- * instead of touching freed state.
+ * close the window so the blocking @c showWindow call returns.
  */
 class RunWindowTask final : public vigine::AbstractTask
 {
@@ -72,13 +74,6 @@ class RunWindowTask final : public vigine::AbstractTask
     void onKeyUp(const vigine::ecs::platform::KeyEvent &event);
     void onChar(const vigine::ecs::platform::TextEvent &event);
 
-    void setEntityManager(vigine::EntityManager *entityManager) noexcept;
-    void setPlatformServiceId(vigine::service::ServiceId id) noexcept;
-    void setGraphicsServiceId(vigine::service::ServiceId id) noexcept;
-    void setEngine(vigine::engine::IEngine *engine) noexcept;
-    void setTextEditorSystem(std::shared_ptr<TextEditorSystem> editorSystem);
-    void setSignalEmitter(vigine::messaging::ISignalEmitter *emitter) noexcept;
-
   private:
     enum MovementKeyMask : uint8_t
     {
@@ -90,29 +85,64 @@ class RunWindowTask final : public vigine::AbstractTask
         MoveKeyE = 1u << 5,
     };
 
-    bool resolveServices();
+    /**
+     * @brief Per-call resolution snapshot of every engine-known
+     *        dependency the task touches.
+     *
+     * Each member is a non-owning handle resolved fresh through
+     * @ref apiToken at the call site. A method that needs any subset
+     * checks the relevant pointer for null before dereferencing — the
+     * resolver tolerates a missing token / failed dynamic_cast and
+     * returns null pointers for the unresolved slots so callers can
+     * skip the work without surfacing an error to the FSM.
+     *
+     * Lifetime: the snapshot is short-lived. The pointers themselves
+     * resolve to engine-default services that live for the engine's
+     * entire lifetime, so the snapshot stays valid for as long as the
+     * caller keeps it on the stack — but each method re-resolves to
+     * keep the "no caching" rule visible at every touchpoint.
+     */
+    struct Deps
+    {
+        vigine::EntityManager                  *entityManager{nullptr};
+        vigine::ecs::platform::PlatformService *platformService{nullptr};
+        vigine::ecs::graphics::GraphicsService *graphicsService{nullptr};
+        vigine::ecs::graphics::RenderSystem    *renderSystem{nullptr};
+        vigine::engine::IEngine                *engine{nullptr};
+        vigine::messaging::ISignalEmitter      *signalEmitter{nullptr};
+        std::shared_ptr<TextEditorSystem>       textEditorSystem;
+    };
+
+    /**
+     * @brief Resolves every engine-known dependency through the
+     *        current @ref apiToken in a single call.
+     *
+     * Returns a snapshot with non-null members for every successfully
+     * resolved slot and null for the rest. A null token, an expired
+     * gated accessor, or an unexpected-type dynamic_cast each leave
+     * their respective slot null without touching the others.
+     */
+    [[nodiscard]] Deps resolveDeps() const;
+
     void onWindowResized(vigine::ecs::platform::WindowComponent *window, int width, int height);
-    void updateCameraMovementKey(unsigned int keyCode, bool pressed);
-    bool handleClipboardShortcut(const vigine::ecs::platform::KeyEvent &event);
-    bool isFocusedTextEditor() const;
-    void setFocusedEntity(vigine::Entity *entity);
-    bool ensureMouseRayEntity();
-    bool ensureMouseClickSphereEntity();
-    void updateMouseRayVisualization(int x, int y);
-    void updateMouseClickSphereVisualization(int x, int y);
-    bool beginObjectDrag(vigine::Entity *entity, int x, int y);
-    void updateObjectDrag(int x, int y, bool suppressZDelta = true);
+    void updateCameraMovementKey(vigine::ecs::graphics::RenderSystem *renderSystem,
+                                 unsigned int                          keyCode,
+                                 bool                                  pressed);
+    bool handleClipboardShortcut(const std::shared_ptr<TextEditorSystem> &textEditorSystem,
+                                 const vigine::ecs::platform::KeyEvent   &event);
+    bool isFocusedTextEditor(const std::shared_ptr<TextEditorSystem> &textEditorSystem) const;
+    void setFocusedEntity(const Deps &deps, vigine::Entity *entity);
+    bool ensureMouseRayEntity(const Deps &deps);
+    bool ensureMouseClickSphereEntity(const Deps &deps);
+    void updateMouseRayVisualization(const Deps &deps, int x, int y);
+    void updateMouseClickSphereVisualization(const Deps &deps, int x, int y);
+    bool beginObjectDrag(const Deps &deps, vigine::Entity *entity, int x, int y);
+    void updateObjectDrag(const Deps &deps, int x, int y, bool suppressZDelta = true);
     void endObjectDrag();
 
-    vigine::EntityManager *_entityManager{nullptr};
-    vigine::service::ServiceId _platformServiceId{};
-    vigine::service::ServiceId _graphicsServiceId{};
-    vigine::engine::IEngine *_engine{nullptr};
-    vigine::messaging::ISignalEmitter *_signalEmitter{nullptr};
-    vigine::ecs::platform::PlatformService *_platformService{nullptr};
-    vigine::ecs::graphics::GraphicsService *_graphicsService{nullptr};
-    vigine::ecs::graphics::RenderSystem *_renderSystem{nullptr};
-    std::shared_ptr<TextEditorSystem> _textEditorSystem;
+    // Task-private state. None of these are DI-resolved; they track the
+    // task's own bookkeeping across event callbacks fired during the
+    // platform showWindow loop.
     vigine::Entity *_mainWindowEntity{nullptr};
     vigine::Entity *_focusedEntity{nullptr};
     vigine::Entity *_mouseRayEntity{nullptr};

--- a/example/window/task/window/runwindowtask.h
+++ b/example/window/task/window/runwindowtask.h
@@ -4,48 +4,24 @@
 #include <vigine/api/ecs/platform/iwindoweventhandler.h>
 
 #include <atomic>
-#include <chrono>
-#include <cstdint>
-#include <glm/vec3.hpp>
 #include <memory>
 
-namespace vigine
-{
-class Entity;
-
-namespace ecs
-{
-namespace platform
-{
-class WindowComponent;
-} // namespace platform
-namespace graphics
-{
-class RenderSystem;
-} // namespace graphics
-} // namespace ecs
-
-namespace messaging
+namespace vigine::messaging
 {
 class ISubscriptionToken;
-} // namespace messaging
-} // namespace vigine
+} // namespace vigine::messaging
 
 /**
- * @brief Window-driving task for the modern FSM-pumped engine.
+ * @brief Window-driving task: thin event router that forwards every
+ *        platform callback to @c TextEditorService.
  *
- * Every dependency is resolved through @ref apiToken at the call site:
- * the entity manager, platform / graphics services, signal emitter,
- * engine back-ref, and app-scope text-editor service all flow through
- * the engine token without any task-side caching.
+ * The task owns no DI handles, no cached services, no interaction
+ * state — every dependency is resolved through @ref apiToken at the
+ * call site, and every piece of state that used to live as a member
+ * here has moved into @c TextEditorComponent (managed by
+ * @c TextEditorSystem behind @c TextEditorService).
  *
- * Task-private state covers only what the task needs to track across
- * event callbacks fired during the platform showWindow loop — focused
- * entity, drag state, mouse-ray helper handles, resize bookkeeping,
- * the modifier-key bitmask, plus the one-shot expiration subscription
- * token that ties the task's lifetime to the FSM-driven invalidation.
- *
- * Token-expiration cooperation: on entry @ref run subscribes a one-shot
+ * Token-expiration cooperation: @ref run subscribes a one-shot
  * callback through @ref apiToken()->subscribeExpiration. When the FSM
  * transitions away from @c InitState the callback flips
  * @ref _shutdownRequested; the per-frame callback observes the flag,
@@ -68,68 +44,12 @@ class RunWindowTask final : public vigine::AbstractTask
     void onChar(const vigine::ecs::platform::TextEvent &event);
 
   private:
-    enum MovementKeyMask : uint8_t
-    {
-        MoveKeyW = 1u << 0,
-        MoveKeyA = 1u << 1,
-        MoveKeyS = 1u << 2,
-        MoveKeyD = 1u << 3,
-        MoveKeyQ = 1u << 4,
-        MoveKeyE = 1u << 5,
-    };
-
-    void onWindowResized(vigine::ecs::platform::WindowComponent *window, int width, int height);
-    void updateCameraMovementKey(unsigned int keyCode, bool pressed);
-    bool handleClipboardShortcut(const vigine::ecs::platform::KeyEvent &event);
-    bool isFocusedTextEditor() const;
-    void setFocusedEntity(vigine::Entity *entity);
-    bool ensureMouseRayEntity();
-    bool ensureMouseClickSphereEntity();
-    void updateMouseRayVisualization(int x, int y);
-    void updateMouseClickSphereVisualization(int x, int y);
-    bool beginObjectDrag(vigine::Entity *entity, int x, int y);
-    void updateObjectDrag(int x, int y, bool suppressZDelta = true);
-    void endObjectDrag();
-
-    // Task-private state. None of these are DI-resolved; they track the
-    // task's own bookkeeping across event callbacks fired during the
-    // platform showWindow loop.
-    vigine::Entity *_focusedEntity{nullptr};
-    vigine::Entity *_mouseRayEntity{nullptr};
-    vigine::Entity *_mouseClickSphereEntity{nullptr};
-    vigine::Entity *_dragEntity{nullptr};
-    glm::vec3 _focusedOriginalScale{1.0f, 1.0f, 1.0f};
-    bool _hasFocusedOriginalScale{false};
-    bool _mouseRayVisible{true};
-    bool _hasMouseRaySample{false};
-    int _lastMouseRayX{0};
-    int _lastMouseRayY{0};
-    bool _ctrlHeld{false};
-    bool _objectDragActive{false};
-    bool _dragEditorGroup{false};
-    float _dragDistanceFromCamera{0.0f};
-    glm::vec3 _dragGrabOffset{0.0f, 0.0f, 0.0f};
-    vigine::ecs::platform::WindowComponent *_pendingResizeWindow{nullptr};
-    uint32_t _pendingResizeWidth{0};
-    uint32_t _pendingResizeHeight{0};
-    uint32_t _appliedResizeWidth{0};
-    uint32_t _appliedResizeHeight{0};
-    bool _resizePending{false};
-    uint8_t _movementKeyMask{0};
-    std::chrono::steady_clock::time_point _lastResizeEvent{};
-    std::chrono::steady_clock::time_point _lastResizeApply{};
-    // Token-expiration cooperation flag. The expiration callback flips
-    // it to @c true on FSM transition out of the bound state; the
-    // per-frame callback reads it on every tick and asks the platform
-    // service to close the window so @c showWindow returns and the
-    // task exits cleanly. Atomic because the callback runs on the FSM
-    // controller thread while the frame callback runs on the engine
-    // pump thread.
+    // Single member: the FSM-driven token-expiration subscription.
+    // Held here (not on the system) because the subscription's
+    // lifetime tracks the task's run() invocation, not the editor's.
+    // Atomic flag below cooperates with the per-frame callback so a
+    // late FSM transition observes the close request without racing
+    // the render path.
     std::atomic<bool> _shutdownRequested{false};
-    // Held until @ref run returns so the FSM stops invoking the
-    // expiration callback once the task itself has finished. Reset
-    // explicitly at the end of the run path even though the destructor
-    // would also drop it; keeping the lifetime explicit makes the
-    // ordering relative to the cached service pointers obvious.
     std::unique_ptr<vigine::messaging::ISubscriptionToken> _expirationSubscription;
 };

--- a/example/window/task/window/runwindowtask.h
+++ b/example/window/task/window/runwindowtask.h
@@ -11,46 +11,39 @@
 
 namespace vigine
 {
-class EntityManager;
 class Entity;
 
 namespace ecs
 {
 namespace platform
 {
-class PlatformService;
 class WindowComponent;
 } // namespace platform
 namespace graphics
 {
-class GraphicsService;
 class RenderSystem;
 } // namespace graphics
 } // namespace ecs
 
-namespace engine
-{
-class IEngine;
-} // namespace engine
-
 namespace messaging
 {
-class ISignalEmitter;
 class ISubscriptionToken;
 } // namespace messaging
 } // namespace vigine
 
-class TextEditorSystem;
-
 /**
  * @brief Window-driving task for the modern FSM-pumped engine.
  *
- * Every dependency the task needs (entity manager, platform / graphics
- * services, render system, engine back-ref, signal emitter, app-scope
- * text-editor service) is resolved through @ref apiToken at the call
- * site. The task carries no DI-result members — only task-private state
- * (focused entity, drag state, resize bookkeeping, the one-shot
- * expiration subscription token).
+ * Every dependency is resolved through @ref apiToken at the call site:
+ * the entity manager, platform / graphics services, signal emitter,
+ * engine back-ref, and app-scope text-editor service all flow through
+ * the engine token without any task-side caching.
+ *
+ * Task-private state covers only what the task needs to track across
+ * event callbacks fired during the platform showWindow loop — focused
+ * entity, drag state, mouse-ray helper handles, resize bookkeeping,
+ * the modifier-key bitmask, plus the one-shot expiration subscription
+ * token that ties the task's lifetime to the FSM-driven invalidation.
  *
  * Token-expiration cooperation: on entry @ref run subscribes a one-shot
  * callback through @ref apiToken()->subscribeExpiration. When the FSM
@@ -85,68 +78,26 @@ class RunWindowTask final : public vigine::AbstractTask
         MoveKeyE = 1u << 5,
     };
 
-    /**
-     * @brief Per-call resolution snapshot of every engine-known
-     *        dependency the task touches.
-     *
-     * Each member is a non-owning handle resolved fresh through
-     * @ref apiToken at the call site. A method that needs any subset
-     * checks the relevant pointer for null before dereferencing — the
-     * resolver tolerates a missing token / failed dynamic_cast and
-     * returns null pointers for the unresolved slots so callers can
-     * skip the work without surfacing an error to the FSM.
-     *
-     * Lifetime: the snapshot is short-lived. The pointers themselves
-     * resolve to engine-default services that live for the engine's
-     * entire lifetime, so the snapshot stays valid for as long as the
-     * caller keeps it on the stack — but each method re-resolves to
-     * keep the "no caching" rule visible at every touchpoint.
-     */
-    struct Deps
-    {
-        vigine::EntityManager                  *entityManager{nullptr};
-        vigine::ecs::platform::PlatformService *platformService{nullptr};
-        vigine::ecs::graphics::GraphicsService *graphicsService{nullptr};
-        vigine::ecs::graphics::RenderSystem    *renderSystem{nullptr};
-        vigine::engine::IEngine                *engine{nullptr};
-        vigine::messaging::ISignalEmitter      *signalEmitter{nullptr};
-        std::shared_ptr<TextEditorSystem>       textEditorSystem;
-    };
-
-    /**
-     * @brief Resolves every engine-known dependency through the
-     *        current @ref apiToken in a single call.
-     *
-     * Returns a snapshot with non-null members for every successfully
-     * resolved slot and null for the rest. A null token, an expired
-     * gated accessor, or an unexpected-type dynamic_cast each leave
-     * their respective slot null without touching the others.
-     */
-    [[nodiscard]] Deps resolveDeps() const;
-
     void onWindowResized(vigine::ecs::platform::WindowComponent *window, int width, int height);
-    void updateCameraMovementKey(vigine::ecs::graphics::RenderSystem *renderSystem,
-                                 unsigned int                          keyCode,
-                                 bool                                  pressed);
-    bool handleClipboardShortcut(const std::shared_ptr<TextEditorSystem> &textEditorSystem,
-                                 const vigine::ecs::platform::KeyEvent   &event);
-    bool isFocusedTextEditor(const std::shared_ptr<TextEditorSystem> &textEditorSystem) const;
-    void setFocusedEntity(const Deps &deps, vigine::Entity *entity);
-    bool ensureMouseRayEntity(const Deps &deps);
-    bool ensureMouseClickSphereEntity(const Deps &deps);
-    void updateMouseRayVisualization(const Deps &deps, int x, int y);
-    void updateMouseClickSphereVisualization(const Deps &deps, int x, int y);
-    bool beginObjectDrag(const Deps &deps, vigine::Entity *entity, int x, int y);
-    void updateObjectDrag(const Deps &deps, int x, int y, bool suppressZDelta = true);
+    void updateCameraMovementKey(unsigned int keyCode, bool pressed);
+    bool handleClipboardShortcut(const vigine::ecs::platform::KeyEvent &event);
+    bool isFocusedTextEditor() const;
+    void setFocusedEntity(vigine::Entity *entity);
+    bool ensureMouseRayEntity();
+    bool ensureMouseClickSphereEntity();
+    void updateMouseRayVisualization(int x, int y);
+    void updateMouseClickSphereVisualization(int x, int y);
+    bool beginObjectDrag(vigine::Entity *entity, int x, int y);
+    void updateObjectDrag(int x, int y, bool suppressZDelta = true);
     void endObjectDrag();
 
     // Task-private state. None of these are DI-resolved; they track the
     // task's own bookkeeping across event callbacks fired during the
     // platform showWindow loop.
-    vigine::Entity *_mainWindowEntity{nullptr};
     vigine::Entity *_focusedEntity{nullptr};
     vigine::Entity *_mouseRayEntity{nullptr};
     vigine::Entity *_mouseClickSphereEntity{nullptr};
+    vigine::Entity *_dragEntity{nullptr};
     glm::vec3 _focusedOriginalScale{1.0f, 1.0f, 1.0f};
     bool _hasFocusedOriginalScale{false};
     bool _mouseRayVisible{true};
@@ -156,7 +107,6 @@ class RunWindowTask final : public vigine::AbstractTask
     bool _ctrlHeld{false};
     bool _objectDragActive{false};
     bool _dragEditorGroup{false};
-    vigine::Entity *_dragEntity{nullptr};
     float _dragDistanceFromCamera{0.0f};
     glm::vec3 _dragGrabOffset{0.0f, 0.0f, 0.0f};
     vigine::ecs::platform::WindowComponent *_pendingResizeWindow{nullptr};

--- a/example/window/task/window/runwindowtask.h
+++ b/example/window/task/window/runwindowtask.h
@@ -42,13 +42,13 @@ class IEngine;
  * The task is constructed before @c IEngine::run with non-owning handles
  * to the legacy @c EntityManager and to the platform / graphics service
  * @ref vigine::service::ServiceId values stamped at registration time.
- * Each tick the task resolves the services through @ref api()->service
+ * Each tick the task resolves the services through @ref apiToken()->service
  * (the gated state-scoped accessor on @ref vigine::engine::IEngineToken),
  * shows the platform window, and pumps the per-frame render callback
  * until the window closes.
  *
  * Token-expiration cooperation: on entry @ref run subscribes a one-shot
- * callback through @ref api()->subscribeExpiration. When the FSM
+ * callback through @ref apiToken()->subscribeExpiration. When the FSM
  * transitions away from @c InitState the callback flips
  * @ref _shutdownRequested; the per-frame callback observes the flag,
  * stops issuing new render commands, and asks the platform service to

--- a/include/vigine/api/context/abstractcontext.h
+++ b/include/vigine/api/context/abstractcontext.h
@@ -8,6 +8,7 @@
 
 #include "vigine/api/context/contextconfig.h"
 #include "vigine/api/context/icontext.h"
+#include "vigine/api/ecs/ientitymanager.h"
 #include "vigine/api/engine/iengine_token.h"
 #include "vigine/api/service/iservice.h"
 #include "vigine/api/service/serviceid.h"
@@ -15,11 +16,17 @@
 #include "vigine/api/messaging/busconfig.h"
 #include "vigine/api/messaging/busid.h"
 #include "vigine/api/messaging/imessagebus.h"
+#include "vigine/api/messaging/isignalemitter.h"
 #include "vigine/result.h"
 #include "vigine/api/statemachine/istatemachine.h"
 #include "vigine/api/statemachine/stateid.h"
 #include "vigine/api/taskflow/itaskflow.h"
 #include "vigine/core/threading/ithreadmanager.h"
+
+namespace vigine::engine
+{
+class IEngine;
+} // namespace vigine::engine
 
 namespace vigine::context
 {
@@ -103,6 +110,28 @@ class AbstractContext : public IContext
 
     [[nodiscard]] core::threading::IThreadManager &threadManager() override;
 
+    // ------ IContext: engine environment ------
+
+    [[nodiscard]] IEntityManager &entityManager() override;
+    void setEntityManager(std::unique_ptr<IEntityManager> entityManager) override;
+
+    [[nodiscard]] messaging::ISignalEmitter &signalEmitter() override;
+    void setSignalEmitter(std::unique_ptr<messaging::ISignalEmitter> signalEmitter) override;
+
+    [[nodiscard]] engine::IEngine &engine() override;
+
+    /**
+     * @brief Engine-internal hook the @ref vigine::engine::AbstractEngine
+     *        constructor calls to wire its self-pointer into the
+     *        context's @ref engine accessor.
+     *
+     * Public on the abstract base so the concrete @c Context closer
+     * inherits the symbol; never lifted onto @ref IContext because
+     * applications must not be able to swap the engine back-pointer
+     * mid-life.
+     */
+    void setEngineBackRef(engine::IEngine *engine) noexcept;
+
     // ------ IContext: service registry ------
 
     [[nodiscard]] std::shared_ptr<service::IService>
@@ -110,6 +139,10 @@ class AbstractContext : public IContext
 
     [[nodiscard]] Result
         registerService(std::shared_ptr<service::IService> service) override;
+
+    [[nodiscard]] Result
+        registerService(std::shared_ptr<service::IService> service,
+                        service::ServiceId                 knownId) override;
 
     // ------ IContext: engine-token factory ------
 
@@ -257,6 +290,40 @@ class AbstractContext : public IContext
      * @brief Level-1 wrapper: task flow.
      */
     std::unique_ptr<taskflow::ITaskFlow> _taskFlow;
+
+    // ------ Engine environment (default-built; replaceable via setter) ------
+
+    /**
+     * @brief Default-built entity manager.
+     *
+     * Constructed in the @ref AbstractContext ctor as a concrete
+     * @c EntityManager and replaceable via @ref setEntityManager. The
+     * pointer is non-null for the context's lifetime (the constructor
+     * fills it; setters either replace the held value or assert in
+     * Debug if a null is supplied).
+     */
+    std::unique_ptr<IEntityManager> _entityManager;
+
+    /**
+     * @brief Default-built signal emitter facade.
+     *
+     * Constructed in the @ref AbstractContext ctor as a concrete
+     * @c SignalEmitter bound to the engine-owned thread manager and
+     * the shared-pool bus config. Replaceable via
+     * @ref setSignalEmitter; same null-handling contract as
+     * @ref _entityManager.
+     */
+    std::unique_ptr<messaging::ISignalEmitter> _signalEmitter;
+
+    /**
+     * @brief Back-pointer to the engine that owns this context.
+     *
+     * The pointer is wired in by @ref engine::AbstractEngine's
+     * constructor body via @ref setEngineBackRef shortly after this
+     * context is built; @ref engine() dereferences it. Non-owning;
+     * the engine outlives the context so no dangling read occurs.
+     */
+    engine::IEngine *_engine{nullptr};
 
     // ------ Registries (mutable state guarded by _registryMutex) ------
 

--- a/include/vigine/api/context/icontext.h
+++ b/include/vigine/api/context/icontext.h
@@ -8,6 +8,11 @@
 #include "vigine/api/service/serviceid.h"
 #include "vigine/api/statemachine/stateid.h"
 
+namespace vigine
+{
+class IEntityManager;
+} // namespace vigine
+
 namespace vigine::ecs
 {
 class IECS;
@@ -15,12 +20,14 @@ class IECS;
 
 namespace vigine::engine
 {
+class IEngine;
 class IEngineToken;
 } // namespace vigine::engine
 
 namespace vigine::messaging
 {
 class IMessageBus;
+class ISignalEmitter;
 } // namespace vigine::messaging
 
 namespace vigine::service
@@ -198,6 +205,67 @@ class IContext
      */
     [[nodiscard]] virtual core::threading::IThreadManager &threadManager() = 0;
 
+    // ------ Engine environment (default-built; replaceable via setter) ------
+
+    /**
+     * @brief Returns the engine-wide entity manager.
+     *
+     * The aggregator builds a default @ref IEntityManager during
+     * construction so every task observes a live manager through
+     * @c apiToken()->entityManager() without anyone wiring it up
+     * explicitly. Applications that need a different concrete
+     * implementation replace the slot through @ref setEntityManager;
+     * the prior owner is destroyed via the unique_ptr slot's RAII
+     * chain. The reference is valid for the context's lifetime
+     * regardless of how many overrides have happened.
+     */
+    [[nodiscard]] virtual IEntityManager &entityManager() = 0;
+
+    /**
+     * @brief Replaces the default entity manager with @p entityManager.
+     *
+     * The prior owner (whatever the constructor or a previous
+     * @ref setEntityManager call left in the slot) is destroyed in
+     * place by the unique_ptr's RAII chain. Passing a null pointer is
+     * implementation-defined; the default concrete asserts on null in
+     * Debug and treats null as a no-op in Release so the "the
+     * accessor never returns a null reference" contract holds.
+     */
+    virtual void
+        setEntityManager(std::unique_ptr<IEntityManager> entityManager) = 0;
+
+    /**
+     * @brief Returns the engine-wide signal-emitter facade.
+     *
+     * The aggregator builds a default @ref messaging::ISignalEmitter
+     * during construction so every task observes a live emitter
+     * through @c apiToken()->signalEmitter() without anyone wiring it
+     * up explicitly. Applications that need a different concrete
+     * implementation replace the slot through @ref setSignalEmitter;
+     * the prior owner is destroyed via the unique_ptr slot's RAII
+     * chain. The reference is valid for the context's lifetime.
+     */
+    [[nodiscard]] virtual messaging::ISignalEmitter &signalEmitter() = 0;
+
+    /**
+     * @brief Replaces the default signal emitter with @p signalEmitter.
+     *
+     * Same RAII-replacement contract as @ref setEntityManager.
+     */
+    virtual void
+        setSignalEmitter(std::unique_ptr<messaging::ISignalEmitter> signalEmitter) = 0;
+
+    /**
+     * @brief Returns the engine that owns this context.
+     *
+     * The reference is the back-pointer the engine wires in through
+     * its constructor body so tasks reaching the engine surface
+     * through @c apiToken()->engine() see the same object that
+     * created the context. The reference is valid for the engine's
+     * entire lifetime.
+     */
+    [[nodiscard]] virtual engine::IEngine &engine() = 0;
+
     // ------ Service registry ------
 
     /**
@@ -214,18 +282,59 @@ class IContext
         service(service::ServiceId id) const = 0;
 
     /**
-     * @brief Registers @p service on the context.
+     * @brief Registers @p service on the context with a fresh
+     *        auto-allocated id.
      *
-     * The context stamps the service with a fresh @ref service::ServiceId
-     * and stores it in its registry. Callers obtain the stamped id
-     * through @c service->id() after the call returns success. Returns
-     * @ref Result::Code::TopologyFrozen when the context has been
-     * frozen; returns @ref Result::Code::Error when @p service is
-     * @c nullptr. The service is held by @c std::shared_ptr inside the
-     * registry; callers may keep or drop their own handle.
+     * The context stamps the service with a generational
+     * @ref service::ServiceId and stores it in its registry. Callers
+     * obtain the stamped id through @c service->id() after the call
+     * returns success. Returns @ref Result::Code::TopologyFrozen when
+     * the context has been frozen; returns @ref Result::Code::Error
+     * when @p service is @c nullptr. The service is held by
+     * @c std::shared_ptr inside the registry; callers may keep or
+     * drop their own handle.
      */
     [[nodiscard]] virtual Result
         registerService(std::shared_ptr<service::IService> service) = 0;
+
+    /**
+     * @brief Registers @p service under the caller-provided
+     *        @p knownId, replacing any existing slot occupant.
+     *
+     * Used for the well-known id pattern (see
+     * @c include/vigine/api/service/wellknown.h): the caller declares
+     * a stable @ref service::ServiceId constant, registers a service
+     * implementation under that id, and every task resolves the
+     * service through the same constant via @c apiToken()->service.
+     * Both engine-scope (@c platformService, @c graphicsService) and
+     * application-scope ids use this overload; the engine reserves
+     * @c index in [1..15] for its own well-known slots, leaving
+     * @c index >= 16 free for application-scope ids.
+     *
+     * @param service A non-null @c std::shared_ptr to the service.
+     *        Must derive from @ref service::AbstractService so the
+     *        registry can stamp the @p knownId on the service via
+     *        @ref service::AbstractService::setId.
+     * @param knownId The caller-provided id. Must satisfy
+     *        @ref service::ServiceId::valid (non-zero generation).
+     * @return @ref Result::Code::Success on registration success.
+     *         @ref Result::Code::TopologyFrozen when the context has
+     *         been frozen. @ref Result::Code::Error when @p service is
+     *         null, when @p knownId is the invalid sentinel, or when
+     *         @p service is not derived from
+     *         @ref service::AbstractService (no setId path).
+     *
+     * Replacement semantics: if the slot keyed by @p knownId.index
+     * already holds a service (engine-built default or a prior
+     * caller-side registration), that occupant is destroyed via its
+     * @c shared_ptr count dropping to zero (assuming the caller did
+     * not keep an external handle). Callers that intend to reuse the
+     * prior occupant should hold their own @c shared_ptr before
+     * calling this overload.
+     */
+    [[nodiscard]] virtual Result
+        registerService(std::shared_ptr<service::IService> service,
+                        service::ServiceId                 knownId) = 0;
 
     // ------ Engine-token factory ------
 

--- a/include/vigine/api/ecs/ientitymanager.h
+++ b/include/vigine/api/ecs/ientitymanager.h
@@ -1,26 +1,95 @@
 #pragma once
 
+#include <string>
+
 namespace vigine
 {
+class IEntity;
+
 /**
- * @brief Pure-virtual forward-declared stub for the entity-manager
- *        surface.
+ * @brief Pure-virtual surface of the engine-wide entity manager.
  *
- * @ref IEntityManager is a minimal stub whose only contract is a
- * virtual destructor. It exists so that @ref Engine::entityManager can
- * return a reference to a pure-virtual interface without requiring the
- * ECS domain to be finalised in this leaf. The finalised surface --
- * entity creation, removal, alias lookup -- lands in a later leaf that
- * refactors @c EntityManager onto this interface.
+ * @ref IEntityManager is the contract @ref IContext exposes through
+ * @c IContext::entityManager. The default implementation is built by
+ * @ref AbstractContext during construction (concrete @c EntityManager
+ * in @c include/vigine/impl/ecs/entitymanager.h) so tasks always observe
+ * a live, working manager without anyone wiring it up explicitly.
+ * Applications that need a different concrete implementation override
+ * the slot through @c IContext::setEntityManager — the prior owner is
+ * destroyed via the unique_ptr slot's RAII chain.
  *
- * Ownership: the stub is never instantiated directly. Concrete
- * @c EntityManager objects derive from it and are owned by the
- * @ref Engine as @c std::unique_ptr.
+ * Surface shape:
+ *   - @ref createEntity stamps a fresh entity, owns it, and returns a
+ *     non-owning pointer the caller may use until the entity is
+ *     removed.
+ *   - @ref removeEntity drops the entity and any alias bindings it
+ *     carried.
+ *   - @ref addAlias / @ref getEntityByAlias provide string-keyed
+ *     lookups so callers do not have to thread @ref IEntity::Id
+ *     handles through the wiring path.
+ *
+ * Ownership: every entity returned through @ref createEntity is owned
+ * by the manager. Callers receive a non-owning raw pointer and never
+ * delete it; @ref removeEntity is the one path that releases an entity.
+ *
+ * Thread-safety: implementations document their own policy; the
+ * default concrete @c EntityManager carries no internal
+ * synchronisation today, so external callers must serialise create /
+ * remove / alias mutations themselves. Reads through
+ * @ref getEntityByAlias are safe to interleave with other reads on
+ * the same instance.
+ *
+ * INV-1 compliance: no template parameters on the surface. INV-10
+ * compliance: the @c I prefix marks a pure-virtual interface with no
+ * state and no non-virtual method bodies.
  */
 class IEntityManager
 {
   public:
     virtual ~IEntityManager() = default;
+
+    /**
+     * @brief Allocates a fresh entity, stamps it with a non-zero id,
+     *        and stores it in the manager.
+     *
+     * Returns a non-owning pointer to the new entity. Ownership stays
+     * with the manager; callers never delete the returned pointer.
+     * Returns @c nullptr only if allocation itself fails (the default
+     * concrete propagates @c std::bad_alloc through; embedders that
+     * want a quieter contract override this method).
+     */
+    [[nodiscard]] virtual IEntity *createEntity() = 0;
+
+    /**
+     * @brief Releases @p entity from the manager and drops any alias
+     *        bindings that named it.
+     *
+     * Idempotent: calling @ref removeEntity on a pointer the manager
+     * does not own is a no-op. After the call returns, the pointer is
+     * dangling; callers must drop their handle.
+     */
+    virtual void removeEntity(IEntity *entity) = 0;
+
+    /**
+     * @brief Binds @p alias to @p entity so future @ref getEntityByAlias
+     *        lookups under that string return the same entity.
+     *
+     * Re-binding an alias to a different entity overwrites the prior
+     * binding silently. Binding an alias to a null @p entity is
+     * implementation-defined and the default concrete drops the
+     * mapping rather than storing a null entry.
+     */
+    virtual void addAlias(IEntity *entity, const std::string &alias) = 0;
+
+    /**
+     * @brief Looks up the entity bound to @p alias.
+     *
+     * Returns @c nullptr when no entity is bound under @p alias.
+     * Returned pointer is non-owning and stays valid until the entity
+     * is removed.
+     */
+    [[nodiscard]] virtual IEntity *
+        getEntityByAlias(const std::string &alias) const = 0;
 
     IEntityManager(const IEntityManager &)            = delete;
     IEntityManager &operator=(const IEntityManager &) = delete;

--- a/include/vigine/api/engine/abstractengine.h
+++ b/include/vigine/api/engine/abstractengine.h
@@ -73,9 +73,9 @@ class AbstractEngine : public IEngine
 
     // ------ IEngine ------
 
-    [[nodiscard]] IContext &context() override;
-    [[nodiscard]] Result    run() override;
-    void                    shutdown() noexcept override;
+    [[nodiscard]] IContext     &context() override;
+    [[nodiscard]] vigine::Result run() override;
+    void                        shutdown() noexcept override;
     [[nodiscard]] bool      isRunning() const noexcept override;
 
     AbstractEngine(const AbstractEngine &)            = delete;

--- a/include/vigine/api/engine/iengine.h
+++ b/include/vigine/api/engine/iengine.h
@@ -81,7 +81,7 @@ class IEngine
      * dedicate to pump work for the engine's lifetime; the canonical
      * caller is the OS main thread in a foreground engine.
      */
-    [[nodiscard]] virtual Result run() = 0;
+    [[nodiscard]] virtual vigine::Result run() = 0;
 
     /**
      * @brief Requests a clean stop of the main loop.

--- a/include/vigine/api/engine/iengine_token.h
+++ b/include/vigine/api/engine/iengine_token.h
@@ -130,6 +130,7 @@ class ISystem;                 // to be defined under #197 (system wrapper leaf)
 
 namespace vigine::engine
 {
+class IEngine;
 
 /**
  * @brief Thin value wrapper carrying either a live reference of type
@@ -359,6 +360,18 @@ class IEngineToken
      */
     [[nodiscard]] virtual vigine::statemachine::IStateMachine &
         stateMachine() noexcept = 0;
+
+    /**
+     * @brief Returns the engine that owns the context behind this
+     *        token.
+     *
+     * Ungated infrastructure accessor: the engine outlives every
+     * state transition (it is the object that hands the context
+     * out), so the reference stays valid for the token's entire
+     * lifetime regardless of @ref isAlive. Tasks that need to call
+     * @c IEngine::shutdown reach the engine through this accessor.
+     */
+    [[nodiscard]] virtual vigine::engine::IEngine &engine() noexcept = 0;
 
     // ------ Expiration notification ------
 

--- a/include/vigine/api/service/wellknown.h
+++ b/include/vigine/api/service/wellknown.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "vigine/api/service/serviceid.h"
+
+namespace vigine::service::wellknown
+{
+/**
+ * @file wellknown.h
+ * @brief Engine-reserved well-known @ref ServiceId constants.
+ *
+ * The well-known constants below identify services the engine itself
+ * registers under stable, caller-known ids during context construction.
+ * Tasks that depend on those services resolve them by these constants
+ * through the engine-token's @c service() accessor without anyone
+ * threading a runtime-allocated id through the wiring path.
+ *
+ * Id-space convention:
+ *   - @c index in [1..15] is reserved for the engine. Adding a new
+ *     engine-scope well-known id picks the next free slot in this
+ *     range and bumps the @c generation field with every breaking
+ *     change to its contract.
+ *   - @c index >= 16 is free for application-side well-known ids.
+ *     Applications declare their own constants in their own
+ *     namespace (e.g. @c myapp::services::wellknown) and register
+ *     services through @c IContext::registerService(svc, knownId).
+ *   - The @c generation field starts at @c 1 for every freshly-
+ *     declared id; bump it (and the matching @c registerService
+ *     call site) when a new service implementation replaces an
+ *     incompatible predecessor under the same slot.
+ *
+ * Lookups always go through the engine token:
+ * @code
+ *   auto svc = apiToken()->service(vigine::service::wellknown::platformService);
+ *   if (!svc.ok()) { ... }
+ *   auto* platformService =
+ *       dynamic_cast<vigine::ecs::platform::PlatformService*>(&svc.value());
+ * @endcode
+ *
+ * The engine-built defaults are auto-registered by @ref AbstractContext
+ * during construction; applications that want a different concrete
+ * implementation call @c IContext::registerService(myImpl, knownId)
+ * which replaces the slot's occupant and destroys the prior default
+ * via the registry's RAII chain.
+ */
+
+/**
+ * @brief Well-known id for the engine-wide @c PlatformService.
+ *
+ * The default is built by @ref AbstractContext with a default
+ * @c WindowSystem("DefaultWindow") owned internally. Applications
+ * that need a different concrete platform implementation register
+ * their own under this id; the default is destroyed in the process.
+ */
+inline constexpr ServiceId platformService{1, 1};
+
+/**
+ * @brief Well-known id for the engine-wide @c GraphicsService.
+ *
+ * The default is built by @ref AbstractContext with a default
+ * @c RenderSystem("DefaultRender") owned internally. Override pattern
+ * mirrors @ref platformService.
+ */
+inline constexpr ServiceId graphicsService{2, 1};
+
+} // namespace vigine::service::wellknown

--- a/include/vigine/api/taskflow/abstracttask.h
+++ b/include/vigine/api/taskflow/abstracttask.h
@@ -23,13 +23,13 @@ namespace vigine
  * @ref AbstractTask wires the task-side half of the
  * @ref vigine::engine::IEngineToken contract documented in
  * @c architecture.md § R-StateScope: it stores the non-owning token
- * pointer bound by the engine via @ref setApi and exposes it through
- * @ref api. Concrete tasks override @ref run and reach engine
+ * pointer bound by the engine via @ref setApiToken and exposes it through
+ * @ref apiToken. Concrete tasks override @ref run and reach engine
  * subsystems exclusively through the bound token returned by
- * @ref api.
+ * @ref apiToken.
  *
  * Strict encapsulation: the @c _api token pointer is @c private. The
- * @ref setApi and @ref api overrides are marked @c final so concrete
+ * @ref setApiToken and @ref apiToken overrides are marked @c final so concrete
  * tasks cannot bypass the binding contract.
  */
 class AbstractTask : public ITask
@@ -37,9 +37,9 @@ class AbstractTask : public ITask
   public:
     ~AbstractTask() override;
 
-    void setApi(engine::IEngineToken *api) noexcept override final;
+    void setApiToken(engine::IEngineToken *api) noexcept override final;
 
-    [[nodiscard]] engine::IEngineToken *api() noexcept override final;
+    [[nodiscard]] engine::IEngineToken *apiToken() noexcept override final;
 
   protected:
     AbstractTask();
@@ -54,7 +54,7 @@ class AbstractTask : public ITask
      * task flow (or the state machine that issued the token) keeps
      * the concrete object alive while it is in scope.
      */
-    engine::IEngineToken *_api{nullptr};
+    engine::IEngineToken *_apiToken{nullptr};
 };
 
 } // namespace vigine

--- a/include/vigine/api/taskflow/abstracttaskflow.h
+++ b/include/vigine/api/taskflow/abstracttaskflow.h
@@ -242,7 +242,7 @@ class AbstractTaskFlow : public ITaskFlow
      * Installed by the @ref vigine::engine::AbstractEngine pump via
      * @ref setContext before each tick of the bound flow. @c nullptr until
      * the first @ref setContext call lands; in that case @ref runCurrentTask
-     * falls back to the no-token shape (the api() pointer the task observes
+     * falls back to the no-token shape (the apiToken() pointer the task observes
      * is @c nullptr).
      */
     vigine::IContext *_context{nullptr};
@@ -271,10 +271,10 @@ class AbstractTaskFlow : public ITaskFlow
      * "FSM has transitioned out of my state".
      *
      * @ref runCurrentTask reads the raw pointer through @c _activeToken.get()
-     * and binds it on the runnable through @ref vigine::ITask::setApi
+     * and binds it on the runnable through @ref vigine::ITask::setApiToken
      * for the duration of @c run(); the binding is cleared back to
      * @c nullptr by an RAII guard so a throwing @c run still leaves the
-     * task with a null api() pointer once the call returns.
+     * task with a null apiToken() pointer once the call returns.
      */
     std::unique_ptr<vigine::engine::IEngineToken> _activeToken;
 };

--- a/include/vigine/api/taskflow/abstracttaskflow.h
+++ b/include/vigine/api/taskflow/abstracttaskflow.h
@@ -72,7 +72,7 @@ class TaskOrchestrator;
  *     the start (and current) task. A caller that never registers
  *     its own tasks still sees a valid @ref current id. A caller
  *     that registers its own tasks freely overrides the selection
- *     with @ref enqueue.
+ *     with @ref setRoot.
  *   - The default task id is stored as a private member so the
  *     concrete closer can expose it through an internal helper if it
  *     ever needs to (the public API does not surface it separately).
@@ -125,6 +125,7 @@ class AbstractTaskFlow : public ITaskFlow
 
     Result               attachTaskRun(TaskId taskId,
                                        std::unique_ptr<vigine::ITask> task) override;
+    [[nodiscard]] TaskId addTask(std::unique_ptr<vigine::ITask> task) override;
     void                 runCurrentTask() override;
     [[nodiscard]] bool   hasTasksToRun() const noexcept override;
     void                 setContext(vigine::IContext *context) noexcept override;
@@ -140,7 +141,7 @@ class AbstractTaskFlow : public ITaskFlow
 
     // ------ ITaskFlow: flow control ------
 
-    Result               enqueue(TaskId start) override;
+    Result               setRoot(TaskId root) override;
     [[nodiscard]] TaskId current() const noexcept override;
 
     AbstractTaskFlow(const AbstractTaskFlow &)            = delete;
@@ -172,7 +173,7 @@ class AbstractTaskFlow : public ITaskFlow
      * or expose the default task (e.g. for diagnostics) can reach it
      * without walking the orchestrator themselves. The public API
      * does not surface the default id separately because callers who
-     * register their own tasks use @ref enqueue instead.
+     * register their own tasks use @ref setRoot instead.
      */
     [[nodiscard]] TaskId defaultTask() const noexcept;
 
@@ -203,7 +204,7 @@ class AbstractTaskFlow : public ITaskFlow
      *
      * Initialised to @ref _defaultTask during construction so the
      * flow has a valid @ref current immediately. Updated by
-     * @ref enqueue.
+     * @ref setRoot.
      */
     TaskId _current{};
 

--- a/include/vigine/api/taskflow/abstracttaskflow.h
+++ b/include/vigine/api/taskflow/abstracttaskflow.h
@@ -79,8 +79,9 @@ class TaskOrchestrator;
  *
  * Routing (UD-3):
  *   - The default @ref RouteMode for transitions registered through
- *     the short overload of @ref route is @ref RouteMode::FirstMatch,
- *     matching the back-compat behaviour of the legacy task flow.
+ *     @ref route is @ref RouteMode::FirstMatch (also the default for
+ *     the @c mode parameter), matching the back-compat behaviour of
+ *     the legacy task flow.
  *     Callers opt into @ref RouteMode::FanOut or @ref RouteMode::Chain
  *     per transition through the explicit-mode overload.
  *   - Per @c (source, ResultCode) pair the orchestrator stores a
@@ -114,12 +115,10 @@ class AbstractTaskFlow : public ITaskFlow
 
     // ------ ITaskFlow: transitions ------
 
-    Result route(TaskId source, ResultCode code, TaskId next) override;
-    Result route(
-        TaskId    source,
-        ResultCode code,
-        TaskId    next,
-        RouteMode mode) override;
+    Result route(TaskId     source,
+                 TaskId     next,
+                 ResultCode code = ResultCode::Success,
+                 RouteMode  mode = RouteMode::FirstMatch) override;
 
     // ------ ITaskFlow: runnable attachment ------
 

--- a/include/vigine/api/taskflow/abstracttaskflow.h
+++ b/include/vigine/api/taskflow/abstracttaskflow.h
@@ -79,7 +79,7 @@ class TaskOrchestrator;
  *
  * Routing (UD-3):
  *   - The default @ref RouteMode for transitions registered through
- *     the short overload of @ref onResult is @ref RouteMode::FirstMatch,
+ *     the short overload of @ref route is @ref RouteMode::FirstMatch,
  *     matching the back-compat behaviour of the legacy task flow.
  *     Callers opt into @ref RouteMode::FanOut or @ref RouteMode::Chain
  *     per transition through the explicit-mode overload.
@@ -114,8 +114,8 @@ class AbstractTaskFlow : public ITaskFlow
 
     // ------ ITaskFlow: transitions ------
 
-    Result onResult(TaskId source, ResultCode code, TaskId next) override;
-    Result onResult(
+    Result route(TaskId source, ResultCode code, TaskId next) override;
+    Result route(
         TaskId    source,
         ResultCode code,
         TaskId    next,

--- a/include/vigine/api/taskflow/abstracttaskflow.h
+++ b/include/vigine/api/taskflow/abstracttaskflow.h
@@ -3,13 +3,23 @@
 #include <memory>
 #include <unordered_map>
 
+#include <vector>
+
 #include "vigine/result.h"
 #include "vigine/api/engine/iengine_token.h"
+#include "vigine/api/messaging/isubscriptiontoken.h"
+#include "vigine/api/messaging/payload/payloadtypeid.h"
 #include "vigine/api/statemachine/stateid.h"
 #include "vigine/api/taskflow/itaskflow.h"
 #include "vigine/api/taskflow/resultcode.h"
 #include "vigine/api/taskflow/routemode.h"
 #include "vigine/api/taskflow/taskid.h"
+#include "vigine/core/threading/threadaffinity.h"
+
+namespace vigine::messaging
+{
+class ISignalEmitter;
+} // namespace vigine::messaging
 
 namespace vigine
 {
@@ -119,6 +129,14 @@ class AbstractTaskFlow : public ITaskFlow
     [[nodiscard]] bool   hasTasksToRun() const noexcept override;
     void                 setContext(vigine::IContext *context) noexcept override;
     void                 setActiveState(vigine::statemachine::StateId state) noexcept override;
+
+    // ------ ITaskFlow: signal subscription ------
+
+    void   setSignalEmitter(vigine::messaging::ISignalEmitter *emitter) noexcept override;
+    Result signal(TaskId                                  source,
+                  TaskId                                  target,
+                  vigine::payload::PayloadTypeId        payloadTypeId,
+                  vigine::core::threading::ThreadAffinity affinity) override;
 
     // ------ ITaskFlow: flow control ------
 
@@ -277,6 +295,26 @@ class AbstractTaskFlow : public ITaskFlow
      * task with a null apiToken() pointer once the call returns.
      */
     std::unique_ptr<vigine::engine::IEngineToken> _activeToken;
+
+    /**
+     * @brief Non-owning back-pointer to the signal emitter used by
+     *        @ref signal. Installed via @ref setSignalEmitter; @c nullptr
+     *        until the host wires it.
+     */
+    vigine::messaging::ISignalEmitter *_signalEmitter{nullptr};
+
+    /**
+     * @brief Holds every subscription token returned by @ref signal so
+     *        the flow itself controls the subscriptions' lifetime.
+     *
+     * Declared AFTER @ref _runnables on purpose: members destruct in
+     * reverse declaration order, so this vector unwinds first and
+     * cancels every subscription BEFORE @ref _runnables destroys the
+     * subscriber tasks. Without this ordering a subscription token's
+     * cancel path could dereference a freed @c ISubscriber.
+     */
+    std::vector<std::unique_ptr<vigine::messaging::ISubscriptionToken>>
+        _signalSubscriptions;
 };
 
 } // namespace vigine::taskflow

--- a/include/vigine/api/taskflow/itask.h
+++ b/include/vigine/api/taskflow/itask.h
@@ -8,17 +8,17 @@
  * @ref ITask is the task-side half of the @ref vigine::engine::IEngineToken
  * contract documented in @c architecture.md § R-StateScope. The task
  * flow hands every concrete task a state-scoped @ref IEngineToken via
- * @ref setApi before invoking @ref run; tasks reach engine subsystems
- * exclusively through the bound token returned by @ref api.
+ * @ref setApiToken before invoking @ref run; tasks reach engine subsystems
+ * exclusively through the bound token returned by @ref apiToken.
  *
  * Lifecycle:
- *   - @ref setApi binds a non-owning @ref vigine::engine::IEngineToken
+ *   - @ref setApiToken binds a non-owning @ref vigine::engine::IEngineToken
  *     pointer for the upcoming @ref run call. The pointer must remain
  *     live for the duration of the @ref run invocation; the engine
  *     guarantees this by issuing the token, calling @ref run
  *     synchronously inside the bound state's scope, and only then
  *     letting the token expire.
- *   - @ref api returns the bound token (or @c nullptr when no token
+ *   - @ref apiToken returns the bound token (or @c nullptr when no token
  *     has been bound yet). Callers branch on the return value before
  *     dereferencing.
  *   - @ref run is the canonical task-facing entry point. The task
@@ -28,7 +28,7 @@
  *
  * Self-destruct contract (architecture.md § R-StateScope, mechanism
  * step 5): a task whose bound state has been torn down out from under
- * it sees gated accessors on @ref api return
+ * it sees gated accessors on @ref apiToken return
  * @ref vigine::engine::Result::Code::Expired. The task MUST cooperate
  * by returning from @ref run promptly with an error @ref Result rather
  * than racing the engine through additional gated calls. The engine
@@ -57,9 +57,9 @@ namespace vigine
  *        task flow.
  *
  * Concrete tasks derive from @ref AbstractTask, which implements
- * @ref setApi and @ref api as @c final and leaves @ref run pure
+ * @ref setApiToken and @ref apiToken as @c final and leaves @ref run pure
  * virtual. The task flow binds a state-scoped
- * @ref vigine::engine::IEngineToken via @ref setApi before invoking
+ * @ref vigine::engine::IEngineToken via @ref setApiToken before invoking
  * @ref run.
  *
  * Thread-safety: the contract does not pin one. The default
@@ -81,10 +81,10 @@ class ITask
      * The pointer is non-owning. The task must not store it past the
      * end of @ref run because the token expires when the FSM
      * transitions away from the bound state. Pass @c nullptr to clear
-     * the binding (e.g. between ticks); subsequent @ref api calls
-     * return @c nullptr until the next @ref setApi.
+     * the binding (e.g. between ticks); subsequent @ref apiToken calls
+     * return @c nullptr until the next @ref setApiToken.
      */
-    virtual void setApi(engine::IEngineToken *api) = 0;
+    virtual void setApiToken(engine::IEngineToken *api) = 0;
 
     /**
      * @brief Returns the engine token bound for the current
@@ -98,13 +98,13 @@ class ITask
      * helpers running outside @ref run (e.g. event handlers) must
      * branch on null.
      */
-    [[nodiscard]] virtual engine::IEngineToken *api() = 0;
+    [[nodiscard]] virtual engine::IEngineToken *apiToken() = 0;
 
     /**
      * @brief Canonical task-facing entry point.
      *
      * The task flow invokes @ref run exactly once per scheduled tick
-     * after binding the engine token via @ref setApi. The returned
+     * after binding the engine token via @ref setApiToken. The returned
      * @ref Result drives the result-code-keyed transitions registered
      * on the enclosing flow: a transition with a matching
      * @ref Result::Code fires; otherwise the flow stops.

--- a/include/vigine/api/taskflow/itaskflow.h
+++ b/include/vigine/api/taskflow/itaskflow.h
@@ -214,6 +214,24 @@ class ITaskFlow
     virtual Result attachTaskRun(TaskId taskId, std::unique_ptr<vigine::ITask> task) = 0;
 
     /**
+     * @brief Allocates a fresh task slot AND binds @p task to it in a
+     *        single call. Overload of @ref addTask for the canonical
+     *        case where the caller has the runnable in hand and wants
+     *        the slot allocated and bound atomically.
+     *
+     * The flow takes ownership of @p task. Returns the freshly minted
+     * @ref TaskId on success, or an invalid @ref TaskId on failure
+     * (null @p task).
+     *
+     * Use the no-argument @ref addTask overload + @ref attachTaskRun
+     * when the task handle must be referenced from another transition
+     * before its runnable is available (forward-reference pattern);
+     * use this overload for the common back-to-back create + attach
+     * idiom.
+     */
+    [[nodiscard]] virtual TaskId addTask(std::unique_ptr<vigine::ITask> task) = 0;
+
+    /**
      * @brief Executes the runnable bound to the current task slot and
      *        advances the cursor to whichever next task the registered
      *        transitions select.
@@ -361,19 +379,20 @@ class ITaskFlow
     // ------ Flow control ------
 
     /**
-     * @brief Marks @p start as the task the flow begins with.
+     * @brief Marks @p root as the task the flow begins with — the root
+     *        of the task graph traversal driven by @ref runCurrentTask.
      *
      * The referenced task must have been registered through
-     * @ref addTask. Reports @ref Result::Code::Error when @p start is
-     * stale; on success the next @ref current call returns @p start.
+     * @ref addTask. Reports @ref Result::Code::Error when @p root is
+     * stale; on success the next @ref current call returns @p root.
      *
-     * The flow auto-provisions a default start task in its
-     * constructor per UD-3, so callers that never register their own
-     * tasks still observe a valid @ref current id. Callers that
-     * register their own tasks freely override the selection with
-     * this call before they begin driving the flow.
+     * The flow auto-provisions a default root task in its constructor
+     * per UD-3, so callers that never register their own tasks still
+     * observe a valid @ref current id. Callers that register their
+     * own tasks freely override the selection with this call before
+     * they begin driving the flow.
      */
-    virtual Result enqueue(TaskId start) = 0;
+    virtual Result setRoot(TaskId root) = 0;
 
     /**
      * @brief Returns the task the flow currently considers active.

--- a/include/vigine/api/taskflow/itaskflow.h
+++ b/include/vigine/api/taskflow/itaskflow.h
@@ -142,45 +142,33 @@ class ITaskFlow
 
     /**
      * @brief Registers a transition: when @p source completes with
-     *        @p code the flow advances to @p next.
+     *        @p code the flow advances to @p next under @p mode.
      *
-     * Shorthand for @ref route with @ref RouteMode::FirstMatch —
-     * the UD-3 default. Multiple calls with the same
-     * @c (source, code) pair stack up in registration order; the
-     * default @c FirstMatch mode routes to the first registered
-     * target and ignores the rest.
-     *
-     * Both @p source and @p next must have been registered via
-     * @ref addTask beforehand. Reports @ref Result::Code::Error when
-     * either id is stale or when the source id is the same as the
-     * next id (a task cannot transition directly to itself through
-     * a zero-length transition — callers that need a loop wire it
-     * through an explicit intermediate task).
-     */
-    virtual Result route(TaskId source, ResultCode code, TaskId next) = 0;
-
-    /**
-     * @brief Registers a transition with an explicit routing mode.
-     *
-     * Use this overload to opt into @ref RouteMode::FanOut (every
+     * @p code defaults to @ref ResultCode::Success and @p mode to
+     * @ref RouteMode::FirstMatch — the UD-3 defaults — so the common
+     * "Success leads to next" wiring reads as a two-argument call.
+     * Callers that need to opt into @ref RouteMode::FanOut (every
      * target registered against the pair runs independently) or
      * @ref RouteMode::Chain (registered targets run sequentially as
-     * a pipeline). Multiple registrations with the same
-     * @c (source, code) pair must agree on the @ref RouteMode; the
-     * wrapper reports @ref Result::Code::Error on a conflicting
-     * re-registration so the routing contract stays unambiguous.
+     * a pipeline) supply the @p mode argument explicitly. Multiple
+     * registrations with the same @c (source, code) pair must agree
+     * on the @ref RouteMode; the wrapper reports
+     * @ref Result::Code::Error on a conflicting re-registration so
+     * the routing contract stays unambiguous.
      *
      * Both @p source and @p next must have been registered via
      * @ref addTask beforehand. Reports @ref Result::Code::Error when
      * either id is stale, when the source id is the same as the next
-     * id, or when the re-registration conflicts with the already-
-     * stored @ref RouteMode for that pair.
+     * id (a task cannot transition directly to itself through a
+     * zero-length transition — callers that need a loop wire it
+     * through an explicit intermediate task), or when the
+     * re-registration conflicts with the already-stored
+     * @ref RouteMode for that pair.
      */
-    virtual Result route(
-        TaskId    source,
-        ResultCode code,
-        TaskId    next,
-        RouteMode mode) = 0;
+    virtual Result route(TaskId     source,
+                         TaskId     next,
+                         ResultCode code = ResultCode::Success,
+                         RouteMode  mode = RouteMode::FirstMatch) = 0;
 
     // ------ Runnable attachment ------
 

--- a/include/vigine/api/taskflow/itaskflow.h
+++ b/include/vigine/api/taskflow/itaskflow.h
@@ -3,10 +3,17 @@
 #include <memory>
 
 #include "vigine/result.h"
+#include "vigine/api/messaging/payload/payloadtypeid.h"
 #include "vigine/api/statemachine/stateid.h"
 #include "vigine/api/taskflow/resultcode.h"
 #include "vigine/api/taskflow/routemode.h"
 #include "vigine/api/taskflow/taskid.h"
+#include "vigine/core/threading/threadaffinity.h"
+
+namespace vigine::messaging
+{
+class ISignalEmitter;
+} // namespace vigine::messaging
 
 namespace vigine
 {
@@ -298,6 +305,58 @@ class ITaskFlow
      * @ref runCurrentTask, so the contract is naturally satisfied.
      */
     virtual void setActiveState(vigine::statemachine::StateId state) noexcept = 0;
+
+    // ------ Signal subscription ------
+
+    /**
+     * @brief Wires a non-owning @ref vigine::messaging::ISignalEmitter into
+     *        the flow so @ref signal can subscribe target tasks against it.
+     *
+     * The flow stores the pointer; the caller retains ownership of the
+     * emitter and must keep it alive at least as long as the flow.
+     * Passing @c nullptr detaches the binding; subsequent @ref signal
+     * calls report @ref Result::Code::Error until a fresh emitter is
+     * wired in.
+     */
+    virtual void setSignalEmitter(vigine::messaging::ISignalEmitter *emitter) noexcept = 0;
+
+    /**
+     * @brief Subscribes @p target as an @c ISubscriber on the wired
+     *        signal emitter so it receives signals carrying
+     *        @p payloadTypeId. The @p source task identifies the
+     *        in-flow producer for documentation / future routing.
+     *
+     * Both @p source and @p target must have been registered through
+     * @ref addTask. @p target must additionally have a runnable
+     * attached via @ref attachTaskRun whose runtime type implements
+     * @ref vigine::messaging::ISubscriber so the flow can supply it as
+     * the subscriber to @c subscribeSignal. @p payloadTypeId selects
+     * which signal payload type the target is interested in;
+     * @c MessageKind is hard-wired to @c Signal.
+     *
+     * @p affinity expresses the caller's preference for the dispatch
+     * thread. The actual dispatch policy is fixed by the emitter's
+     * configuration (@ref vigine::messaging::sharedBusConfig and
+     * friends) — the parameter is recorded for future per-subscription
+     * overrides; today it serves as a documentation hint.
+     *
+     * The flow takes ownership of the returned subscription token and
+     * keeps it alive for as long as the flow itself, so the caller no
+     * longer needs an external sink for the subscription's lifetime.
+     * Subscriptions release in reverse-registration order at flow
+     * destruction so any state-bound emitter survives until each
+     * subscription has been cleanly cancelled.
+     *
+     * Reports @ref Result::Code::Error when the emitter is not wired,
+     * either task id is stale, the target has no runnable attached,
+     * the target's runnable does not implement
+     * @ref vigine::messaging::ISubscriber, or the emitter rejects the
+     * subscription request.
+     */
+    virtual Result signal(TaskId                            source,
+                          TaskId                            target,
+                          vigine::payload::PayloadTypeId  payloadTypeId,
+                          vigine::core::threading::ThreadAffinity affinity) = 0;
 
     // ------ Flow control ------
 

--- a/include/vigine/api/taskflow/itaskflow.h
+++ b/include/vigine/api/taskflow/itaskflow.h
@@ -86,7 +86,7 @@ namespace vigine::taskflow
  * Routing model (UD-3):
  *   - Sync transitions fire when a completed task reports a
  *     @ref ResultCode. The flow looks up the list of next tasks
- *     registered via @ref onResult against the @c (source, resultCode)
+ *     registered via @ref route against the @c (source, resultCode)
  *     pair and advances according to the transition's @ref RouteMode.
  *   - @ref RouteMode::FirstMatch is the default. Callers pass
  *     @ref RouteMode::FanOut to register a transition that lets every
@@ -144,7 +144,7 @@ class ITaskFlow
      * @brief Registers a transition: when @p source completes with
      *        @p code the flow advances to @p next.
      *
-     * Shorthand for @ref onResult with @ref RouteMode::FirstMatch —
+     * Shorthand for @ref route with @ref RouteMode::FirstMatch —
      * the UD-3 default. Multiple calls with the same
      * @c (source, code) pair stack up in registration order; the
      * default @c FirstMatch mode routes to the first registered
@@ -157,7 +157,7 @@ class ITaskFlow
      * a zero-length transition — callers that need a loop wire it
      * through an explicit intermediate task).
      */
-    virtual Result onResult(TaskId source, ResultCode code, TaskId next) = 0;
+    virtual Result route(TaskId source, ResultCode code, TaskId next) = 0;
 
     /**
      * @brief Registers a transition with an explicit routing mode.
@@ -176,7 +176,7 @@ class ITaskFlow
      * id, or when the re-registration conflicts with the already-
      * stored @ref RouteMode for that pair.
      */
-    virtual Result onResult(
+    virtual Result route(
         TaskId    source,
         ResultCode code,
         TaskId    next,
@@ -244,7 +244,7 @@ class ITaskFlow
      *      @ref hasTasksToRun reports false on the next probe.
      *   2. Invoke the runnable's @c run(). The returned @ref Result is
      *      mapped to the closest @ref ResultCode (Success / Error) and
-     *      the orchestrator looks up the @c onResult transition for
+     *      the orchestrator looks up the @c route transition for
      *      the @c (current, code) pair.
      *   3. When a matching transition exists the cursor advances to
      *      the next task. When no transition is registered the cursor

--- a/include/vigine/api/taskflow/itaskflow.h
+++ b/include/vigine/api/taskflow/itaskflow.h
@@ -228,7 +228,7 @@ class ITaskFlow
      *      alone.
      *
      * The engine wires a state-scoped @c IEngineToken into the
-     * runnable through @ref vigine::ITask::setApi before invoking
+     * runnable through @ref vigine::ITask::setApiToken before invoking
      * @c run and clears the binding through an RAII guard so a
      * throwing @c run still leaves the task with a null token; that
      * sequencing is required by the R-StateScope contract documented
@@ -262,7 +262,7 @@ class ITaskFlow
      *        to mint the per-tick @ref vigine::engine::IEngineToken.
      *
      * The flow stores the context as a non-owning back-pointer so the
-     * R-StateScope binding shape (mint -> setApi -> run -> setApi(nullptr))
+     * R-StateScope binding shape (mint -> setApiToken -> run -> setApiToken(nullptr))
      * inside @ref runCurrentTask reaches the engine-token factory. The
      * @ref vigine::engine::AbstractEngine pump installs this back-pointer
      * once per tick on the bound flow before driving it; the assignment
@@ -278,7 +278,7 @@ class ITaskFlow
      *
      * The flow uses @p state to mint a per-state @ref vigine::engine::IEngineToken
      * via @ref vigine::IContext::makeEngineToken. The token is the one
-     * @ref runCurrentTask binds onto each runnable through @ref vigine::ITask::setApi.
+     * @ref runCurrentTask binds onto each runnable through @ref vigine::ITask::setApiToken.
      *
      * Calling @ref setActiveState with a state that differs from the
      * previously stored one drops the existing token (which fires the

--- a/include/vigine/impl/ecs/entitymanager.h
+++ b/include/vigine/impl/ecs/entitymanager.h
@@ -7,6 +7,7 @@
 
 #include "vigine/api/ecs/abstractentitymanager.h"
 #include "vigine/api/ecs/ientity.h"
+#include "vigine/impl/ecs/entity.h"
 
 #include <map>
 #include <memory>
@@ -15,8 +16,6 @@
 
 namespace vigine
 {
-class Entity;
-
 using EntityUPtr = std::unique_ptr<Entity>;
 
 /**
@@ -29,7 +28,11 @@ using EntityUPtr = std::unique_ptr<Entity>;
  *
  * Closes the legacy entity manager chain: derives from
  * @ref AbstractEntityManager, which in turn implements the pure
- * @ref IEntityManager contract.
+ * @ref IEntityManager contract. The interface signatures use
+ * @ref IEntity *; the concrete narrows the return types to
+ * @ref Entity * via covariant overrides so callers that already work
+ * against the legacy substrate continue to receive @c Entity * without
+ * an extra cast at the call site.
  */
 class EntityManager final : public AbstractEntityManager
 {
@@ -37,21 +40,23 @@ class EntityManager final : public AbstractEntityManager
     /**
      * @brief Constructs an empty entity manager.
      *
-     * Consumers of the @ref vigine::engine::IEngine front door build
-     * their own @ref EntityManager alongside the engine -- the
-     * @ref vigine::IContext aggregator carries the
-     * @ref vigine::ecs::IECS wrapper instead, and no legacy
-     * entity-manager handle is exposed through it. Examples and
-     * downstream embedders construct one directly here, hand it to
-     * each task that still walks the legacy @c Entity* surface, and
-     * let it die alongside the surrounding scope.
+     * The default-built manager is created by @ref AbstractContext
+     * during context construction so every task observes a live
+     * @ref IEntityManager through @c apiToken()->entityManager()
+     * without anyone wiring it up explicitly. Embedders that need a
+     * different concrete implementation register theirs through
+     * @c IContext::setEntityManager and the default is destroyed via
+     * the unique_ptr slot's RAII chain.
      */
     EntityManager();
     ~EntityManager() override;
-    Entity *createEntity();
-    void removeEntity(Entity *entity);
-    void addAlias(Entity *entity, const std::string &alias);
-    Entity *getEntityByAlias(const std::string &alias) const;
+
+    // ------ IEntityManager ------
+
+    [[nodiscard]] Entity *createEntity() override;
+    void                  removeEntity(IEntity *entity) override;
+    void addAlias(IEntity *entity, const std::string &alias) override;
+    [[nodiscard]] Entity *getEntityByAlias(const std::string &alias) const override;
 
   private:
     std::vector<EntityUPtr> _entities;

--- a/include/vigine/impl/ecs/graphics/graphicsservice.h
+++ b/include/vigine/impl/ecs/graphics/graphicsservice.h
@@ -37,32 +37,43 @@ class TextureComponent;
  * per-entity render data for other services / systems to consume.
  *
  * Wrapper base: the service derives from
- * @ref vigine::service::AbstractService. The render system itself is
- * wired in through @ref setRenderSystem because @ref vigine::IContext
- * does not yet expose a system locator — adding one is tracked as a
- * separate architect decision.
+ * @ref vigine::service::AbstractService. Ownership of the underlying
+ * @c RenderSystem is taken at construction time through a
+ * @c std::unique_ptr — there is no post-construction setter. The
+ * service tears the system down through its private member when the
+ * service itself is destroyed.
  */
 class GraphicsService : public vigine::service::AbstractService
 {
   public:
-    explicit GraphicsService(const Name &name);
-    ~GraphicsService() override = default;
+    /**
+     * @brief Constructs the service taking ownership of @p renderSystem.
+     *
+     * The @ref AbstractContext default registration creates the service
+     * with a default @c RenderSystem internally; applications that
+     * need a different concrete render system pass a custom
+     * @c std::unique_ptr<RenderSystem> here and register the resulting
+     * service through @c IContext::registerService(svc, knownId) which
+     * replaces the default at the slot.
+     */
+    GraphicsService(const Name &name, std::unique_ptr<RenderSystem> renderSystem);
+    ~GraphicsService() override;
 
     /**
      * @brief Returns the instance name supplied at construction.
      */
     [[nodiscard]] const Name &name() const noexcept;
 
-    [[nodiscard]] RenderSystem *renderSystem() const noexcept { return _renderSystem; }
-
     /**
-     * @brief Attaches the @c RenderSystem this service exposes.
+     * @brief Returns the owned @c RenderSystem.
      *
-     * Called by the engine bootstrapper after the render system has
-     * been constructed and registered on the ECS substrate. Passing
-     * @c nullptr detaches.
+     * The pointer is valid for the service's lifetime; the service
+     * owns the system through a @c std::unique_ptr and the accessor
+     * never returns @c nullptr because the constructor refuses a null
+     * argument (asserts in Debug, treats null as a constructor
+     * pre-condition violation in Release).
      */
-    void setRenderSystem(RenderSystem *system) noexcept;
+    [[nodiscard]] RenderSystem *renderSystem() const noexcept;
 
     [[nodiscard]] bool initializeRender(void *nativeWindowHandle, std::uint32_t width, std::uint32_t height);
 
@@ -74,15 +85,11 @@ class GraphicsService : public vigine::service::AbstractService
      * the @ref RenderSystem level (driven by ECS @c entityBound
      * callbacks). This accessor is a thin pass-through to
      * @c RenderSystem::boundRenderComponent and therefore returns
-     * @c nullptr in three observable cases:
-     *   1. The render system has not been attached yet
-     *      (see @ref setRenderSystem).
-     *   2. The render system has no bound entity.
-     *   3. The bound entity has no @c RenderComponent registered.
-     *
-     * Callers MUST null-check the return value; the accessor is
-     * intentionally tolerant of unbound state because example code
-     * inspects bindings opportunistically during input handling.
+     * @c nullptr when the render system has no bound entity or the
+     * bound entity has no @c RenderComponent registered. Callers
+     * MUST null-check the return value; the accessor is intentionally
+     * tolerant of unbound state because example code inspects bindings
+     * opportunistically during input handling.
      */
     [[nodiscard]] RenderComponent *renderComponent() const;
 
@@ -91,9 +98,8 @@ class GraphicsService : public vigine::service::AbstractService
      *        @ref RenderSystem's currently bound entity.
      *
      * Same null-state contract as @ref renderComponent: returns
-     * @c nullptr when the render system is unattached, has no bound
-     * entity, or the bound entity has no @c TextureComponent.
-     * Callers MUST null-check.
+     * @c nullptr when the render system has no bound entity or the
+     * bound entity has no @c TextureComponent. Callers MUST null-check.
      */
     [[nodiscard]] TextureComponent *textureComponent() const;
 
@@ -108,14 +114,16 @@ class GraphicsService : public vigine::service::AbstractService
     /**
      * @brief Modern teardown entry point.
      *
-     * Drops the render-system observer pointer and chains to
-     * @ref vigine::service::AbstractService::onShutdown.
+     * The owned @c RenderSystem is torn down alongside this service
+     * via the private @c unique_ptr; @ref onShutdown only chains to
+     * @ref vigine::service::AbstractService::onShutdown so the
+     * @ref isInitialised flag flips back to @c false.
      */
     [[nodiscard]] vigine::Result onShutdown(vigine::IContext &context) override;
 
   private:
-    Name _name;
-    RenderSystem *_renderSystem{nullptr};
+    Name                          _name;
+    std::unique_ptr<RenderSystem> _renderSystem;
 };
 
 using GraphicsServiceUPtr = std::unique_ptr<GraphicsService>;

--- a/include/vigine/impl/ecs/platform/platformservice.h
+++ b/include/vigine/impl/ecs/platform/platformservice.h
@@ -36,13 +36,14 @@ class WindowComponent;
  * @ref vigine::context::AbstractContext via @c registerService. The
  * service exposes a window-centric API (create, show, query native
  * handle, bind an @c IWindowEventHandlerComponent) built on top of
- * the ECS-side @c WindowSystem. Callers reach the service through
- * the service container after registration.
+ * the ECS-side @c WindowSystem.
  *
  * Wrapper base: the service derives from
- * @ref vigine::service::AbstractService. The window system is wired
- * in through @ref setWindowSystem because @ref vigine::IContext does
- * not yet expose a system locator.
+ * @ref vigine::service::AbstractService. Ownership of the underlying
+ * @c WindowSystem is taken at construction time through a
+ * @c std::unique_ptr — there is no post-construction setter. The
+ * service tears the system down through its private member when the
+ * service itself is destroyed.
  *
  * Entity binding: the service holds no per-entity state of its own.
  * Callers pass the target entity to the per-call methods that need
@@ -52,7 +53,17 @@ class WindowComponent;
 class PlatformService : public vigine::service::AbstractService
 {
   public:
-    explicit PlatformService(const Name &name);
+    /**
+     * @brief Constructs the service taking ownership of @p windowSystem.
+     *
+     * The @ref AbstractContext default registration creates the service
+     * with a default @c WindowSystem internally; applications that
+     * need a different concrete window system pass a custom
+     * @c std::unique_ptr<WindowSystem> here and register the resulting
+     * service through @c IContext::registerService(svc, knownId) which
+     * replaces the default at the slot.
+     */
+    PlatformService(const Name &name, std::unique_ptr<WindowSystem> windowSystem);
     ~PlatformService() override;
 
     /**
@@ -61,13 +72,15 @@ class PlatformService : public vigine::service::AbstractService
     [[nodiscard]] const Name &name() const noexcept;
 
     /**
-     * @brief Attaches the @c WindowSystem this service mediates.
+     * @brief Returns the owned @c WindowSystem.
      *
-     * Called by the engine bootstrapper after the window system has
-     * been constructed and registered on the ECS substrate. Passing
-     * @c nullptr detaches.
+     * The pointer is valid for the service's lifetime; the service
+     * owns the system through a @c std::unique_ptr and the accessor
+     * never returns @c nullptr because the constructor refuses a null
+     * argument (asserts in Debug, treats null as a constructor
+     * pre-condition violation in Release).
      */
-    void setWindowSystem(WindowSystem *system) noexcept;
+    [[nodiscard]] WindowSystem *windowSystem() const noexcept;
 
     [[nodiscard]] WindowComponent *createWindow();
     [[nodiscard]] vigine::Result showWindow(WindowComponent *window);
@@ -114,14 +127,16 @@ class PlatformService : public vigine::service::AbstractService
     /**
      * @brief Modern teardown entry point.
      *
-     * Drops the window-system observer pointer and chains to
-     * @ref vigine::service::AbstractService::onShutdown.
+     * The owned @c WindowSystem is torn down with the service itself
+     * via the private @c unique_ptr; @ref onShutdown only chains to
+     * @ref vigine::service::AbstractService::onShutdown so the
+     * @ref isInitialised flag flips back to @c false.
      */
     [[nodiscard]] vigine::Result onShutdown(vigine::IContext &context) override;
 
   private:
-    Name _name;
-    WindowSystem *_windowSystem{nullptr};
+    Name                          _name;
+    std::unique_ptr<WindowSystem> _windowSystem;
 };
 
 using PlatformServiceUPtr = std::unique_ptr<PlatformService>;

--- a/include/vigine/impl/engine/enginetoken.h
+++ b/include/vigine/impl/engine/enginetoken.h
@@ -195,6 +195,8 @@ class EngineToken final : public AbstractEngineToken
     [[nodiscard]] vigine::statemachine::IStateMachine &
         stateMachine() noexcept override;
 
+    [[nodiscard]] vigine::engine::IEngine &engine() noexcept override;
+
     // ------ IEngineToken: expiration notification ------
 
     [[nodiscard]] std::unique_ptr<vigine::messaging::ISubscriptionToken>

--- a/src/api/context/abstractcontext.cpp
+++ b/src/api/context/abstractcontext.cpp
@@ -1,17 +1,32 @@
 #include "vigine/api/context/abstractcontext.h"
 
+#include <cassert>
 #include <memory>
 #include <mutex>
 #include <utility>
 
 #include "vigine/api/engine/iengine_token.h"
+#include "vigine/api/messaging/busconfig.h"
 #include "vigine/api/messaging/factory.h"
+#include "vigine/api/messaging/isignalemitter.h"
 #include "vigine/api/service/abstractservice.h"
+#include "vigine/api/service/wellknown.h"
+#include "vigine/impl/ecs/entitymanager.h"
 #include "vigine/impl/ecs/factory.h"
+#include "vigine/impl/ecs/graphics/graphicsservice.h"
+#include "vigine/impl/ecs/graphics/rendersystem.h"
+#include "vigine/impl/ecs/platform/platformservice.h"
+#include "vigine/impl/ecs/platform/windowsystem.h"
 #include "vigine/impl/engine/enginetoken.h"
+#include "vigine/impl/messaging/signalemitter.h"
 #include "vigine/api/statemachine/factory.h"
 #include "vigine/api/taskflow/factory.h"
 #include "vigine/core/threading/factory.h"
+
+namespace vigine::engine
+{
+class IEngine;
+} // namespace vigine::engine
 
 namespace vigine::context
 {
@@ -42,9 +57,59 @@ AbstractContext::AbstractContext(const ContextConfig &config)
     , _ecs{ecs::createECS()}
     , _stateMachine{statemachine::createStateMachine()}
     , _taskFlow{taskflow::createTaskFlow()}
-// Steps 6--8: empty registries + cleared freeze flag are covered by
-// the member default initialisers declared on @c AbstractContext.
+    // Step 6: engine-environment defaults. The aggregator owns a
+    // default EntityManager and SignalEmitter so every task observes a
+    // live IContext::entityManager() / signalEmitter() reference
+    // through @c apiToken() without anyone wiring them up explicitly.
+    // Applications override either default through @ref setEntityManager
+    // / @ref setSignalEmitter and the prior owner is destroyed via the
+    // unique_ptr slot's RAII chain.
+    , _entityManager{std::make_unique<vigine::EntityManager>()}
+    , _signalEmitter{messaging::createSignalEmitter(*_threadManager,
+                                                    messaging::sharedBusConfig())}
+// Steps 7--9: empty registries + cleared freeze flag + null engine
+// back-ref are covered by the member default initialisers declared
+// on @c AbstractContext. The default Platform/Graphics services are
+// built and auto-registered in the constructor body below because
+// @ref registerService takes the registry mutex and the ctor body
+// is the canonical place for that.
 {
+    // Step 10: default Platform / Graphics services. The aggregator
+    // builds them with default WindowSystem / RenderSystem instances
+    // owned through their service unique_ptr so every task observes a
+    // live, working pair through @c apiToken()->service(...) without
+    // anyone wiring them up explicitly. Applications that need a
+    // different concrete platform / graphics implementation register
+    // theirs via @ref registerService(svc, wellknown::*) which
+    // replaces the default at the well-known slot.
+    auto defaultPlatform =
+        std::make_shared<ecs::platform::PlatformService>(
+            Name("DefaultPlatform"),
+            std::make_unique<ecs::platform::WindowSystem>("DefaultWindow"));
+    if (auto r = registerService(defaultPlatform,
+                                 service::wellknown::platformService);
+        r.isError())
+    {
+        // Default registration failure is a programming error in the
+        // engine bootstrap path: the well-known slot is empty at ctor
+        // entry, the freeze flag is clear, and the service we just
+        // built is non-null. Surface the violation in Debug; Release
+        // continues without the default — application-side code will
+        // still detect a missing service when it tries to look up the
+        // well-known id.
+        assert(false && "AbstractContext: default PlatformService registration failed");
+    }
+
+    auto defaultGraphics =
+        std::make_shared<ecs::graphics::GraphicsService>(
+            Name("DefaultGraphics"),
+            std::make_unique<ecs::graphics::RenderSystem>("DefaultRender"));
+    if (auto r = registerService(defaultGraphics,
+                                 service::wellknown::graphicsService);
+        r.isError())
+    {
+        assert(false && "AbstractContext: default GraphicsService registration failed");
+    }
 }
 
 AbstractContext::~AbstractContext() = default;
@@ -149,6 +214,69 @@ core::threading::IThreadManager &AbstractContext::threadManager()
 }
 
 // ---------------------------------------------------------------------
+// Engine environment (default-built; replaceable via setter)
+// ---------------------------------------------------------------------
+
+IEntityManager &AbstractContext::entityManager()
+{
+    // The unique_ptr slot is filled in the ctor and never observed
+    // null through public mutation paths (the setter asserts on null
+    // in Debug and treats a null argument as a no-op in Release), so
+    // the dereference is always safe between construction and
+    // destruction.
+    assert(_entityManager && "AbstractContext::entityManager: slot is null");
+    return *_entityManager;
+}
+
+void AbstractContext::setEntityManager(std::unique_ptr<IEntityManager> entityManager)
+{
+    // The "default exists" invariant of @ref entityManager requires the
+    // slot to stay non-null. A null replacement is treated as a no-op
+    // in Release (and asserted in Debug) so callers cannot accidentally
+    // strip the default by passing a null argument; replacing means
+    // building a non-null replacement first.
+    assert(entityManager && "AbstractContext::setEntityManager: replacement is null");
+    if (!entityManager)
+        return;
+    _entityManager = std::move(entityManager);
+}
+
+messaging::ISignalEmitter &AbstractContext::signalEmitter()
+{
+    assert(_signalEmitter && "AbstractContext::signalEmitter: slot is null");
+    return *_signalEmitter;
+}
+
+void AbstractContext::setSignalEmitter(std::unique_ptr<messaging::ISignalEmitter> signalEmitter)
+{
+    assert(signalEmitter && "AbstractContext::setSignalEmitter: replacement is null");
+    if (!signalEmitter)
+        return;
+    _signalEmitter = std::move(signalEmitter);
+}
+
+engine::IEngine &AbstractContext::engine()
+{
+    // The engine back-pointer is wired in by
+    // @ref engine::AbstractEngine's constructor body shortly after this
+    // context is built; tasks reaching this accessor through their
+    // engine token observe the live engine for the engine's entire
+    // lifetime. A null read here would mean either the engine
+    // bootstrap path skipped @ref setEngineBackRef (programming
+    // error) or the context was constructed standalone outside any
+    // engine (test fixture). Surface the misuse loudly in Debug;
+    // Release crashes on the dereference, which is also acceptable
+    // because the contract requires a non-null engine reference.
+    assert(_engine && "AbstractContext::engine: engine back-ref is null");
+    return *_engine;
+}
+
+void AbstractContext::setEngineBackRef(engine::IEngine *engine) noexcept
+{
+    _engine = engine;
+}
+
+// ---------------------------------------------------------------------
 // Service registry
 // ---------------------------------------------------------------------
 
@@ -229,6 +357,52 @@ Result AbstractContext::registerService(std::shared_ptr<service::IService> servi
     return Result{};
 }
 
+Result AbstractContext::registerService(std::shared_ptr<service::IService> service,
+                                        service::ServiceId                 knownId)
+{
+    if (!service)
+    {
+        return Result{Result::Code::Error, "registerService: service is null"};
+    }
+    if (!knownId.valid())
+    {
+        return Result{Result::Code::Error,
+                      "registerService: knownId is the invalid sentinel"};
+    }
+
+    // The well-known path requires the service to expose
+    // @ref AbstractService::setId so the registry can stamp the
+    // caller-provided id. IService-only implementations have no setId
+    // hook; reject them rather than registering with a divergent id
+    // that would fail the @ref service lookup's exact-pair match.
+    auto *abstractService = dynamic_cast<service::AbstractService *>(service.get());
+    if (abstractService == nullptr)
+    {
+        return Result{Result::Code::Error,
+                      "registerService: knownId requires AbstractService base"};
+    }
+
+    std::scoped_lock lock{_registryMutex};
+    if (_frozen.load(std::memory_order_acquire))
+    {
+        return Result{
+            Result::Code::TopologyFrozen,
+            "registerService: context is frozen after Engine::run()"};
+    }
+
+    // Replace the slot keyed by @p knownId.index. The previous
+    // occupant (engine-built default or a prior caller-side
+    // registration) is dropped from the @c _services map; if no
+    // external caller held a @c shared_ptr to it, its destructor
+    // runs as the map shrinks. Callers who intend to keep the prior
+    // occupant alive should hold their own @c shared_ptr before
+    // invoking this overload.
+    abstractService->setId(knownId);
+    _services[knownId.index] = std::move(service);
+
+    return Result{};
+}
+
 // ---------------------------------------------------------------------
 // Engine-token factory
 // ---------------------------------------------------------------------
@@ -244,15 +418,11 @@ AbstractContext::makeEngineToken(vigine::statemachine::StateId boundState)
     //     register an invalidation listener via the
     //     @ref AbstractStateMachine subclass back-end and observe
     //     transitions out of @p boundState),
-    //   - a @c nullptr signal-emitter pointer because the engine-wide
-    //     @ref ISignalEmitter façade has not yet been wired through
-    //     @ref IContext (the wrapper follow-up under the #197 umbrella
-    //     ships separately, see #283). The @c EngineToken constructor
-    //     handles the null path by allocating a file-private
-    //     @c NullSignalEmitter stub so the ungated @c signalEmitter
-    //     accessor never crashes; once the real façade lands, this
-    //     factory passes the live wrapper through and the stub stays
-    //     uninstantiated.
+    //   - the aggregator's owned @ref ISignalEmitter façade so the
+    //     ungated @c signalEmitter accessor returns the live wrapper
+    //     directly (the file-private @c NullSignalEmitter stub the
+    //     token carries as a fallback stays uninstantiated when this
+    //     pointer is non-null, which it always is post-construction).
     //
     // The token does NOT inspect this aggregator's freeze flag: a task
     // can request a fresh token after @ref freeze (e.g. when a state
@@ -261,7 +431,7 @@ AbstractContext::makeEngineToken(vigine::statemachine::StateId boundState)
     // boundary blocks topology mutation; minting a state-scoped DI
     // handle is not a topology mutation.
     return std::make_unique<vigine::engine::EngineToken>(
-        boundState, *this, *_stateMachine, /*signalEmitter=*/nullptr);
+        boundState, *this, *_stateMachine, _signalEmitter.get());
 }
 
 // ---------------------------------------------------------------------

--- a/src/api/engine/abstractengine.cpp
+++ b/src/api/engine/abstractengine.cpp
@@ -168,7 +168,7 @@ Result AbstractEngine::run()
     //   tick by calling runCurrentTask(). That call asks IContext for
     //   a fresh engine token (when a context has been wired into the
     //   flow via TaskFlow::setContext), binds it on the task via
-    //   setApi, runs the task once, clears the binding, and lets the
+    //   setApiToken, runs the task once, clears the binding, and lets the
     //   token go out of scope so any subscribeExpiration callbacks
     //   that fired during run() can finish their bookkeeping. When
     //   the lookup misses (no TaskFlow registered for the current
@@ -244,8 +244,8 @@ Result AbstractEngine::run()
                 boundFlow->setActiveState(currentState);
 
                 /*
-                 * runCurrentTask handles the per-task setApi /
-                 * setApi(nullptr) lifecycle on its own through its
+                 * runCurrentTask handles the per-task setApiToken /
+                 * setApiToken(nullptr) lifecycle on its own through its
                  * RAII guard; the engine just tells it to advance
                  * once. Any FSM transition requested by the task
                  * during run() lands on the FSM's request queue and

--- a/src/api/engine/abstractengine.cpp
+++ b/src/api/engine/abstractengine.cpp
@@ -4,6 +4,7 @@
 #include <cstdio>
 #include <thread>
 
+#include "vigine/api/context/abstractcontext.h"
 #include "vigine/api/context/factory.h"
 #include "vigine/api/context/icontext.h"
 #include "vigine/api/statemachine/istatemachine.h"
@@ -23,6 +24,19 @@ AbstractEngine::AbstractEngine(const EngineConfig &config)
     : _context{context::createContext(config.context)}
     , _runMode{config.runMode}
 {
+    // Wire the engine back-pointer into the context so tasks reaching
+    // @c apiToken()->engine() observe the same engine that built the
+    // context. The factory always returns an @ref AbstractContext-
+    // derived object (the @c Context closer below); a future leaf that
+    // swaps the factory for a non-AbstractContext implementation must
+    // expose its own back-ref hook. The dynamic_cast guards the cast in
+    // Debug builds; Release skips the check and trusts the factory
+    // contract.
+    if (auto *abstractContext =
+            dynamic_cast<context::AbstractContext *>(_context.get()))
+    {
+        abstractContext->setEngineBackRef(this);
+    }
 }
 
 // The destructor mirrors the ctor order in reverse: lifecycle state
@@ -80,7 +94,7 @@ IContext &AbstractEngine::context()
     return *_context;
 }
 
-Result AbstractEngine::run()
+vigine::Result AbstractEngine::run()
 {
     // Single-shot guard: the first call through flips _runEntered
     // from false to true. Subsequent calls see the flag set and
@@ -92,8 +106,8 @@ Result AbstractEngine::run()
     if (!_runEntered.compare_exchange_strong(
             expected, true, std::memory_order_acq_rel, std::memory_order_acquire))
     {
-        return Result{
-            Result::Code::Error,
+        return vigine::Result{
+            vigine::Result::Code::Error,
             "AbstractEngine::run: lifecycle is single-shot; build a new engine"};
     }
 
@@ -308,7 +322,7 @@ Result AbstractEngine::run()
     tm.runMainThreadPump();
 
     _running.store(false, std::memory_order_release);
-    return Result{};
+    return vigine::Result{};
 }
 
 void AbstractEngine::shutdown() noexcept

--- a/src/api/statemachine/abstractstatemachine.cpp
+++ b/src/api/statemachine/abstractstatemachine.cpp
@@ -37,13 +37,30 @@ AbstractStateMachine::AbstractStateMachine()
 
 AbstractStateMachine::~AbstractStateMachine()
 {
-    // Debug-only lifetime invariant guard: no
-    // @ref InvalidationSubscriptionToken is allowed to outlive its
-    // owning @ref AbstractStateMachine. The token's @c cancel path
-    // dereferences the raw @c _owner back-pointer, so a token that
-    // survives its owner would dereference freed storage. Tracking
-    // the live-token count surfaces the misuse immediately under
-    // Debug; Release skips the check.
+    /*
+     * Drop the bound task flows before the live-token assertion below:
+     * each flow holds a per-state @ref vigine::engine::IEngineToken whose
+     * destructor releases an @ref InvalidationSubscriptionToken against
+     * this state machine. C++ runs the destructor body BEFORE member
+     * destruction, so without the explicit clear here the assertion
+     * would observe @c _liveInvalidationTokens > 0 and abort whenever
+     * any state-bound flow is still attached at shutdown — the typical
+     * shape after #355 lifted the engine token to a per-state lifetime.
+     */
+    {
+        std::scoped_lock lock{_stateTaskFlowsMutex};
+        _stateTaskFlows.clear();
+    }
+
+    /*
+     * Debug-only lifetime invariant guard: no
+     * @ref InvalidationSubscriptionToken is allowed to outlive its
+     * owning @ref AbstractStateMachine. The token's @c cancel path
+     * dereferences the raw @c _owner back-pointer, so a token that
+     * survives its owner would dereference freed storage. Tracking
+     * the live-token count surfaces the misuse immediately under
+     * Debug; Release skips the check.
+     */
     assert(_liveInvalidationTokens.load(std::memory_order_acquire) == 0u
            && "AbstractStateMachine: invalidation subscription token "
               "outlived its owning state machine");

--- a/src/api/taskflow/abstracttask.cpp
+++ b/src/api/taskflow/abstracttask.cpp
@@ -7,14 +7,14 @@ AbstractTask::AbstractTask() = default;
 
 AbstractTask::~AbstractTask() = default;
 
-void AbstractTask::setApi(engine::IEngineToken *api) noexcept
+void AbstractTask::setApiToken(engine::IEngineToken *apiToken) noexcept
 {
-    _api = api;
+    _apiToken = apiToken;
 }
 
-engine::IEngineToken *AbstractTask::api() noexcept
+engine::IEngineToken *AbstractTask::apiToken() noexcept
 {
-    return _api;
+    return _apiToken;
 }
 
 } // namespace vigine

--- a/src/api/taskflow/abstracttaskflow.cpp
+++ b/src/api/taskflow/abstracttaskflow.cpp
@@ -82,16 +82,7 @@ bool AbstractTaskFlow::hasTask(TaskId task) const noexcept
 // enforces the "one @ref RouteMode per pair" invariant.
 // ---------------------------------------------------------------------------
 
-Result AbstractTaskFlow::route(TaskId source, ResultCode code, TaskId next)
-{
-    return route(source, code, next, RouteMode::FirstMatch);
-}
-
-Result AbstractTaskFlow::route(
-    TaskId    source,
-    ResultCode code,
-    TaskId    next,
-    RouteMode mode)
+Result AbstractTaskFlow::route(TaskId source, TaskId next, ResultCode code, RouteMode mode)
 {
     return _orchestrator->addTransition(source, code, next, mode);
 }

--- a/src/api/taskflow/abstracttaskflow.cpp
+++ b/src/api/taskflow/abstracttaskflow.cpp
@@ -132,6 +132,31 @@ namespace
 
 } // namespace
 
+TaskId AbstractTaskFlow::addTask(std::unique_ptr<vigine::ITask> task)
+{
+    /*
+     * Convenience overload: allocate a slot AND bind the runnable in
+     * a single call. Reject a null @p task before allocating so we do
+     * not leave an orphan task id behind on misuse. After the slot is
+     * reserved we delegate to attachTaskRun for the binding so the
+     * storage and error-handling stays in one place.
+     */
+    if (task == nullptr)
+    {
+        return TaskId{};
+    }
+    const TaskId taskId = addTask();
+    if (!taskId.valid())
+    {
+        return taskId;
+    }
+    if (!attachTaskRun(taskId, std::move(task)).isSuccess())
+    {
+        return TaskId{};
+    }
+    return taskId;
+}
+
 Result AbstractTaskFlow::attachTaskRun(TaskId taskId,
                                        std::unique_ptr<vigine::ITask> task)
 {
@@ -384,13 +409,13 @@ bool AbstractTaskFlow::hasTasksToRun() const noexcept
 // observe an @ref Result::Code::Error and no state change.
 // ---------------------------------------------------------------------------
 
-Result AbstractTaskFlow::enqueue(TaskId start)
+Result AbstractTaskFlow::setRoot(TaskId root)
 {
-    if (!_orchestrator->hasTask(start))
+    if (!_orchestrator->hasTask(root))
     {
-        return Result(Result::Code::Error, "start task not registered");
+        return Result(Result::Code::Error, "setRoot: root task is not registered");
     }
-    _current = start;
+    _current = root;
     return Result();
 }
 

--- a/src/api/taskflow/abstracttaskflow.cpp
+++ b/src/api/taskflow/abstracttaskflow.cpp
@@ -7,6 +7,10 @@
 #include "vigine/result.h"
 #include "vigine/api/context/icontext.h"
 #include "vigine/api/engine/iengine_token.h"
+#include "vigine/api/messaging/isignalemitter.h"
+#include "vigine/api/messaging/isubscriber.h"
+#include "vigine/api/messaging/messagefilter.h"
+#include "vigine/api/messaging/messagekind.h"
 #include "vigine/api/statemachine/stateid.h"
 #include "vigine/api/taskflow/abstracttask.h"
 #include "vigine/api/taskflow/itask.h"
@@ -256,6 +260,86 @@ void AbstractTaskFlow::setContext(vigine::IContext *context) noexcept
      * engine pump and that want to observe apiToken() == nullptr inside run().
      */
     _context = context;
+}
+
+void AbstractTaskFlow::setSignalEmitter(vigine::messaging::ISignalEmitter *emitter) noexcept
+{
+    /*
+     * Plain raw-pointer assignment. The flow stores a non-owning back-
+     * pointer to the signal emitter wired by the host (typically the
+     * application's main()). A nullptr argument detaches the binding so
+     * subsequent signal() calls report Result::Code::Error until a
+     * fresh emitter lands.
+     */
+    _signalEmitter = emitter;
+}
+
+Result AbstractTaskFlow::signal(TaskId                                  source,
+                                TaskId                                  target,
+                                vigine::payload::PayloadTypeId        payloadTypeId,
+                                vigine::core::threading::ThreadAffinity affinity)
+{
+    /*
+     * Flow-level signal subscription. The flow owns the subscription
+     * token returned by ISignalEmitter::subscribeSignal so callers do
+     * not have to maintain an external sink for the subscription's
+     * lifetime. Tokens unwind at flow destruction in the reverse-order
+     * pass over @ref _signalSubscriptions, which is declared AFTER
+     * @ref _runnables so subscriptions cancel BEFORE the underlying
+     * subscriber objects (the runnables themselves) are freed.
+     *
+     * The @p affinity parameter is kept for the documented per-
+     * subscription dispatch hint; today the actual delivery thread is
+     * fixed by the emitter's bus configuration. The signature reserves
+     * the slot for a future emitter overload that takes an explicit
+     * per-subscription override without breaking the public surface.
+     */
+    static_cast<void>(affinity);
+
+    if (_signalEmitter == nullptr)
+    {
+        return Result(Result::Code::Error,
+                      "signal: no signal emitter wired (call setSignalEmitter first)");
+    }
+    if (!_orchestrator->hasTask(source))
+    {
+        return Result(Result::Code::Error,
+                      "signal: source task is not registered");
+    }
+    if (!_orchestrator->hasTask(target))
+    {
+        return Result(Result::Code::Error,
+                      "signal: target task is not registered");
+    }
+
+    auto it = _runnables.find(target);
+    if (it == _runnables.end() || it->second == nullptr)
+    {
+        return Result(Result::Code::Error,
+                      "signal: target task has no runnable attached");
+    }
+
+    auto *subscriber =
+        dynamic_cast<vigine::messaging::ISubscriber *>(it->second.get());
+    if (subscriber == nullptr)
+    {
+        return Result(Result::Code::Error,
+                      "signal: target runnable does not implement ISubscriber");
+    }
+
+    vigine::messaging::MessageFilter filter{};
+    filter.kind   = vigine::messaging::MessageKind::Signal;
+    filter.typeId = payloadTypeId;
+
+    auto token = _signalEmitter->subscribeSignal(filter, subscriber);
+    if (!token)
+    {
+        return Result(Result::Code::Error,
+                      "signal: emitter subscribeSignal returned null");
+    }
+
+    _signalSubscriptions.push_back(std::move(token));
+    return Result();
 }
 
 void AbstractTaskFlow::setActiveState(vigine::statemachine::StateId state) noexcept

--- a/src/api/taskflow/abstracttaskflow.cpp
+++ b/src/api/taskflow/abstracttaskflow.cpp
@@ -82,12 +82,12 @@ bool AbstractTaskFlow::hasTask(TaskId task) const noexcept
 // enforces the "one @ref RouteMode per pair" invariant.
 // ---------------------------------------------------------------------------
 
-Result AbstractTaskFlow::onResult(TaskId source, ResultCode code, TaskId next)
+Result AbstractTaskFlow::route(TaskId source, ResultCode code, TaskId next)
 {
-    return onResult(source, code, next, RouteMode::FirstMatch);
+    return route(source, code, next, RouteMode::FirstMatch);
 }
 
-Result AbstractTaskFlow::onResult(
+Result AbstractTaskFlow::route(
     TaskId    source,
     ResultCode code,
     TaskId    next,
@@ -122,7 +122,7 @@ namespace
             return ResultCode::Success;
         default:
             // Every non-Success outcome maps to Error so callers wiring
-            // an explicit error route through @c onResult observe the
+            // an explicit error route through @c route observe the
             // failure path. Tasks that only distinguish Success vs.
             // Error see the closed two-outcome shape the orchestrator
             // stores on transition edges.

--- a/src/api/taskflow/abstracttaskflow.cpp
+++ b/src/api/taskflow/abstracttaskflow.cpp
@@ -96,7 +96,7 @@ Result AbstractTaskFlow::onResult(
 // ITaskFlow: runnable attachment. The runnable registry is a small
 // per-task map populated by @ref attachTaskRun; @ref runCurrentTask
 // looks the runnable for @ref _current up, executes it through the
-// R-StateScope binding shape (setApi -> run -> setApi(nullptr) under an
+// R-StateScope binding shape (setApiToken -> run -> setApiToken(nullptr) under an
 // RAII guard), and advances @c _current through the transition edge
 // matching the runnable's reported outcome.
 // ---------------------------------------------------------------------------
@@ -179,11 +179,11 @@ void AbstractTaskFlow::runCurrentTask()
     /*
      * Execute the runnable through the R-StateScope binding shape.
      * Concrete tasks derive from @ref vigine::AbstractTask which makes
-     * @c setApi / @c api final and stores the bound token; the flow
+     * @c setApiToken / @c api final and stores the bound token; the flow
      * binds the long-lived per-state token onto the runnable through
-     * @c setApi before @c run and clears the binding back to nullptr
+     * @c setApiToken before @c run and clears the binding back to nullptr
      * through an RAII guard so a throwing @c run still leaves the task
-     * with a null api() once the call returns.
+     * with a null apiToken() once the call returns.
      *
      * Per-state token lifetime. The token bound on every tick is the
      * one stored in @ref _activeToken — minted in @ref setActiveState
@@ -199,7 +199,7 @@ void AbstractTaskFlow::runCurrentTask()
      * No-context / no-state fallback. When @ref setContext has never
      * been called or @ref setActiveState has not been driven, the
      * @ref _activeToken stays null. @ref runCurrentTask then binds
-     * @c nullptr onto the runnable and tasks observe api() == nullptr
+     * @c nullptr onto the runnable and tasks observe apiToken() == nullptr
      * inside @c run(). Tests that drive the flow directly without the
      * engine pump rely on this shape.
      */
@@ -211,7 +211,7 @@ void AbstractTaskFlow::runCurrentTask()
         {
             if (task != nullptr)
             {
-                task->setApi(nullptr);
+                task->setApiToken(nullptr);
             }
         }
         ApiBindingGuard(const ApiBindingGuard &)            = delete;
@@ -222,12 +222,12 @@ void AbstractTaskFlow::runCurrentTask()
 
     Result outcome;
     {
-        runnable->setApi(_activeToken.get());
+        runnable->setApiToken(_activeToken.get());
         [[maybe_unused]] ApiBindingGuard guard(runnable);
         outcome = runnable->run();
     }
     /*
-     * On scope exit ApiBindingGuard fires setApi(nullptr); the
+     * On scope exit ApiBindingGuard fires setApiToken(nullptr); the
      * per-state @ref _activeToken stays alive for subsequent ticks
      * until the next @ref setActiveState call drops it.
      */
@@ -253,7 +253,7 @@ void AbstractTaskFlow::setContext(vigine::IContext *context) noexcept
      * AbstractEngine::run. A nullptr argument detaches the binding so
      * subsequent setActiveState calls fall back to the no-token shape —
      * useful for tests that drive the flow directly bypassing the
-     * engine pump and that want to observe api() == nullptr inside run().
+     * engine pump and that want to observe apiToken() == nullptr inside run().
      */
     _context = context;
 }
@@ -269,7 +269,7 @@ void AbstractTaskFlow::setActiveState(vigine::statemachine::StateId state) noexc
      * "old state's token expires precisely on transition out" contract.
      * Then mint a fresh token bound to the new state when a context is
      * wired; without one we leave _activeToken null and tasks observe
-     * api() == nullptr until the engine pump installs a context.
+     * apiToken() == nullptr until the engine pump installs a context.
      */
     if (_activeState == state)
     {

--- a/src/impl/ecs/entitymanager.cpp
+++ b/src/impl/ecs/entitymanager.cpp
@@ -2,6 +2,10 @@
 
 #include "vigine/impl/ecs/entity.h"
 
+vigine::EntityManager::EntityManager() = default;
+
+vigine::EntityManager::~EntityManager() = default;
+
 vigine::Entity *vigine::EntityManager::createEntity()
 {
     // Stamp a fresh non-zero id so the entity can be distinguished
@@ -11,16 +15,48 @@ vigine::Entity *vigine::EntityManager::createEntity()
     return _entities.back().get();
 }
 
-vigine::EntityManager::~EntityManager() = default;
-
-void vigine::EntityManager::removeEntity(Entity *entity)
+void vigine::EntityManager::removeEntity(IEntity *entity)
 {
-    std::erase_if(_entities, [entity](const EntityUPtr &uptr) { return uptr.get() == entity; });
+    if (entity == nullptr)
+        return;
+
+    // Drop alias bindings first so a future @ref getEntityByAlias
+    // call cannot hand out a pointer that is about to be deleted by
+    // the @ref _entities erase below. The check uses the IEntity*
+    // identity so callers that pass through the interface signature
+    // are matched the same way as those that pass an Entity* directly.
+    for (auto it = _entityAliases.begin(); it != _entityAliases.end();)
+    {
+        if (static_cast<IEntity *>(it->second) == entity)
+            it = _entityAliases.erase(it);
+        else
+            ++it;
+    }
+
+    std::erase_if(_entities, [entity](const EntityUPtr &uptr) {
+        return static_cast<IEntity *>(uptr.get()) == entity;
+    });
 }
 
-void vigine::EntityManager::addAlias(Entity *entity, const std::string &alias)
+void vigine::EntityManager::addAlias(IEntity *entity, const std::string &alias)
 {
-    _entityAliases[alias] = entity;
+    // A null entity with an active alias drops the binding rather
+    // than storing a null entry; this keeps @ref getEntityByAlias's
+    // "null on miss" contract observable from the call site without
+    // a poisoned mapping ever materialising.
+    if (entity == nullptr)
+    {
+        _entityAliases.erase(alias);
+        return;
+    }
+
+    // Manager only ever stores entities it allocated through
+    // @ref createEntity, so a pointer the user just got back from
+    // this manager is necessarily an @c Entity * underneath. The
+    // static_cast is safe by construction; a future leaf may swap it
+    // for a checked dynamic_cast if the manager grows alternative
+    // entity types.
+    _entityAliases[alias] = static_cast<Entity *>(entity);
 }
 
 vigine::Entity *vigine::EntityManager::getEntityByAlias(const std::string &alias) const
@@ -30,5 +66,3 @@ vigine::Entity *vigine::EntityManager::getEntityByAlias(const std::string &alias
 
     return nullptr;
 }
-
-vigine::EntityManager::EntityManager() = default;

--- a/src/impl/ecs/graphics/graphicsservice.cpp
+++ b/src/impl/ecs/graphics/graphicsservice.cpp
@@ -5,33 +5,49 @@
 #include "vigine/impl/ecs/graphics/rendersystem.h"
 #include "vigine/impl/ecs/graphics/texturecomponent.h"
 
-vigine::ecs::graphics::GraphicsService::GraphicsService(const Name &name)
+#include <cassert>
+#include <utility>
+
+vigine::ecs::graphics::GraphicsService::GraphicsService(const Name &name,
+                                                        std::unique_ptr<RenderSystem> renderSystem)
     : vigine::service::AbstractService()
     , _name{name}
+    , _renderSystem{std::move(renderSystem)}
 {
+    // Construction pre-condition: the service owns a non-null
+    // render system for its entire lifetime so every accessor below
+    // can dereference @ref _renderSystem unconditionally. The default
+    // registration path in @ref AbstractContext supplies a default
+    // @c RenderSystem; applications that override the default through
+    // @c IContext::registerService also pass a non-null one.
+    assert(_renderSystem && "GraphicsService: renderSystem must be non-null");
 }
+
+vigine::ecs::graphics::GraphicsService::~GraphicsService() = default;
 
 const vigine::Name &vigine::ecs::graphics::GraphicsService::name() const noexcept { return _name; }
 
-void vigine::ecs::graphics::GraphicsService::setRenderSystem(RenderSystem *system) noexcept
+vigine::ecs::graphics::RenderSystem *
+vigine::ecs::graphics::GraphicsService::renderSystem() const noexcept
 {
-    _renderSystem = system;
+    return _renderSystem.get();
 }
 
 vigine::Result vigine::ecs::graphics::GraphicsService::onInit(vigine::IContext &context)
 {
     // Modern lifecycle: chain to the wrapper base so the
-    // @c isInitialised flag flips to @c true. Render-system attachment
-    // is performed through @ref setRenderSystem; @ref onInit itself
-    // does not perform the lookup because @ref vigine::IContext does
-    // not yet expose a system locator.
+    // @c isInitialised flag flips to @c true. The render system was
+    // wired in at construction time and is owned by this service for
+    // its entire lifetime; @ref onInit therefore has no per-call
+    // attachment work to do.
     return vigine::service::AbstractService::onInit(context);
 }
 
 vigine::Result vigine::ecs::graphics::GraphicsService::onShutdown(vigine::IContext &context)
 {
-    // Drop the non-owning render-system handle before chaining up.
-    _renderSystem = nullptr;
+    // The owned @c RenderSystem is torn down alongside this service
+    // via the private @c unique_ptr; @ref onShutdown only flips the
+    // @c isInitialised flag back through the wrapper base.
     return vigine::service::AbstractService::onShutdown(context);
 }
 
@@ -39,24 +55,15 @@ bool vigine::ecs::graphics::GraphicsService::initializeRender(void *nativeWindow
                                                               std::uint32_t width,
                                                               std::uint32_t height)
 {
-    if (!_renderSystem)
-        return false;
-
     return _renderSystem->initialize(nativeWindowHandle, width, height);
 }
 
 vigine::ecs::graphics::RenderComponent *vigine::ecs::graphics::GraphicsService::renderComponent() const
 {
-    if (!_renderSystem)
-        return nullptr;
-
     return _renderSystem->boundRenderComponent();
 }
 
 vigine::ecs::graphics::TextureComponent *vigine::ecs::graphics::GraphicsService::textureComponent() const
 {
-    if (!_renderSystem)
-        return nullptr;
-
     return _renderSystem->boundTextureComponent();
 }

--- a/src/impl/ecs/platform/platformservice.cpp
+++ b/src/impl/ecs/platform/platformservice.cpp
@@ -5,65 +5,67 @@
 
 #include "impl/ecs/platform/windowcomponent.h"
 
+#include <cassert>
+#include <utility>
+
 using namespace vigine::ecs::platform;
 
-PlatformService::PlatformService(const Name &name)
+PlatformService::PlatformService(const Name &name,
+                                 std::unique_ptr<WindowSystem> windowSystem)
     : vigine::service::AbstractService()
     , _name{name}
+    , _windowSystem{std::move(windowSystem)}
 {
+    // Construction pre-condition: the service owns a non-null
+    // window system for its entire lifetime so every accessor below
+    // can dereference @ref _windowSystem unconditionally. The default
+    // registration path in @ref AbstractContext supplies a default
+    // @c WindowSystem; applications that override the default through
+    // @c IContext::registerService also pass a non-null one (a null
+    // service is rejected by the registry's own validation).
+    assert(_windowSystem && "PlatformService: windowSystem must be non-null");
 }
 
 PlatformService::~PlatformService() = default;
 
 const vigine::Name &PlatformService::name() const noexcept { return _name; }
 
-void PlatformService::setWindowSystem(WindowSystem *system) noexcept
+WindowSystem *PlatformService::windowSystem() const noexcept
 {
-    _windowSystem = system;
+    return _windowSystem.get();
 }
 
 vigine::Result PlatformService::onInit(vigine::IContext &context)
 {
     // Modern lifecycle: chain to the wrapper base so the
-    // @c isInitialised flag flips to @c true. Window-system
-    // attachment is performed through @ref setWindowSystem because
-    // @ref vigine::IContext does not yet expose a system locator.
+    // @c isInitialised flag flips to @c true. The window system was
+    // wired in at construction time and is owned by this service for
+    // its entire lifetime; @ref onInit therefore has no per-call
+    // attachment work to do.
     return vigine::service::AbstractService::onInit(context);
 }
 
 vigine::Result PlatformService::onShutdown(vigine::IContext &context)
 {
-    // Drop the non-owning window-system handle before chaining up.
-    _windowSystem = nullptr;
+    // The owned @c WindowSystem is torn down alongside this service
+    // via the private @c unique_ptr; @ref onShutdown only flips the
+    // @c isInitialised flag back through the wrapper base.
     return vigine::service::AbstractService::onShutdown(context);
 }
 
 WindowComponent *PlatformService::createWindow()
 {
-    if (!_windowSystem)
-        return nullptr;
-
     return _windowSystem->createWindowComponent();
 }
 
 vigine::Result PlatformService::showWindow(WindowComponent *window)
 {
-    if (!_windowSystem)
-        return vigine::Result(vigine::Result::Code::Error, "Window system is unavailable");
-
     return _windowSystem->showWindow(window);
 }
 
 vigine::Result PlatformService::bindWindowEventHandler(vigine::Entity *entity, WindowComponent *window,
                                                        IWindowEventHandlerComponent *handler)
 {
-    // Surface the specific null arg so callers don't have to guess
-    // which of the three required handles came in null. The previous
-    // catch-all "No entity or window system" message swallowed the
-    // window argument entirely.
-    if (!_windowSystem)
-        return vigine::Result(vigine::Result::Code::Error,
-                              "PlatformService::bindWindowEventHandler: window system is unattached");
     if (!entity)
         return vigine::Result(vigine::Result::Code::Error,
                               "PlatformService::bindWindowEventHandler: entity is null");
@@ -88,7 +90,7 @@ void *PlatformService::nativeWindowHandle(WindowComponent *window) const
 
 std::vector<WindowComponent *> PlatformService::windowComponents(vigine::Entity *entity) const
 {
-    if (!_windowSystem || !entity)
+    if (!entity)
         return {};
 
     return _windowSystem->windowComponents(entity);
@@ -96,7 +98,7 @@ std::vector<WindowComponent *> PlatformService::windowComponents(vigine::Entity 
 
 std::vector<IWindowEventHandlerComponent *> PlatformService::windowEventHandlers(vigine::Entity *entity) const
 {
-    if (!_windowSystem || !entity)
+    if (!entity)
         return {};
 
     return _windowSystem->windowEventHandlers(entity, nullptr);
@@ -105,7 +107,7 @@ std::vector<IWindowEventHandlerComponent *> PlatformService::windowEventHandlers
 std::vector<IWindowEventHandlerComponent *>
 PlatformService::windowEventHandlers(vigine::Entity *entity, WindowComponent *window) const
 {
-    if (!_windowSystem || !entity || !window)
+    if (!entity || !window)
         return {};
 
     return _windowSystem->windowEventHandlers(entity, window);

--- a/src/impl/engine/enginetoken.cpp
+++ b/src/impl/engine/enginetoken.cpp
@@ -10,6 +10,8 @@
 
 #include "vigine/api/context/icontext.h"
 #include "vigine/api/ecs/iecs.h"
+#include "vigine/api/ecs/ientitymanager.h"
+#include "vigine/api/engine/iengine.h"
 #include "vigine/api/service/iservice.h"
 #include "vigine/api/service/serviceid.h"
 #include "vigine/core/threading/ithreadmanager.h"
@@ -223,12 +225,14 @@ Result<vigine::IEntityManager &> EngineToken::entityManager()
     {
         return R::failure(R::Code::Expired);
     }
-    // The entity manager is a forward-declared stub today
-    // (`include/vigine/api/ecs/ientitymanager.h`). The IContext
-    // aggregator does not yet hand one out; @ref ecs() exposes the
-    // wrapper instead. A follow-up leaf wires the entity manager
-    // through and flips this branch to @ref Result::Code::Ok.
-    return R::failure(R::Code::Unavailable);
+    // The IContext aggregator owns a default @ref IEntityManager
+    // through @ref AbstractContext::_entityManager (and any caller-
+    // side override installed via @ref IContext::setEntityManager).
+    // The slot is non-null for the context's lifetime, so the
+    // reference @ref IContext::entityManager hands back is always
+    // live; the alive-state gate above is the only failure path the
+    // accessor needs to honour.
+    return R::ok(_context.entityManager());
 }
 
 Result<vigine::IComponentManager &> EngineToken::components()
@@ -292,6 +296,17 @@ vigine::messaging::ISignalEmitter &EngineToken::signalEmitter() noexcept
 vigine::statemachine::IStateMachine &EngineToken::stateMachine() noexcept
 {
     return _stateMachine;
+}
+
+vigine::engine::IEngine &EngineToken::engine() noexcept
+{
+    // The engine outlives the context (the engine OWNS the context)
+    // and therefore the token, so the back-pointer wired in by the
+    // engine's constructor body is valid for the token's entire
+    // lifetime. Forwarding through the context keeps the
+    // single-source-of-truth invariant: every accessor that points at
+    // an engine-lifetime resource resolves it through @ref IContext.
+    return _context.engine();
 }
 
 // ---------------------------------------------------------------------------

--- a/test/contract/scenario_23_token_expires_on_transition.cpp
+++ b/test/contract/scenario_23_token_expires_on_transition.cpp
@@ -208,9 +208,9 @@ struct DriverGuard
         ADD_FAILURE() << "ITaskFlow::attachTaskRun must bind the probe runnable";
         return fx;
     }
-    if (!flow->enqueue(probeId).isSuccess())
+    if (!flow->setRoot(probeId).isSuccess())
     {
-        ADD_FAILURE() << "ITaskFlow::enqueue must position the cursor on the probe";
+        ADD_FAILURE() << "ITaskFlow::setRoot must position the cursor on the probe";
         return fx;
     }
 

--- a/test/contract/scenario_24_fresh_token_in_new_state.cpp
+++ b/test/contract/scenario_24_fresh_token_in_new_state.cpp
@@ -188,9 +188,9 @@ struct DriverGuard
             ADD_FAILURE() << "ITaskFlow::attachTaskRun must bind the StateA probe runnable";
             return fx;
         }
-        if (!flow->enqueue(probeId).isSuccess())
+        if (!flow->setRoot(probeId).isSuccess())
         {
-            ADD_FAILURE() << "ITaskFlow::enqueue must position the cursor on the StateA probe";
+            ADD_FAILURE() << "ITaskFlow::setRoot must position the cursor on the StateA probe";
             return fx;
         }
         if (!fsm.addStateTaskFlow(fx.stateA, std::move(flow)).isSuccess())


### PR DESCRIPTION
Rolling tail-fix branch for findings surfaced after the main release-readiness waves landed. Each fix is a separate commit; the PR carries all of them as one merge unit.

## Commits in this PR

1. `Clear bound task flows in AbstractStateMachine destructor before invalidation-token assertion (#359)`
   - File: `src/api/statemachine/abstractstatemachine.cpp`.
   - The dtor body's `assert(_liveInvalidationTokens == 0u)` ran BEFORE `_stateTaskFlows` member destructed, so any state-bound flow whose per-state EngineToken still held an `InvalidationSubscriptionToken` aborted shutdown. Added an explicit `_stateTaskFlows.clear()` under the existing mutex at the top of the dtor body, then the assertion observes a clean count and passes.
   - Reproducer: open example-window, close the window, observe Debug abort with `_liveInvalidationTokens != 0` assertion. Fixed: window closes cleanly.

## Pending findings (will land as additional commits on this branch)

- Vulkan validation error `VUID-vkDestroySampler-sampler-01082` on example-window shutdown — sampler destroyed while still bound to a VkDescriptorSet. Needs RenderSystem shutdown ordering fix (idle queue / destroy descriptor sets before samplers).

Closes #359.