### PR TITLE
Add IPayloadRegistry::allocateRange / allocateId / labelsOf — broker-managed user-range ids (#363)

### DIFF
--- a/example/window/CMakeLists.txt
+++ b/example/window/CMakeLists.txt
@@ -23,7 +23,7 @@ set(EXAMPLE_WINDOW_HANDLER_SOURCES
 set(EXAMPLE_WINDOW_TASK_SOURCES
     task/window/initwindowtask.h task/window/initwindowtask.cpp
     task/window/runwindowtask.h task/window/runwindowtask.cpp
-    task/window/windoweventpayload.h
+    task/window/windoweventpayload.h task/window/windoweventpayload.cpp
     task/window/processinputeventtask.h task/window/processinputeventtask.cpp
     task/vulkan/initvulkantask.h task/vulkan/initvulkantask.cpp
     task/vulkan/setupcubetask.h task/vulkan/setupcubetask.cpp

--- a/example/window/main.cpp
+++ b/example/window/main.cpp
@@ -88,10 +88,10 @@ std::unique_ptr<vigine::taskflow::ITaskFlow> createInitTaskFlow()
 
     using vigine::core::threading::ThreadAffinity;
     static_cast<void>(taskFlow->signal(runWindowId, processInputId,
-                                       kMouseButtonDownPayloadTypeId,
+                                       example::payloads::mouseButtonDown,
                                        ThreadAffinity::Pool));
     static_cast<void>(taskFlow->signal(runWindowId, processInputId,
-                                       kKeyDownPayloadTypeId,
+                                       example::payloads::keyDown,
                                        ThreadAffinity::Pool));
 
     static_cast<void>(taskFlow->setRoot(initWindowId));
@@ -148,22 +148,27 @@ int main()
         return 1;
     }
 
-    // Register the user-range payload ids the window input pipeline
-    // will publish. Engine-bundled ranges (Control, System, SystemExt,
-    // Reserved) are auto-registered by the context's default
-    // payload registry under owner "vigine.core" — application code
-    // only adds the user-range ids it owns. Every signalEmitter->emit
-    // through the engine context now validates the payload's
-    // PayloadTypeId against this registry; an unregistered id
-    // surfaces as an error Result instead of a silently-dropped
-    // message on the bus.
+    // Allocate the user-range payload ids the window input pipeline
+    // will publish through the registry's broker API. The engine-bundled
+    // ranges (Control / System / SystemExt / Reserved) are auto-
+    // registered by the context's default payload registry under owner
+    // "vigine.core"; the broker walks the user range
+    // ([0x10000 .. 0xFFFFFFFF]) and returns the first free slot, so the
+    // example never picks numeric ids itself. Every signalEmitter->emit
+    // through the engine context validates the payload's PayloadTypeId
+    // against this registry; an unregistered id surfaces as an error
+    // Result instead of a silently-dropped message on the bus.
     auto &payloadRegistry = context.payloadRegistry();
-    static_cast<void>(payloadRegistry.registerRange(
-        kMouseButtonDownPayloadTypeId, kMouseButtonDownPayloadTypeId,
-        "example-window.mouse"));
-    static_cast<void>(payloadRegistry.registerRange(
-        kKeyDownPayloadTypeId, kKeyDownPayloadTypeId,
-        "example-window.key"));
+    auto mouseIdOpt = payloadRegistry.allocateId("example-window.mouse.button.down");
+    auto keyIdOpt   = payloadRegistry.allocateId("example-window.key.down");
+    if (!mouseIdOpt || !keyIdOpt)
+    {
+        std::cerr << "[example-window] payloadRegistry.allocateId returned nullopt"
+                  << std::endl;
+        return 1;
+    }
+    example::payloads::mouseButtonDown = *mouseIdOpt;
+    example::payloads::keyDown          = *keyIdOpt;
 
     // FSM states: Init -> Work -> Close, Error as the failure off-ramp.
     // Reuse the FSM's auto-provisioned default state as InitState so

--- a/example/window/task/window/processinputeventtask.cpp
+++ b/example/window/task/window/processinputeventtask.cpp
@@ -41,7 +41,7 @@ vigine::messaging::DispatchResult
 {
     const vigine::payload::PayloadTypeId id = message.payloadTypeId();
 
-    if (id == kMouseButtonDownPayloadTypeId)
+    if (id == example::payloads::mouseButtonDown)
     {
         if (const auto *payload =
                 dynamic_cast<const MouseButtonDownPayload *>(message.payload()))
@@ -52,7 +52,7 @@ vigine::messaging::DispatchResult
         return vigine::messaging::DispatchResult::Pass;
     }
 
-    if (id == kKeyDownPayloadTypeId)
+    if (id == example::payloads::keyDown)
     {
         if (const auto *payload =
                 dynamic_cast<const KeyDownPayload *>(message.payload()))

--- a/example/window/task/window/windoweventpayload.cpp
+++ b/example/window/task/window/windoweventpayload.cpp
@@ -1,0 +1,12 @@
+#include "windoweventpayload.h"
+
+namespace example::payloads
+{
+// Default-initialised to the invalid sentinel (PayloadTypeId{} == 0,
+// which is engine-bundled "Control" range — emit() against it would
+// be rejected by the registry's validation if @c main.cpp forgets to
+// fill these in. main.cpp overwrites them with the broker-allocated
+// ids before the engine pump starts.
+vigine::payload::PayloadTypeId mouseButtonDown{};
+vigine::payload::PayloadTypeId keyDown{};
+} // namespace example::payloads

--- a/example/window/task/window/windoweventpayload.h
+++ b/example/window/task/window/windoweventpayload.h
@@ -11,28 +11,35 @@
  * @brief Application-side payloads that carry Win32 window input events
  *        from the window task to an @ref ISignalPayload subscriber.
  *
- * The identifiers below sit in the user half of the @c PayloadTypeId
- * space (@c [0x10000 .. 0xFFFFFFFF]). They are picked from the first
- * block inside the window-example sub-range so that future example
- * payloads can extend contiguously without colliding with other user
- * code that also registers into the user half.
+ * The identifiers used to be hardcoded constants; they are now allocated
+ * at runtime by the engine's payload-registry broker through
+ * @c IPayloadRegistry::allocateId so the example never picks user-range
+ * numbers itself. The two extern variables below get filled in by
+ * @c main.cpp before @c engine->run() — every payload instance reads
+ * its @c typeId() through the variable so emit / subscribe paths see the
+ * registry-allocated id consistently.
  */
 
+namespace example::payloads
+{
 /**
  * @brief Payload identifier for @ref MouseButtonDownPayload.
  *
- * User-range value; registered by the application's payload registry
- * before the bus accepts publishes or subscribes that carry it.
+ * Default-initialised to the invalid sentinel; @c main.cpp overwrites
+ * it with the result of
+ * @c context.payloadRegistry().allocateId("example-window.mouse.button.down")
+ * before the engine pump starts.
  */
-inline constexpr vigine::payload::PayloadTypeId kMouseButtonDownPayloadTypeId{0x20101u};
+extern vigine::payload::PayloadTypeId mouseButtonDown;
 
 /**
  * @brief Payload identifier for @ref KeyDownPayload.
  *
- * User-range value; registered by the application's payload registry
- * before the bus accepts publishes or subscribes that carry it.
+ * Same lifecycle as @ref mouseButtonDown — broker-allocated by
+ * @c main.cpp under owner @c "example-window.key.down".
  */
-inline constexpr vigine::payload::PayloadTypeId kKeyDownPayloadTypeId{0x20102u};
+extern vigine::payload::PayloadTypeId keyDown;
+} // namespace example::payloads
 
 /**
  * @brief Immutable payload describing a mouse-button-down event.
@@ -54,7 +61,7 @@ class MouseButtonDownPayload final : public vigine::messaging::ISignalPayload
 
     [[nodiscard]] vigine::payload::PayloadTypeId typeId() const noexcept override
     {
-        return kMouseButtonDownPayloadTypeId;
+        return example::payloads::mouseButtonDown;
     }
 
     [[nodiscard]] std::unique_ptr<vigine::messaging::ISignalPayload>
@@ -91,7 +98,7 @@ class KeyDownPayload final : public vigine::messaging::ISignalPayload
 
     [[nodiscard]] vigine::payload::PayloadTypeId typeId() const noexcept override
     {
-        return kKeyDownPayloadTypeId;
+        return example::payloads::keyDown;
     }
 
     [[nodiscard]] std::unique_ptr<vigine::messaging::ISignalPayload>

--- a/include/vigine/api/messaging/payload/ipayloadregistry.h
+++ b/include/vigine/api/messaging/payload/ipayloadregistry.h
@@ -4,7 +4,10 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
+#include <vector>
 
+#include "vigine/api/messaging/payload/payloadrange.h"
 #include "vigine/api/messaging/payload/payloadtypeid.h"
 #include "vigine/result.h"
 
@@ -91,6 +94,59 @@ class IPayloadRegistry
      */
     [[nodiscard]] virtual Result
         unregister(std::string_view owner) = 0;
+
+    /**
+     * @brief Atomically allocates the first free contiguous block of
+     *        @p count user-range identifiers and registers it under
+     *        @p owner.
+     *
+     * The registry walks the user range (`[0x10000 .. 0xFFFFFFFF]`)
+     * looking for the lowest gap of size at least @p count, registers
+     * the resulting `[min, min + count - 1]` slice as if
+     * @ref registerRange had been called, and returns a
+     * @ref PayloadRange describing it. Returns @c std::nullopt when
+     * no gap of the requested size exists or when @p count is zero.
+     *
+     * Callers receive an owned, validated id range; @ref resolve then
+     * returns @p owner for any id inside it. The owner string itself
+     * doubles as the semantic label — there is no separate
+     * label-to-id reverse-lookup API.
+     *
+     * Thread-safety: the find-and-register step takes the registry's
+     * exclusive lock so concurrent callers always see disjoint ranges.
+     */
+    [[nodiscard]] virtual std::optional<PayloadRange>
+        allocateRange(std::uint32_t   count,
+                      std::string_view owner) = 0;
+
+    /**
+     * @brief Convenience shorthand for @ref allocateRange with
+     *        `count == 1`.
+     *
+     * Returns the single allocated id or @c std::nullopt when the
+     * user range is full. Equivalent to
+     * `allocateRange(1, owner).transform([](auto r) { return r.min; })`.
+     */
+    [[nodiscard]] virtual std::optional<PayloadTypeId>
+        allocateId(std::string_view owner) = 0;
+
+    /**
+     * @brief Diagnostic dump: lists every `(owner, range)` pair whose
+     *        owner string starts with @p ownerPrefix.
+     *
+     * An empty prefix lists every registered range — including the
+     * engine-bundled ones under owner @c "vigine.core". A non-empty
+     * prefix scopes the dump to one application or namespace
+     * (typically the same string passed to @ref allocateId /
+     * @ref allocateRange / @ref registerRange).
+     *
+     * The returned vector is unsorted; callers that need a specific
+     * order sort it themselves. Thread-safe under the registry's
+     * shared lock so concurrent diagnostic dumps do not block each
+     * other.
+     */
+    [[nodiscard]] virtual std::vector<std::pair<std::string, PayloadRange>>
+        labelsOf(std::string_view ownerPrefix = std::string_view{}) const = 0;
 
     IPayloadRegistry(const IPayloadRegistry &)            = delete;
     IPayloadRegistry &operator=(const IPayloadRegistry &) = delete;

--- a/include/vigine/api/messaging/payload/payloadrange.h
+++ b/include/vigine/api/messaging/payload/payloadrange.h
@@ -2,6 +2,8 @@
 
 #include <cstdint>
 
+#include "vigine/api/messaging/payload/payloadtypeid.h"
+
 namespace vigine::payload
 {
 /**
@@ -58,5 +60,21 @@ inline constexpr std::uint32_t kUserBegin      = 0x10000u;
  *        apart from user-owned ones.
  */
 inline constexpr const char *kEngineOwner = "vigine.core";
+
+/**
+ * @brief Inclusive `[min, max]` slice of the @c PayloadTypeId space.
+ *
+ * The two endpoints are themselves @c PayloadTypeId values so callers
+ * can use the result of an allocation directly as a payload id without
+ * unwrapping. The struct is a pure value aggregate; it carries no owner
+ * label — the @c IPayloadRegistry stores that separately under the
+ * registration owner string.
+ */
+// ENCAP EXEMPT: pure value aggregate
+struct PayloadRange
+{
+    PayloadTypeId min;
+    PayloadTypeId max;
+};
 
 } // namespace vigine::payload

--- a/src/api/messaging/payload/abstractpayloadregistry.cpp
+++ b/src/api/messaging/payload/abstractpayloadregistry.cpp
@@ -195,4 +195,111 @@ const AbstractPayloadRegistry::RangeEntry *
     return nullptr;
 }
 
+std::optional<std::uint32_t>
+    AbstractPayloadRegistry::findFirstFreeBlockLocked(std::uint32_t count) const noexcept
+{
+    if (count == 0u)
+        return std::nullopt;
+
+    // Snapshot the user-half entries sorted by min; engine-half entries
+    // cannot overlap with a user-range allocation so they are ignored
+    // for the gap scan.
+    std::vector<std::pair<std::uint32_t, std::uint32_t>> sorted;
+    sorted.reserve(_ranges.size());
+    for (const RangeEntry &entry : _ranges)
+    {
+        if (entry.min >= kUserBegin)
+            sorted.emplace_back(entry.min, entry.max);
+    }
+    std::sort(sorted.begin(), sorted.end());
+
+    std::uint32_t cursor = kUserBegin;
+    for (const auto &[mn, mx] : sorted)
+    {
+        if (mn > cursor)
+        {
+            const std::uint32_t gap = mn - cursor;
+            if (gap >= count)
+                return cursor;
+        }
+        // Advance past this range. When mx already covers the very
+        // top of the user half, no further gap exists; bail early to
+        // avoid the mx+1 overflow in the cursor update below.
+        if (mx == 0xFFFFFFFFu)
+            return std::nullopt;
+        cursor = (std::max)(cursor, mx + 1u);
+    }
+
+    // Final gap [cursor .. 0xFFFFFFFF] inclusive — width is computed
+    // in 64-bit so the +1 cannot overflow when cursor == 0.
+    const std::uint64_t finalWidth =
+        static_cast<std::uint64_t>(0xFFFFFFFFu) - cursor + 1u;
+    if (finalWidth >= count)
+        return cursor;
+    return std::nullopt;
+}
+
+std::optional<PayloadRange>
+    AbstractPayloadRegistry::allocateRange(std::uint32_t   count,
+                                           std::string_view owner)
+{
+    // Up-front argument validation. Both checks mirror the contract
+    // documented on @ref IPayloadRegistry::allocateRange so callers can
+    // branch on a null optional without having to query the underlying
+    // @ref Result.
+    if (count == 0u)
+        return std::nullopt;
+    if (owner.empty())
+        return std::nullopt;
+
+    std::unique_lock<std::shared_mutex> lock(_mutex);
+    const auto baseOpt = findFirstFreeBlockLocked(count);
+    if (!baseOpt)
+        return std::nullopt;
+
+    const std::uint32_t minId = *baseOpt;
+    const std::uint32_t maxId = minId + count - 1u;
+
+    if (!registerRangeLocked(minId, maxId, owner).isSuccess())
+    {
+        // findFirstFreeBlockLocked guarantees no overlap, the count
+        // check above guarantees min <= max, and owner is non-empty —
+        // so the registration cannot fail under a valid invariant.
+        // Return nullopt as a defensive fallback so callers see one
+        // unified failure surface even if a future code path drifts
+        // the invariant.
+        return std::nullopt;
+    }
+
+    return PayloadRange{PayloadTypeId{minId}, PayloadTypeId{maxId}};
+}
+
+std::optional<PayloadTypeId>
+    AbstractPayloadRegistry::allocateId(std::string_view owner)
+{
+    const auto rangeOpt = allocateRange(1u, owner);
+    if (!rangeOpt)
+        return std::nullopt;
+    return rangeOpt->min;
+}
+
+std::vector<std::pair<std::string, PayloadRange>>
+    AbstractPayloadRegistry::labelsOf(std::string_view ownerPrefix) const
+{
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    std::vector<std::pair<std::string, PayloadRange>> out;
+    out.reserve(_ranges.size());
+    for (const RangeEntry &entry : _ranges)
+    {
+        if (ownerPrefix.empty() ||
+            std::string_view{entry.owner}.starts_with(ownerPrefix))
+        {
+            out.emplace_back(
+                entry.owner,
+                PayloadRange{PayloadTypeId{entry.min}, PayloadTypeId{entry.max}});
+        }
+    }
+    return out;
+}
+
 } // namespace vigine::payload

--- a/src/api/messaging/payload/abstractpayloadregistry.h
+++ b/src/api/messaging/payload/abstractpayloadregistry.h
@@ -54,6 +54,16 @@ class AbstractPayloadRegistry : public IPayloadRegistry
     [[nodiscard]] Result
         unregister(std::string_view owner) override;
 
+    [[nodiscard]] std::optional<PayloadRange>
+        allocateRange(std::uint32_t   count,
+                      std::string_view owner) override;
+
+    [[nodiscard]] std::optional<PayloadTypeId>
+        allocateId(std::string_view owner) override;
+
+    [[nodiscard]] std::vector<std::pair<std::string, PayloadRange>>
+        labelsOf(std::string_view ownerPrefix = std::string_view{}) const override;
+
   protected:
     AbstractPayloadRegistry();
 
@@ -90,6 +100,20 @@ class AbstractPayloadRegistry : public IPayloadRegistry
 
     [[nodiscard]] const RangeEntry *
         findContainingLocked(std::uint32_t value) const noexcept;
+
+    /**
+     * @brief Walks the user range looking for the first gap of size at
+     *        least @p count and returns its lower bound, or
+     *        @c std::nullopt when no such gap exists.
+     *
+     * Caller must hold the exclusive lock; the helper relies on the
+     * range table being stable for the duration of the scan and on the
+     * follow-up @ref registerRangeLocked happening under the same
+     * lock so concurrent @ref allocateRange calls do not race for the
+     * same gap.
+     */
+    [[nodiscard]] std::optional<std::uint32_t>
+        findFirstFreeBlockLocked(std::uint32_t count) const noexcept;
 
     mutable std::shared_mutex _mutex;
     std::vector<RangeEntry>   _ranges;


### PR DESCRIPTION
Closes #363.

Tail-fix on top of #362 (Wave 7h, payload-registry validation). Now that the registry validates emit calls, the next gap is that applications still pick numeric user-range ids by hand and rely on the runtime overlap check to surface collisions late. The broker API closes that gap.

## API additions

- **`struct PayloadRange { PayloadTypeId min, max; }`** in `payloadrange.h`.
- **`IPayloadRegistry::allocateRange(count, owner)`** — exclusive-locked find-and-register; walks user range `[0x10000 .. 0xFFFFFFFF]` starting at the lowest gap of size at least `count`, registers `[min, min + count - 1]` under `owner`, returns `PayloadRange` or `std::nullopt` when no gap fits or `count == 0`.
- **`IPayloadRegistry::allocateId(owner)`** — convenience shorthand for `allocateRange(1, owner).min`.
- **`IPayloadRegistry::labelsOf(ownerPrefix)`** — diagnostic dump of every `(owner, range)` whose owner string starts with `ownerPrefix` (empty prefix lists everything). Shared-locked.

## example/window migration

Hardcoded `kMouseButtonDownPayloadTypeId{0x20101u}` / `kKeyDownPayloadTypeId{0x20102u}` constants are gone. Two extern variables (`example::payloads::mouseButtonDown` / `keyDown`) take their place; the matching `.cpp` default-initialises both to the invalid sentinel. `main.cpp` allocates both ids through the broker right after the engine is up:

```cpp
auto& reg = context.payloadRegistry();
example::payloads::mouseButtonDown = *reg.allocateId(\"example-window.mouse.button.down\");
example::payloads::keyDown          = *reg.allocateId(\"example-window.key.down\");
```

`taskFlow->signal` subscriptions and `signalEmitter->emit` calls read through the same extern variables, so subscriber and publisher always see the same id. `processinputeventtask.cpp` dispatch matches on the same variables.

Build green, 197/197 ctest green at /WX MSVC.