### PR TITLE
Wire IPayloadRegistry into engine signal-emit validation (#361)

### DIFF
--- a/example/window/main.cpp
+++ b/example/window/main.cpp
@@ -23,7 +23,6 @@
 #include <vigine/api/engine/engineconfig.h>
 #include <vigine/api/engine/factory.h>
 #include <vigine/api/engine/iengine.h>
-#include <vigine/api/messaging/payload/factory.h>
 #include <vigine/api/messaging/payload/ipayloadregistry.h>
 #include <vigine/api/messaging/payload/payloadtypeid.h>
 #include <vigine/api/statemachine/istatemachine.h>
@@ -149,14 +148,20 @@ int main()
         return 1;
     }
 
-    // Payload registry for the user-range payload ids used by the
-    // window input pipeline. Engine-bundled ranges (Control, System,
-    // SystemExt, Reserved) are pre-registered by the factory.
-    auto payloadRegistry = vigine::payload::createPayloadRegistry();
-    static_cast<void>(payloadRegistry->registerRange(
+    // Register the user-range payload ids the window input pipeline
+    // will publish. Engine-bundled ranges (Control, System, SystemExt,
+    // Reserved) are auto-registered by the context's default
+    // payload registry under owner "vigine.core" — application code
+    // only adds the user-range ids it owns. Every signalEmitter->emit
+    // through the engine context now validates the payload's
+    // PayloadTypeId against this registry; an unregistered id
+    // surfaces as an error Result instead of a silently-dropped
+    // message on the bus.
+    auto &payloadRegistry = context.payloadRegistry();
+    static_cast<void>(payloadRegistry.registerRange(
         kMouseButtonDownPayloadTypeId, kMouseButtonDownPayloadTypeId,
         "example-window.mouse"));
-    static_cast<void>(payloadRegistry->registerRange(
+    static_cast<void>(payloadRegistry.registerRange(
         kKeyDownPayloadTypeId, kKeyDownPayloadTypeId,
         "example-window.key"));
 

--- a/include/vigine/api/context/abstractcontext.h
+++ b/include/vigine/api/context/abstractcontext.h
@@ -17,6 +17,7 @@
 #include "vigine/api/messaging/busid.h"
 #include "vigine/api/messaging/imessagebus.h"
 #include "vigine/api/messaging/isignalemitter.h"
+#include "vigine/api/messaging/payload/ipayloadregistry.h"
 #include "vigine/result.h"
 #include "vigine/api/statemachine/istatemachine.h"
 #include "vigine/api/statemachine/stateid.h"
@@ -119,6 +120,8 @@ class AbstractContext : public IContext
     void setSignalEmitter(std::unique_ptr<messaging::ISignalEmitter> signalEmitter) override;
 
     [[nodiscard]] engine::IEngine &engine() override;
+
+    [[nodiscard]] payload::IPayloadRegistry &payloadRegistry() override;
 
     /**
      * @brief Engine-internal hook the @ref vigine::engine::AbstractEngine
@@ -305,13 +308,34 @@ class AbstractContext : public IContext
     std::unique_ptr<IEntityManager> _entityManager;
 
     /**
+     * @brief Default-built payload-id registry.
+     *
+     * Constructed in the @ref AbstractContext ctor with the engine-
+     * bundled Control / System / SystemExt / Reserved ranges already
+     * registered under owner @c "vigine.core" (the registry's own
+     * factory does this). Declared BEFORE @ref _signalEmitter so the
+     * emitter's constructor can capture a reference to it; reverse
+     * member-destruction order then keeps the registry alive past the
+     * emitter's destructor. Cannot be replaced after construction —
+     * the engine's internal validation pipeline holds a long-lived
+     * reference into it.
+     */
+    std::unique_ptr<payload::IPayloadRegistry> _payloadRegistry;
+
+    /**
      * @brief Default-built signal emitter facade.
      *
      * Constructed in the @ref AbstractContext ctor as a concrete
      * @c SignalEmitter bound to the engine-owned thread manager and
-     * the shared-pool bus config. Replaceable via
+     * the shared-pool bus config; takes a non-owning reference to
+     * @ref _payloadRegistry so every @c emit / @c emitTo validates
+     * the payload's @ref payload::PayloadTypeId against the engine-
+     * wide registry before posting on the bus. Replaceable via
      * @ref setSignalEmitter; same null-handling contract as
-     * @ref _entityManager.
+     * @ref _entityManager. A replacement emitter is responsible for
+     * its own validation policy — the default registry is still
+     * available via @ref payloadRegistry but the replacement will
+     * not auto-consult it unless the caller wires that themselves.
      */
     std::unique_ptr<messaging::ISignalEmitter> _signalEmitter;
 

--- a/include/vigine/api/context/icontext.h
+++ b/include/vigine/api/context/icontext.h
@@ -30,6 +30,11 @@ class IMessageBus;
 class ISignalEmitter;
 } // namespace vigine::messaging
 
+namespace vigine::payload
+{
+class IPayloadRegistry;
+} // namespace vigine::payload
+
 namespace vigine::service
 {
 class IService;
@@ -265,6 +270,25 @@ class IContext
      * entire lifetime.
      */
     [[nodiscard]] virtual engine::IEngine &engine() = 0;
+
+    /**
+     * @brief Returns the engine-wide payload-id registry.
+     *
+     * The aggregator builds a default @ref payload::IPayloadRegistry
+     * during construction (engine-bundled ranges Control / System /
+     * SystemExt / Reserved auto-registered under owner
+     * @c "vigine.core"). Application code registers its own user-range
+     * ids by calling @c registerRange on the returned reference; the
+     * default signal emitter validates every @ref ISignalEmitter::emit
+     * payload against this registry before posting it on the bus, so
+     * an unregistered id surfaces as an error result instead of a
+     * silently-dropped message.
+     *
+     * The registry is owned by the context for its full lifetime and
+     * cannot be replaced after construction — callers must not retain
+     * the reference past the context's destruction.
+     */
+    [[nodiscard]] virtual payload::IPayloadRegistry &payloadRegistry() = 0;
 
     // ------ Service registry ------
 

--- a/include/vigine/impl/messaging/signalemitter.h
+++ b/include/vigine/impl/messaging/signalemitter.h
@@ -10,6 +10,11 @@ namespace vigine::core::threading
 class IThreadManager;
 } // namespace vigine::core::threading
 
+namespace vigine::payload
+{
+class IPayloadRegistry;
+} // namespace vigine::payload
+
 namespace vigine::messaging
 {
 
@@ -42,6 +47,10 @@ class SignalEmitter final : public AbstractSignalEmitter
      * The inline-only threading policy keeps the signal dispatch
      * synchronous on the caller's thread, which is the historical
      * default and the shape exercised by the facade contract case.
+     *
+     * No payload-id validation: callers that want
+     * @ref vigine::payload::IPayloadRegistry-backed validation use the
+     * registry-aware constructor below.
      */
     explicit SignalEmitter(vigine::core::threading::IThreadManager &threadManager);
 
@@ -55,6 +64,22 @@ class SignalEmitter final : public AbstractSignalEmitter
      */
     SignalEmitter(vigine::core::threading::IThreadManager &threadManager,
                          vigine::messaging::BusConfig       config);
+
+    /**
+     * @brief Constructs the emitter with payload-id validation backed
+     *        by @p registry.
+     *
+     * Every @ref emit / @ref emitTo call resolves the payload's
+     * @ref vigine::payload::PayloadTypeId against @p registry before
+     * posting; an unregistered id surfaces as an error
+     * @ref vigine::Result with a diagnostic message instead of a
+     * silently-dropped message. @p registry must outlive the emitter
+     * (the engine context guarantees this through member declaration
+     * order).
+     */
+    SignalEmitter(vigine::core::threading::IThreadManager &threadManager,
+                  vigine::messaging::BusConfig             config,
+                  vigine::payload::IPayloadRegistry       &registry);
 
     ~SignalEmitter() override = default;
 
@@ -74,6 +99,17 @@ class SignalEmitter final : public AbstractSignalEmitter
     SignalEmitter &operator=(const SignalEmitter &) = delete;
     SignalEmitter(SignalEmitter &&)                  = delete;
     SignalEmitter &operator=(SignalEmitter &&)       = delete;
+
+  private:
+    /**
+     * @brief Optional non-owning reference to the payload-id registry.
+     *
+     * Set by the validation-aware constructor; remains @c nullptr
+     * for the legacy two no-validation constructors. When non-null,
+     * @ref emit / @ref emitTo consult the registry before posting and
+     * fail-fast on an unregistered id.
+     */
+    vigine::payload::IPayloadRegistry *_payloadRegistry{nullptr};
 };
 
 /**
@@ -120,5 +156,19 @@ class SignalEmitter final : public AbstractSignalEmitter
 [[nodiscard]] std::unique_ptr<ISignalEmitter>
     createSignalEmitter(vigine::core::threading::IThreadManager &threadManager,
                         vigine::messaging::BusConfig       config);
+
+/**
+ * @brief Factory that builds a validation-aware emitter — every
+ *        @c emit / @c emitTo consults @p registry and rejects an
+ *        unregistered @ref vigine::payload::PayloadTypeId.
+ *
+ * @p registry must outlive the returned emitter; the engine context
+ * guarantees this through member declaration order. @p threadManager
+ * must outlive the registry.
+ */
+[[nodiscard]] std::unique_ptr<ISignalEmitter>
+    createSignalEmitter(vigine::core::threading::IThreadManager &threadManager,
+                        vigine::messaging::BusConfig             config,
+                        vigine::payload::IPayloadRegistry       &registry);
 
 } // namespace vigine::messaging

--- a/src/api/context/abstractcontext.cpp
+++ b/src/api/context/abstractcontext.cpp
@@ -9,6 +9,8 @@
 #include "vigine/api/messaging/busconfig.h"
 #include "vigine/api/messaging/factory.h"
 #include "vigine/api/messaging/isignalemitter.h"
+#include "vigine/api/messaging/payload/factory.h"
+#include "vigine/api/messaging/payload/ipayloadregistry.h"
 #include "vigine/api/service/abstractservice.h"
 #include "vigine/api/service/wellknown.h"
 #include "vigine/impl/ecs/entitymanager.h"
@@ -58,15 +60,20 @@ AbstractContext::AbstractContext(const ContextConfig &config)
     , _stateMachine{statemachine::createStateMachine()}
     , _taskFlow{taskflow::createTaskFlow()}
     // Step 6: engine-environment defaults. The aggregator owns a
-    // default EntityManager and SignalEmitter so every task observes a
-    // live IContext::entityManager() / signalEmitter() reference
-    // through @c apiToken() without anyone wiring them up explicitly.
+    // default EntityManager, payload registry, and SignalEmitter so
+    // every task observes a live IContext::entityManager() /
+    // payloadRegistry() / signalEmitter() reference through
+    // @c apiToken() without anyone wiring them up explicitly.
     // Applications override either default through @ref setEntityManager
     // / @ref setSignalEmitter and the prior owner is destroyed via the
-    // unique_ptr slot's RAII chain.
+    // unique_ptr slot's RAII chain. The payload registry is internal —
+    // not replaceable via setter — because the SignalEmitter holds a
+    // long-lived reference into it for its emit-time validation path.
     , _entityManager{std::make_unique<vigine::EntityManager>()}
+    , _payloadRegistry{payload::createPayloadRegistry()}
     , _signalEmitter{messaging::createSignalEmitter(*_threadManager,
-                                                    messaging::sharedBusConfig())}
+                                                    messaging::sharedBusConfig(),
+                                                    *_payloadRegistry)}
 // Steps 7--9: empty registries + cleared freeze flag + null engine
 // back-ref are covered by the member default initialisers declared
 // on @c AbstractContext. The default Platform/Graphics services are
