### PR TITLE
Map payload typeId by registered type-name (#367)

### DIFF
--- a/doc/sequence-window-signal.md
+++ b/doc/sequence-window-signal.md
@@ -13,14 +13,14 @@ participant Proc as ProcessInputEventTask
 participant Render as RenderSystem/VulkanAPI
 
 Main->>TF: setSignalEmitter(emitter)
-Main->>TF: signal(Run, Proc, kMouseButtonDownPayloadTypeId)
-TF->>Emitter: subscribeSignal({Signal, kMouseButtonDownPayloadTypeId}, Proc)
+Main->>TF: signal(Run, Proc, idOf(MouseButtonDownPayload::typeName()))
+TF->>Emitter: subscribeSignal({Signal, idOf(MouseButtonDownPayload::typeName())}, Proc)
 Emitter->>Bus: subscribe(filter, Proc)
 Bus-->>Emitter: ISubscriptionToken
 Emitter-->>TF: ISubscriptionToken
 
-Main->>TF: signal(Run, Proc, kKeyDownPayloadTypeId)
-TF->>Emitter: subscribeSignal({Signal, kKeyDownPayloadTypeId}, Proc)
+Main->>TF: signal(Run, Proc, idOf(KeyDownPayload::typeName()))
+TF->>Emitter: subscribeSignal({Signal, idOf(KeyDownPayload::typeName())}, Proc)
 Emitter->>Bus: subscribe(filter, Proc)
 Bus-->>Emitter: ISubscriptionToken
 Emitter-->>TF: ISubscriptionToken

--- a/doc/sequence/window/processinputeventtask.md
+++ b/doc/sequence/window/processinputeventtask.md
@@ -19,7 +19,7 @@ Note over T,M: Signal delivery path for mouse
 Run->>Emitter: emit(make_unique<MouseButtonDownPayload>(button,x,y))
 Emitter->>Bus: post(SignalMessage with M)
 Bus->>T: onMessage(SignalMessage)
-alt payload typeId != kMouseButtonDownPayloadTypeId
+alt payload typeId != idOf(MouseButtonDownPayload::typeName())
   T-->>Bus: DispatchResult::Pass
 else matches mouse filter
   T->>T: downcast payload to MouseButtonDownPayload
@@ -34,7 +34,7 @@ Note over T,K: Signal delivery path for keyboard
 Run->>Emitter: emit(make_unique<KeyDownPayload>(event))
 Emitter->>Bus: post(SignalMessage with K)
 Bus->>T: onMessage(SignalMessage)
-alt payload typeId != kKeyDownPayloadTypeId
+alt payload typeId != idOf(KeyDownPayload::typeName())
   T-->>Bus: DispatchResult::Pass
 else matches key filter
   T->>T: downcast payload to KeyDownPayload

--- a/doc/signals-class-diagram.md
+++ b/doc/signals-class-diagram.md
@@ -80,14 +80,14 @@ participant Proc as ProcessInputEventTask
 Note over Main,TF: signal(...) is configured during flow setup
 
 Main->>TF: setSignalEmitter(emitter)
-Main->>TF: signal(Run, Proc, kMouseButtonDownPayloadTypeId)
-TF->>Emitter: subscribeSignal({Signal, kMouseButtonDownPayloadTypeId}, Proc)
+Main->>TF: signal(Run, Proc, idOf(MouseButtonDownPayload::typeName()))
+TF->>Emitter: subscribeSignal({Signal, idOf(MouseButtonDownPayload::typeName())}, Proc)
 Emitter->>Bus: subscribe(filter, Proc)
 Bus-->>Emitter: ISubscriptionToken
 Emitter-->>TF: ISubscriptionToken
 
-Main->>TF: signal(Run, Proc, kKeyDownPayloadTypeId)
-TF->>Emitter: subscribeSignal({Signal, kKeyDownPayloadTypeId}, Proc)
+Main->>TF: signal(Run, Proc, idOf(KeyDownPayload::typeName()))
+TF->>Emitter: subscribeSignal({Signal, idOf(KeyDownPayload::typeName())}, Proc)
 Emitter->>Bus: subscribe(filter, Proc)
 Bus-->>Emitter: ISubscriptionToken
 Emitter-->>TF: ISubscriptionToken

--- a/example/window/CMakeLists.txt
+++ b/example/window/CMakeLists.txt
@@ -23,7 +23,7 @@ set(EXAMPLE_WINDOW_HANDLER_SOURCES
 set(EXAMPLE_WINDOW_TASK_SOURCES
     task/window/initwindowtask.h task/window/initwindowtask.cpp
     task/window/runwindowtask.h task/window/runwindowtask.cpp
-    task/window/windoweventpayload.h
+    task/window/windoweventpayload.h task/window/windoweventpayload.cpp
     task/window/processinputeventtask.h task/window/processinputeventtask.cpp
     task/vulkan/initvulkantask.h task/vulkan/initvulkantask.cpp
     task/vulkan/setupcubetask.h task/vulkan/setupcubetask.cpp

--- a/example/window/main.cpp
+++ b/example/window/main.cpp
@@ -87,11 +87,12 @@ std::unique_ptr<vigine::taskflow::ITaskFlow> createInitTaskFlow()
     static_cast<void>(taskFlow->route(setupTextEditId, runWindowId));
 
     using vigine::core::threading::ThreadAffinity;
+    using example::payloads::idOf;
     static_cast<void>(taskFlow->signal(runWindowId, processInputId,
-                                       MouseButtonDownPayload::staticTypeId(),
+                                       idOf(MouseButtonDownPayload::typeName()),
                                        ThreadAffinity::Pool));
     static_cast<void>(taskFlow->signal(runWindowId, processInputId,
-                                       KeyDownPayload::staticTypeId(),
+                                       idOf(KeyDownPayload::typeName()),
                                        ThreadAffinity::Pool));
 
     static_cast<void>(taskFlow->setRoot(initWindowId));
@@ -148,19 +149,24 @@ int main()
         return 1;
     }
 
-    // Each window-event payload class registers itself with the
-    // engine's payload registry: the call allocates a fresh user-range
-    // id under a class-scoped owner string and stores it on a private
-    // static member. After the call, MouseButtonDownPayload::staticTypeId()
-    // and KeyDownPayload::staticTypeId() return the allocated ids; every
-    // payload instance reads the same id through its typeId() override.
-    // Engine-bundled ranges (Control / System / SystemExt / Reserved)
-    // are auto-registered by the context's default payload registry
-    // under owner "vigine.core"; the broker walks the user range
-    // ([0x10000 .. 0xFFFFFFFF]) and returns the first free slot, so
-    // the example never picks numeric ids itself.
-    MouseButtonDownPayload::registerWith(context.payloadRegistry());
-    KeyDownPayload::registerWith(context.payloadRegistry());
+    // Allocate user-range PayloadTypeIds for every window-event
+    // payload class declared in windoweventpayload.h. The
+    // namespace-scoped registerAll() walks each class's typeName()
+    // string, asks the broker for a fresh id, and stores the
+    // (typeName -> id) pair in a TU-local lookup map. The map then
+    // backs both the virtual typeId() override on each payload
+    // instance AND the example::payloads::idOf(typeName) lookup that
+    // signal()-subscription / dispatch comparison call sites use.
+    //
+    // The engine does NOT auto-register user-defined payload types —
+    // each application that emits or subscribes to its own
+    // ISignalPayload subclasses is responsible for allocating ids
+    // through IPayloadRegistry::allocateId / allocateRange before
+    // any signal() subscription that depends on the resulting
+    // PayloadTypeId. This call MUST therefore run before
+    // createInitTaskFlow() because that flow's signal() helper
+    // resolves ids through idOf at flow-build time.
+    example::payloads::registerAll(context.payloadRegistry());
 
     // FSM states: Init -> Work -> Close, Error as the failure off-ramp.
     // Reuse the FSM's auto-provisioned default state as InitState so

--- a/example/window/task/window/processinputeventtask.cpp
+++ b/example/window/task/window/processinputeventtask.cpp
@@ -41,7 +41,7 @@ vigine::messaging::DispatchResult
 {
     const vigine::payload::PayloadTypeId id = message.payloadTypeId();
 
-    if (id == MouseButtonDownPayload::staticTypeId())
+    if (id == example::payloads::idOf(MouseButtonDownPayload::typeName()))
     {
         if (const auto *payload =
                 dynamic_cast<const MouseButtonDownPayload *>(message.payload()))
@@ -52,7 +52,7 @@ vigine::messaging::DispatchResult
         return vigine::messaging::DispatchResult::Pass;
     }
 
-    if (id == KeyDownPayload::staticTypeId())
+    if (id == example::payloads::idOf(KeyDownPayload::typeName()))
     {
         if (const auto *payload =
                 dynamic_cast<const KeyDownPayload *>(message.payload()))

--- a/example/window/task/window/processinputeventtask.h
+++ b/example/window/task/window/processinputeventtask.h
@@ -20,11 +20,13 @@ class IMessage;
  *        @ref vigine::messaging::ISubscriber.
  *
  * The task implements @ref vigine::messaging::ISubscriber so an
- * @ref vigine::messaging::ISignalEmitter can register it against
- * @ref kMouseButtonDownPayloadTypeId and @ref kKeyDownPayloadTypeId
- * directly. Subscription tokens are owned here through @ref
- * takeSubscriptionToken so the caller that performs the registrations
- * (for example @c main) does not need to keep a parallel vector alive.
+ * @ref vigine::messaging::ISignalEmitter can register it against the
+ * @c PayloadTypeId allocated for @ref MouseButtonDownPayload and
+ * @ref KeyDownPayload (resolved through @ref example::payloads::idOf
+ * at registration time). Subscription tokens are owned here through
+ * @ref takeSubscriptionToken so the caller that performs the
+ * registrations (for example @c main) does not need to keep a
+ * parallel vector alive.
  *
  * Destruction-order rule: @c _tokens is declared LAST among the data
  * members so that the reverse-declaration-order destruction contract
@@ -51,9 +53,10 @@ class ProcessInputEventTask final : public vigine::AbstractTask,
      * @brief Delivers an incoming message from the bus to the matching
      *        private helper based on @ref vigine::messaging::IMessage::payloadTypeId.
      *
-     * Dispatches on payload type id:
-     *   - @ref kMouseButtonDownPayloadTypeId -> @c onMouseButtonDown.
-     *   - @ref kKeyDownPayloadTypeId          -> @c onKeyDown.
+     * Dispatches on payload type id (each id resolved per-class
+     * through @ref example::payloads::idOf):
+     *   - @ref MouseButtonDownPayload -> @c onMouseButtonDown.
+     *   - @ref KeyDownPayload         -> @c onKeyDown.
      *
      * Both helper paths downcast the payload with @c dynamic_cast and
      * report @c DispatchResult::Handled on a successful match.

--- a/example/window/task/window/windoweventpayload.cpp
+++ b/example/window/task/window/windoweventpayload.cpp
@@ -1,0 +1,107 @@
+#include "windoweventpayload.h"
+
+#include <vigine/api/messaging/payload/ipayloadregistry.h>
+
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+namespace
+{
+/**
+ * @brief TU-local map: each registered payload type-name string
+ *        mapped to its allocated @c PayloadTypeId.
+ *
+ * Filled exactly once by @ref example::payloads::registerAll during
+ * application startup (called from @c main before any @c signal()
+ * subscription that depends on the ids); read-only during the engine
+ * pump, so no synchronisation is needed.
+ */
+std::unordered_map<std::string, vigine::payload::PayloadTypeId> payloadIdsByTypeName;
+
+/**
+ * @brief Returns the id stored for @p typeName, or the invalid
+ *        sentinel when @p typeName has not been registered.
+ */
+[[nodiscard]] vigine::payload::PayloadTypeId
+    lookup(std::string_view typeName) noexcept
+{
+    auto it = payloadIdsByTypeName.find(std::string{typeName});
+    return it != payloadIdsByTypeName.end()
+               ? it->second
+               : vigine::payload::PayloadTypeId{};
+}
+} // namespace
+
+// ---------------------------------------------------------------------------
+//  Type-name string definitions — kept out of the header so the literal lives
+//  in exactly one translation unit.
+// ---------------------------------------------------------------------------
+
+std::string_view MouseButtonDownPayload::typeName() noexcept
+{
+    return "example-window.mouse.button.down";
+}
+
+std::string_view KeyDownPayload::typeName() noexcept
+{
+    return "example-window.key.down";
+}
+
+// ---------------------------------------------------------------------------
+//  Virtual typeId() overrides — read from the lookup map keyed by typeName().
+//  The bus reaches these through the @ref ISignalPayload* base pointer when
+//  a SignalMessage is constructed; the cached value on the message then
+//  drives every subscriber match.
+// ---------------------------------------------------------------------------
+
+vigine::payload::PayloadTypeId MouseButtonDownPayload::typeId() const noexcept
+{
+    return lookup(typeName());
+}
+
+vigine::payload::PayloadTypeId KeyDownPayload::typeId() const noexcept
+{
+    return lookup(typeName());
+}
+
+// ---------------------------------------------------------------------------
+//  clone() — straightforward make_unique copies; defined here to keep the
+//  header free of <memory> std::make_unique churn beyond the include.
+// ---------------------------------------------------------------------------
+
+std::unique_ptr<vigine::messaging::ISignalPayload>
+MouseButtonDownPayload::clone() const
+{
+    return std::make_unique<MouseButtonDownPayload>(_button, _x, _y);
+}
+
+std::unique_ptr<vigine::messaging::ISignalPayload>
+KeyDownPayload::clone() const
+{
+    return std::make_unique<KeyDownPayload>(_event);
+}
+
+// ---------------------------------------------------------------------------
+//  Namespace API: registerAll fills the lookup map; idOf reads it back.
+// ---------------------------------------------------------------------------
+
+namespace example::payloads
+{
+
+vigine::payload::PayloadTypeId idOf(std::string_view typeName) noexcept
+{
+    return lookup(typeName);
+}
+
+void registerAll(vigine::payload::IPayloadRegistry &registry)
+{
+    auto allocateInto = [&](std::string_view name) {
+        if (auto id = registry.allocateId(name))
+            payloadIdsByTypeName[std::string{name}] = *id;
+    };
+    allocateInto(MouseButtonDownPayload::typeName());
+    allocateInto(KeyDownPayload::typeName());
+}
+
+} // namespace example::payloads

--- a/example/window/task/window/windoweventpayload.cpp
+++ b/example/window/task/window/windoweventpayload.cpp
@@ -2,7 +2,6 @@
 
 #include <vigine/api/messaging/payload/ipayloadregistry.h>
 
-#include <string>
 #include <string_view>
 #include <unordered_map>
 
@@ -16,17 +15,28 @@ namespace
  * application startup (called from @c main before any @c signal()
  * subscription that depends on the ids); read-only during the engine
  * pump, so no synchronisation is needed.
+ *
+ * Key type is @c std::string_view so the lookup on the hot path
+ * (every @c typeId() call from @c SignalMessage construction) does
+ * not allocate. Safe because every inserted view comes from a
+ * payload class's @c typeName(), which returns a @c string_view over
+ * a string literal — the literal has static storage duration, so the
+ * view outlives the map.
  */
-std::unordered_map<std::string, vigine::payload::PayloadTypeId> payloadIdsByTypeName;
+std::unordered_map<std::string_view, vigine::payload::PayloadTypeId> payloadIdsByTypeName;
 
 /**
  * @brief Returns the id stored for @p typeName, or the invalid
  *        sentinel when @p typeName has not been registered.
+ *
+ * Allocation-free on the hot path: the map is keyed by
+ * @c std::string_view, so @c find(@p typeName) compares views
+ * directly without materialising a temporary @c std::string.
  */
 [[nodiscard]] vigine::payload::PayloadTypeId
     lookup(std::string_view typeName) noexcept
 {
-    auto it = payloadIdsByTypeName.find(std::string{typeName});
+    auto it = payloadIdsByTypeName.find(typeName);
     return it != payloadIdsByTypeName.end()
                ? it->second
                : vigine::payload::PayloadTypeId{};
@@ -98,7 +108,7 @@ void registerAll(vigine::payload::IPayloadRegistry &registry)
 {
     auto allocateInto = [&](std::string_view name) {
         if (auto id = registry.allocateId(name))
-            payloadIdsByTypeName[std::string{name}] = *id;
+            payloadIdsByTypeName[name] = *id;
     };
     allocateInto(MouseButtonDownPayload::typeName());
     allocateInto(KeyDownPayload::typeName());

--- a/example/window/task/window/windoweventpayload.h
+++ b/example/window/task/window/windoweventpayload.h
@@ -1,38 +1,46 @@
 #pragma once
 
 #include <memory>
+#include <string_view>
 
 #include <vigine/api/ecs/platform/iwindoweventhandler.h>
-#include <vigine/api/messaging/payload/ipayloadregistry.h>
 #include <vigine/api/messaging/payload/payloadtypeid.h>
 #include <vigine/api/messaging/payload/isignalpayload.h>
+
+namespace vigine::payload
+{
+class IPayloadRegistry;
+} // namespace vigine::payload
 
 /**
  * @file windoweventpayload.h
  * @brief Application-side payloads carrying Win32 window input events
  *        from the window task to an @ref ISignalPayload subscriber.
  *
- * Each payload class owns its @ref vigine::payload::PayloadTypeId
- * directly through a private @c static @c inline member. The id is
- * filled at startup by a one-shot @ref registerWith call that asks an
- * @ref vigine::payload::IPayloadRegistry to allocate a fresh user-range
- * id under a class-scoped owner string. Every instance returns the same
- * id from its @ref typeId override; subscribers compare against the
- * matching static getter (e.g. @ref staticTypeId).
+ * Each payload class declares @ref typeName — a @c static descriptor
+ * that returns the registry type-name string used both as the
+ * registration key and as the diagnostic label. The @c typeId()
+ * virtual override on @ref ISignalPayload is implemented in the
+ * matching .cpp by a lookup into a TU-local map
+ * (@c payloadIdsByTypeName) populated once by
+ * @ref example::payloads::registerAll. Callers that need class-level
+ * access without an instance (signal-subscription registration in
+ * @c main, dispatch comparison in @ref ProcessInputEventTask) go
+ * through the namespace helper @ref example::payloads::idOf.
  */
 
 /**
  * @brief Immutable payload describing a mouse-button-down event.
- *
- * Fields are @c const and set at construction time; the bus may
- * deliver the same pointer to multiple subscribers, so the observable
- * state never changes after publish. The payload's @ref typeId is
- * class-scoped — see the class docstring on @ref windoweventpayload.h
- * for the registration story.
  */
 class MouseButtonDownPayload final : public vigine::messaging::ISignalPayload
 {
   public:
+    /**
+     * @brief Class-level type-name string. Definition lives in the .cpp;
+     *        the literal does not appear in this header.
+     */
+    [[nodiscard]] static std::string_view typeName() noexcept;
+
     MouseButtonDownPayload(vigine::ecs::platform::MouseButton button, int x, int y) noexcept
         : _button(button), _x(x), _y(y)
     {
@@ -40,116 +48,68 @@ class MouseButtonDownPayload final : public vigine::messaging::ISignalPayload
 
     ~MouseButtonDownPayload() override = default;
 
-    /**
-     * @brief Returns the registered class-scoped @c PayloadTypeId.
-     *
-     * Reads the @c static @c inline storage filled by @ref registerWith.
-     * Returns the default-constructed (invalid) id when @ref registerWith
-     * has not yet been called — callers depend on @ref registerWith
-     * running before the first emit.
-     */
-    [[nodiscard]] static vigine::payload::PayloadTypeId staticTypeId() noexcept
-    {
-        return _staticTypeId;
-    }
-
-    /**
-     * @brief Overwrites the class-scoped @c PayloadTypeId.
-     *
-     * Exposed alongside @ref registerWith for tests that want to
-     * inject a deterministic id without going through the registry.
-     * Production code calls @ref registerWith.
-     */
-    static void setStaticTypeId(vigine::payload::PayloadTypeId tid) noexcept
-    {
-        _staticTypeId = tid;
-    }
-
-    /**
-     * @brief Allocates the class-scoped @c PayloadTypeId from
-     *        @p registry under owner @c "example-window.mouse.button.down".
-     *
-     * One-shot — call once at startup before the first emit. A failed
-     * allocation leaves the static id at the invalid sentinel; the
-     * subsequent registry-validated emit will reject the payload as
-     * unregistered, which is the desired loud failure.
-     */
-    static void registerWith(vigine::payload::IPayloadRegistry &registry)
-    {
-        if (auto id = registry.allocateId("example-window.mouse.button.down"))
-            _staticTypeId = *id;
-    }
-
-    [[nodiscard]] vigine::payload::PayloadTypeId typeId() const noexcept override
-    {
-        return _staticTypeId;
-    }
+    [[nodiscard]] vigine::payload::PayloadTypeId typeId() const noexcept override;
 
     [[nodiscard]] std::unique_ptr<vigine::messaging::ISignalPayload>
-        clone() const override
-    {
-        return std::make_unique<MouseButtonDownPayload>(_button, _x, _y);
-    }
+        clone() const override;
 
     [[nodiscard]] vigine::ecs::platform::MouseButton button() const noexcept { return _button; }
-    [[nodiscard]] int                           x() const noexcept { return _x; }
-    [[nodiscard]] int                           y() const noexcept { return _y; }
+    [[nodiscard]] int                                x() const noexcept { return _x; }
+    [[nodiscard]] int                                y() const noexcept { return _y; }
 
   private:
-    static inline vigine::payload::PayloadTypeId _staticTypeId{};
-
     const vigine::ecs::platform::MouseButton _button;
-    const int                           _x;
-    const int                           _y;
+    const int                                _x;
+    const int                                _y;
 };
 
 /**
  * @brief Immutable payload describing a key-down event.
- *
- * Wraps a copy of the originating @ref vigine::ecs::platform::KeyEvent so
- * that subscribers can read @c keyCode, @c scanCode, @c modifiers,
- * @c repeatCount, and @c isRepeat without reaching back into the
- * platform layer. Same class-scoped @c PayloadTypeId story as
- * @ref MouseButtonDownPayload.
  */
 class KeyDownPayload final : public vigine::messaging::ISignalPayload
 {
   public:
+    [[nodiscard]] static std::string_view typeName() noexcept;
+
     explicit KeyDownPayload(const vigine::ecs::platform::KeyEvent &event) noexcept : _event(event) {}
 
     ~KeyDownPayload() override = default;
 
-    [[nodiscard]] static vigine::payload::PayloadTypeId staticTypeId() noexcept
-    {
-        return _staticTypeId;
-    }
-
-    static void setStaticTypeId(vigine::payload::PayloadTypeId tid) noexcept
-    {
-        _staticTypeId = tid;
-    }
-
-    static void registerWith(vigine::payload::IPayloadRegistry &registry)
-    {
-        if (auto id = registry.allocateId("example-window.key.down"))
-            _staticTypeId = *id;
-    }
-
-    [[nodiscard]] vigine::payload::PayloadTypeId typeId() const noexcept override
-    {
-        return _staticTypeId;
-    }
+    [[nodiscard]] vigine::payload::PayloadTypeId typeId() const noexcept override;
 
     [[nodiscard]] std::unique_ptr<vigine::messaging::ISignalPayload>
-        clone() const override
-    {
-        return std::make_unique<KeyDownPayload>(_event);
-    }
+        clone() const override;
 
     [[nodiscard]] const vigine::ecs::platform::KeyEvent &event() const noexcept { return _event; }
 
   private:
-    static inline vigine::payload::PayloadTypeId _staticTypeId{};
-
     const vigine::ecs::platform::KeyEvent _event;
 };
+
+namespace example::payloads
+{
+/**
+ * @brief Allocates a fresh @c PayloadTypeId for every payload class
+ *        defined in this file and stores the result in the TU-local
+ *        lookup map.
+ *
+ * Call once from @c main before any @c signal() subscription that
+ * resolves an id through @ref idOf — the lookup returns the invalid
+ * sentinel for type-names not yet registered, so a missing
+ * @ref registerAll call surfaces immediately as an unmatched
+ * subscription.
+ */
+void registerAll(vigine::payload::IPayloadRegistry &registry);
+
+/**
+ * @brief Class-level access without an instance: returns the
+ *        @c PayloadTypeId allocated for @p typeName, or the invalid
+ *        sentinel when @p typeName has not been registered.
+ *
+ * Used by @c main.cpp / @c createInitTaskFlow for @c signal()
+ * registration and by @c ProcessInputEventTask::onMessage for
+ * dispatch comparison.
+ */
+[[nodiscard]] vigine::payload::PayloadTypeId
+    idOf(std::string_view typeName) noexcept;
+} // namespace example::payloads

--- a/include/vigine/api/context/icontext.h
+++ b/include/vigine/api/context/icontext.h
@@ -277,11 +277,17 @@ class IContext
      * The aggregator builds a default @ref payload::IPayloadRegistry
      * during construction (engine-bundled ranges Control / System /
      * SystemExt / Reserved auto-registered under owner
-     * @c "vigine.core"). Application code registers its own user-range
-     * ids by calling @c registerRange on the returned reference; the
-     * default signal emitter validates every @ref ISignalEmitter::emit
-     * payload against this registry before posting it on the bus, so
-     * an unregistered id surfaces as an error result instead of a
+     * @c "vigine.core").
+     *
+     * The engine does NOT auto-register application-defined payload
+     * types: every custom @ref payload::ISignalPayload subclass an
+     * application emits or subscribes to must obtain its
+     * @ref payload::PayloadTypeId on the returned reference (via
+     * @c registerRange, @c allocateRange, or @c allocateId) before any
+     * @c TaskFlow::signal subscription or @c ISignalEmitter::emit call
+     * that references it. The default signal emitter validates every
+     * payload against this registry before posting it on the bus, so an
+     * unregistered id surfaces as an error result instead of a
      * silently-dropped message.
      *
      * The registry is owned by the context for its full lifetime and

--- a/include/vigine/api/context/icontext.h
+++ b/include/vigine/api/context/icontext.h
@@ -280,7 +280,7 @@ class IContext
      * @c "vigine.core").
      *
      * The engine does NOT auto-register application-defined payload
-     * types: every custom @ref payload::ISignalPayload subclass an
+     * types: every custom @ref messaging::ISignalPayload subclass an
      * application emits or subscribes to must obtain its
      * @ref payload::PayloadTypeId on the returned reference (via
      * @c registerRange, @c allocateRange, or @c allocateId) before any

--- a/include/vigine/api/messaging/payload/ipayloadregistry.h
+++ b/include/vigine/api/messaging/payload/ipayloadregistry.h
@@ -26,6 +26,19 @@ namespace vigine::payload
  * half (`[0, 0xFFFF]`) and the user half (`[0x10000, ...]`) is rejected
  * with @ref Result::Code::OutOfRange.
  *
+ * User responsibility: the engine does NOT auto-register
+ * application-defined payload types. Every concrete
+ * @ref vigine::messaging::ISignalPayload subclass that an application
+ * emits or subscribes to must obtain its @ref PayloadTypeId here first
+ * (typically through @ref allocateId or @ref allocateRange) before any
+ * @c TaskFlow::signal subscription or @c ISignalEmitter::emit call that
+ * references it. An unregistered id is rejected by the default signal
+ * emitter at emit time and never matches a subscription at dispatch
+ * time, so a missing registration surfaces as an explicit error rather
+ * than silent dropping. Engine-bundled payload types arrive
+ * pre-registered under owner @c "vigine.core"; only user types need
+ * application-side registration.
+ *
  * Thread-safety: implementations must be safe to call from any thread.
  * Mutating entry points take an exclusive lock on an internal
  * reader-writer mutex; read-only entry points take a shared lock so

--- a/include/vigine/api/messaging/payload/isignalpayload.h
+++ b/include/vigine/api/messaging/payload/isignalpayload.h
@@ -18,11 +18,22 @@ namespace vigine::messaging
  * bus infrastructure keeps routing by the underlying
  * @ref vigine::payload::PayloadTypeId returned by @ref typeId.
  *
- * Concrete signal payloads derive from this class, provide a unique
- * @ref vigine::payload::PayloadTypeId, and store their fields as @c const
- * members set at construction time. Immutability is required by the
- * messaging contract: the bus may deliver the same payload pointer to
- * multiple subscribers without copying.
+ * Concrete signal payloads derive from this class, provide a unique,
+ * registered @ref vigine::payload::PayloadTypeId, and store their fields
+ * as @c const members set at construction time. Immutability is required
+ * by the messaging contract: the bus may deliver the same payload
+ * pointer to multiple subscribers without copying.
+ *
+ * Registration requirement: the engine does NOT auto-register
+ * user-defined payload types. Each application is responsible for
+ * obtaining its @ref vigine::payload::PayloadTypeId from
+ * @ref vigine::payload::IPayloadRegistry — typically through
+ * @c allocateId / @c allocateRange on the registry exposed via
+ * @c IContext::payloadRegistry — before any @c TaskFlow::signal
+ * subscription or @c ISignalEmitter::emit call that references it.
+ * An unregistered id is rejected at emit time and never matches a
+ * subscription at dispatch time. Engine-bundled payload types arrive
+ * pre-registered; only application-defined subclasses need this glue.
  *
  * Naming: @c ISignalPayload follows INV-10 — @c I prefix for a pure-virtual
  * interface with no state.


### PR DESCRIPTION
## Summary

- Replaces the static-inline `staticTypeId()` approach with a TU-local lookup map keyed by each payload class's static `typeName()`. Concrete `ISignalPayload` subclasses keep the virtual `typeId()` contract; their implementation reads the registered id from the map populated once by `example::payloads::registerAll()` invoked in `main` before flow construction.
- The class-level `typeName()` is declared in the header and defined in the matching `.cpp` so the literal owner string lives in exactly one translation unit.
- Tightens the engine API documentation to make user responsibility explicit: `IPayloadRegistry`, `ISignalPayload`, and `IContext::payloadRegistry()` now spell out that the engine does not auto-register application-defined payload types — every custom `ISignalPayload` subclass must obtain its `PayloadTypeId` on the registry before any `signal()` / `emit` call references it.

## Test plan

- [x] `cmake --build build` (Ninja, MSVC 18 Insiders, /WX) — 22/22 objects + `vigine.lib` + `example-window.exe` link clean.
- [x] `ctest --test-dir build` — 197/197 tests passed (5.89s real).

Closes #367.