@@ -253,6 +260,12 @@ void AbstractContext::setSignalEmitter(std::unique_ptr<messaging::ISignalEmitter
     if (!signalEmitter)
         return;
     _signalEmitter = std::move(signalEmitter);
+}
+
+payload::IPayloadRegistry &AbstractContext::payloadRegistry()
+{
+    assert(_payloadRegistry && "AbstractContext::payloadRegistry: slot is null");
+    return *_payloadRegistry;
 }
 
 engine::IEngine &AbstractContext::engine()

--- a/src/impl/messaging/signalemitter.cpp
+++ b/src/impl/messaging/signalemitter.cpp
@@ -11,10 +11,13 @@
 #include "vigine/api/messaging/imessagepayload.h"
 #include "vigine/api/messaging/messagekind.h"
 #include "vigine/api/messaging/routemode.h"
+#include "vigine/api/messaging/payload/ipayloadregistry.h"
 #include "vigine/api/messaging/payload/payloadtypeid.h"
 #include "vigine/result.h"
 #include "vigine/api/messaging/payload/isignalpayload.h"
 #include "vigine/core/threading/ithreadmanager.h"
+
+#include <sstream>
 
 namespace vigine::messaging
 {
@@ -152,12 +155,41 @@ SignalEmitter::SignalEmitter(
 {
 }
 
+SignalEmitter::SignalEmitter(
+    vigine::core::threading::IThreadManager &threadManager,
+    vigine::messaging::BusConfig             config,
+    vigine::payload::IPayloadRegistry       &registry)
+    : AbstractSignalEmitter{std::move(config), threadManager}
+    , _payloadRegistry{&registry}
+{
+}
+
+namespace
+{
+// Build a hex-formatted "0xNNNN" diagnostic for an unregistered id.
+[[nodiscard]] std::string formatUnregisteredId(
+    const char                            *prefix,
+    vigine::payload::PayloadTypeId         id)
+{
+    std::ostringstream out;
+    out << prefix << ": payload type id 0x" << std::hex << id.value
+        << " is not registered in the payload registry";
+    return out.str();
+}
+} // namespace
+
 vigine::Result
 SignalEmitter::emit(std::unique_ptr<ISignalPayload> payload)
 {
     if (!payload)
     {
         return vigine::Result{vigine::Result::Code::Error, "emit: null payload"};
+    }
+    if (_payloadRegistry != nullptr &&
+        !_payloadRegistry->isRegistered(payload->typeId()))
+    {
+        return vigine::Result{vigine::Result::Code::Error,
+                              formatUnregisteredId("emit", payload->typeId())};
     }
     auto msg = std::make_unique<SignalMessage>(
         std::move(payload),
@@ -178,6 +210,12 @@ SignalEmitter::emitTo(
     if (!payload)
     {
         return vigine::Result{vigine::Result::Code::Error, "emitTo: null payload"};
+    }
+    if (_payloadRegistry != nullptr &&
+        !_payloadRegistry->isRegistered(payload->typeId()))
+    {
+        return vigine::Result{vigine::Result::Code::Error,
+                              formatUnregisteredId("emitTo", payload->typeId())};
     }
     auto msg = std::make_unique<SignalMessage>(
         std::move(payload),
@@ -209,6 +247,14 @@ createSignalEmitter(vigine::core::threading::IThreadManager &threadManager,
                     vigine::messaging::BusConfig       config)
 {
     return std::make_unique<SignalEmitter>(threadManager, std::move(config));
+}
+
+std::unique_ptr<ISignalEmitter>
+createSignalEmitter(vigine::core::threading::IThreadManager &threadManager,
+                    vigine::messaging::BusConfig             config,
+                    vigine::payload::IPayloadRegistry       &registry)
+{
+    return std::make_unique<SignalEmitter>(threadManager, std::move(config), registry);
 }
 
 } // namespace vigine::messaging


### PR DESCRIPTION
Closes #361.

The payload registry was a standalone module — applications could register `PayloadTypeId` ranges on a local instance, but no engine pipeline consulted it. `ISignalEmitter::emit` / `emitTo` routed messages by id without validating, so an unclaimed id silently fanned out to whatever subscriber happened to match. `example/window`'s `main.cpp` showed the symptom: it built a local registry, registered its mouse / key ranges, and let the registry die at end of scope; the engine never saw the registrations and the example only worked because dispatch did not validate.

## Changes

- **`IContext::payloadRegistry()`** accessor; `AbstractContext` default-builds an `IPayloadRegistry` through the existing factory (engine-bundled Control / System / SystemExt / Reserved ranges auto-registered under owner `"vigine.core"`) and stores it BEFORE `_signalEmitter` so reverse-member-destruction order keeps the registry alive past the emitter's destructor. The slot is not replaceable via setter — the `SignalEmitter` holds a long-lived reference into it.
- **New `SignalEmitter` constructor** takes `IPayloadRegistry&` and stores it as a non-owning pointer. `emit` / `emitTo` consult the registry before posting; an unregistered `PayloadTypeId` surfaces as `Result::Code::Error` with a `0xNNNN is not registered` diagnostic instead of a silently-routed message.
- **Legacy no-registry constructors stay** (used by the standalone smoke tests in `test/contract/scenario_04_signal_emitter.cpp`); a new `createSignalEmitter(tm, config, registry)` factory selects the validating path. `AbstractContext` uses the validating factory.
- **`example/window/main.cpp`** registers its `kMouseButtonDown*` / `kKeyDown*` ranges through `context.payloadRegistry()` instead of a local instance — registrations now actually feed the validation pipeline.

Build green, 197/197 ctest green.